### PR TITLE
Add free function void(Simulator &s, Model &m)

### DIFF
--- a/apps/tungsten.cpp
+++ b/apps/tungsten.cpp
@@ -285,6 +285,22 @@ void from_json(const json &j, Tungsten &m) {
   p.q4_bar = p.q40_bar;
 }
 
+/*
+Sometimes, one need to get access to the simulator during stepping. This can be
+done by overriding the following function. The default implementation just runs
+m.step(t) so if there's no need to access the simulator, it's not necessary to
+override this function.
+*/
+void step(Simulator &s, Tungsten &m) {
+#ifdef TUNGSTEN_DEBUG
+  if (m.rank0) cout << "Performing Tungsten step" << endl;
+#endif
+  double t = s.get_time().get_current();
+  m.step(t);
+  // perform some extra logic after the step, which can access both simulator
+  // and model
+}
+
 int main(int argc, char *argv[]) {
   cout << std::fixed;
   cout.precision(3);

--- a/include/openpfc/simulator.hpp
+++ b/include/openpfc/simulator.hpp
@@ -32,6 +32,8 @@ along with this program.  If not, see https://www.gnu.org/licenses/.
 
 namespace pfc {
 
+void step(class Simulator &s, Model &m);
+
 /**
  * @brief The Simulator class is responsible for running the simulation of the
  * model.
@@ -269,6 +271,10 @@ public:
     return time.done();
   }
 };
+
+void step(Simulator &s, Model &m) {
+  m.step(s.get_time().get_current());
+}
 
 } // namespace pfc
 

--- a/include/openpfc/ui.hpp
+++ b/include/openpfc/ui.hpp
@@ -681,7 +681,7 @@ public:
       double l_fft_time = 0.0;
       MPI_Barrier(m_comm);
       l_steptime = -MPI_Wtime();
-      model.step(time.get_current());
+      step(simulator, model);
       MPI_Barrier(m_comm);
       l_steptime += MPI_Wtime();
       l_fft_time = fft.get_fft_time();


### PR DESCRIPTION
This workaround addresses issue #56. In certain situations, we need to access the simulator while the model is stepping. This scenario arises when we need to examine boundary conditions, for example.

The solution is demonstrated in `apps/tungsten.cpp`. There is an additional overridable function `void step(Simulator &s, Model &m)`, which by default simply runs `m.step(s.get_time().get_current())`. If necessary, it can be implemented for a specific model to provide extra functionality:

```cpp
void step(Simulator &s, Tungsten &m) {
  m.step(s.get_time().get_current());
  // perform some extra logic after the step, which can access both simulator and model
}
```