### PR TITLE
fix(cmake): correct relative path to sparsevector GPU test sources

### DIFF
--- a/tests/unit/runtime/gpu/CMakeLists.txt
+++ b/tests/unit/runtime/gpu/CMakeLists.txt
@@ -82,7 +82,7 @@ endif()
 
 # SparseVector tests - build based on available backends
 if(OpenPFC_ENABLE_CUDA AND OpenPFC_CUDA_AVAILABLE)
-    add_executable(test_sparsevector_cuda ../operators/test_sparsevector_cuda.cpp)
+    add_executable(test_sparsevector_cuda ../../operators/test_sparsevector_cuda.cpp)
     target_include_directories(test_sparsevector_cuda PRIVATE
         ${CMAKE_SOURCE_DIR}/tests/unit/operators
         ${CMAKE_SOURCE_DIR}/include
@@ -92,7 +92,7 @@ if(OpenPFC_ENABLE_CUDA AND OpenPFC_CUDA_AVAILABLE)
 endif()
 
 if(OpenPFC_ENABLE_HIP AND OpenPFC_HIP_AVAILABLE)
-    add_executable(test_sparsevector_hip ../operators/test_sparsevector_hip.cpp)
+    add_executable(test_sparsevector_hip ../../operators/test_sparsevector_hip.cpp)
     target_include_directories(test_sparsevector_hip PRIVATE
         ${CMAKE_SOURCE_DIR}/tests/unit/operators
         ${CMAKE_SOURCE_DIR}/include


### PR DESCRIPTION
## Summary
- `tests/unit/runtime/gpu/CMakeLists.txt` referenced
  `../operators/test_sparsevector_{cuda,hip}.cpp`, resolving one directory
  level short of the real location `tests/unit/operators/`.
- This silently breaks CUDA/HIP test configuration (`--with-cuda`/`--with-rocm`
  CMake configure fails outright with "Cannot find source file"), invisible
  to routine `--cpu` validation which never enables these targets.
- Fixed the relative path from `../operators/` to `../../operators/` for both
  `test_sparsevector_cuda.cpp` and `test_sparsevector_hip.cpp`.

## Test plan
- [x] Verified with a real `--with-cuda` configure on tohtori: CMake generate
      now proceeds past this point (previously failed outright).
- [x] Confirmed the default `--cpu` build+test suite is unaffected:
      `bash scripts/build.sh --machine=tohtori --build-type=Release --with-timestamp --cpu --test --mpi-tests --jobs=8`
      passes 19/19 test batches, 0 failures (run twice, on two independent
      rebases as master moved).