### PR TITLE
fix(hip): build OpenPFC with HIP on Cray MPICH (LUMI-G)

### DIFF
--- a/apps/tungsten/src/tungsten_scalability.cpp
+++ b/apps/tungsten/src/tungsten_scalability.cpp
@@ -86,7 +86,7 @@ public:
                                         pfc::PhysicalOrigin({0.0, 0.0, 0.0}),
                                         pfc::GridSpacing({1.0, 1.0, 1.0}));
       auto decomp = pfc::decomposition::create(domain, size);
-      auto fft = pfc::fft::create(decomp, rank);
+      auto fft = pfc::fft::create(decomp, rank, MPI_COMM_WORLD);
 
       // Create model
       Tungsten model(fft, domain);
@@ -202,7 +202,7 @@ public:
       auto decomp = pfc::decomposition::create(domain, size);
 
       // Create model with specified precision
-      auto fft = pfc::fft::create(decomp, rank);
+      auto fft = pfc::fft::create(decomp, rank, MPI_COMM_WORLD);
       TungstenCUDA<RealType> model(fft, domain);
       model.params.set_n0(-0.4);
       model.params.set_T(0.5);
@@ -324,7 +324,7 @@ public:
                                         pfc::GridSpacing({1.0, 1.0, 1.0}));
       auto decomp = pfc::decomposition::create(domain, size);
 
-      auto fft = pfc::fft::create(decomp, rank);
+      auto fft = pfc::fft::create(decomp, rank, MPI_COMM_WORLD);
       TungstenHIP<RealType> model(fft, domain);
       model.params.set_n0(-0.4);
       model.params.set_T(0.5);

--- a/apps/tungsten/tests/test_tungsten_cpu_vs_cuda.cpp
+++ b/apps/tungsten/tests/test_tungsten_cpu_vs_cuda.cpp
@@ -37,7 +37,7 @@ TEST_CASE("Tungsten CPU vs CUDA: Same results", "[Tungsten][CPU][CUDA]") {
   MPI_Comm_rank(MPI_COMM_WORLD, &rank);
   MPI_Comm_size(MPI_COMM_WORLD, &size);
   auto decomp = pfc::decomposition::create(domain, size);
-  auto fft_cpu = pfc::fft::create(decomp, rank);
+  auto fft_cpu = pfc::fft::create(decomp, rank, MPI_COMM_WORLD);
 
   // Create models (CUDA uses double precision for comparison)
   Tungsten model_cpu(fft_cpu, domain);

--- a/apps/tungsten/tests/test_tungsten_cpu_vs_hip.cpp
+++ b/apps/tungsten/tests/test_tungsten_cpu_vs_hip.cpp
@@ -36,7 +36,7 @@ TEST_CASE("Tungsten CPU vs HIP: Same results", "[Tungsten][CPU][HIP]") {
   MPI_Comm_rank(MPI_COMM_WORLD, &rank);
   MPI_Comm_size(MPI_COMM_WORLD, &size);
   auto decomp = pfc::decomposition::create(domain, size);
-  auto fft_cpu = pfc::fft::create(decomp, rank);
+  auto fft_cpu = pfc::fft::create(decomp, rank, MPI_COMM_WORLD);
 
   Tungsten model_cpu(fft_cpu, domain);
   TungstenHIP<double> model_hip(fft_cpu, domain);

--- a/cmake/LibraryConfiguration.cmake
+++ b/cmake/LibraryConfiguration.cmake
@@ -128,6 +128,7 @@ if(OpenPFC_ENABLE_MPI)
 endif()
 
 target_link_libraries(openpfc PRIVATE nlohmann_json::nlohmann_json)
+target_link_libraries(openpfc_kernel_obj PRIVATE nlohmann_json::nlohmann_json)
 target_link_libraries(openpfc_frontend_obj PRIVATE nlohmann_json::nlohmann_json)
 
 if(OpenPFC_ENABLE_HDF5)

--- a/examples/09_parallel_fft_high_level.cpp
+++ b/examples/09_parallel_fft_high_level.cpp
@@ -32,7 +32,7 @@ int main(int argc, char *argv[]) {
   // Fill input field with random numbers
   input.apply([&](double /*x*/, double /*y*/, double /*z*/) { return dis(gen); });
 
-  auto fft_instance = fft::create(decomp, worker.get_rank());
+  auto fft_instance = fft::create(decomp, worker.get_rank(), MPI_COMM_WORLD);
 
   // Create output array to store FFT results. If requested array is of type T =
   // complex<double>, then array will be constructed using complex indices so

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -66,7 +66,7 @@ add_executable(mpi_timers mpi_timers.cpp)
 target_link_libraries(mpi_timers PRIVATE OpenPFC ${_heffte_tgt})
 
 add_executable(profiling_timer_report profiling_timer_report.cpp)
-target_link_libraries(profiling_timer_report PRIVATE OpenPFC ${_heffte_tgt})
+target_link_libraries(profiling_timer_report PRIVATE OpenPFC nlohmann_json::nlohmann_json ${_heffte_tgt})
 
 add_executable(time time.cpp)
 target_link_libraries(time PRIVATE OpenPFC ${_heffte_tgt})

--- a/include/openpfc/kernel/data/host_device.hpp
+++ b/include/openpfc/kernel/data/host_device.hpp
@@ -51,7 +51,12 @@
  *       function declaration is just a normal C++ function.
  */
 
-#if defined(__CUDACC__)
+// `__CUDACC__` is defined by `nvcc`; `__HIP__` / `__HIPCC__` are defined by
+// `hipcc` / the ROCm clang when compiling HIP code. In all of these the
+// `__host__ __device__` attributes are required for functions called from
+// device kernels. CPU-only compilers define none of them, so the macro
+// collapses to an empty token and the declaration is a plain C++ function.
+#if defined(__CUDACC__) || defined(__HIP__) || defined(__HIPCC__)
 #define OPENPFC_HD __host__ __device__
 #define OPENPFC_INLINE_HD inline __host__ __device__
 #else

--- a/include/openpfc/kernel/fft/fft.hpp
+++ b/include/openpfc/kernel/fft/fft.hpp
@@ -23,6 +23,7 @@
 
 #include <memory>
 #include <mpi.h>
+#include <type_traits>
 
 namespace heffte {
 struct plan_options;

--- a/include/openpfc/kernel/simulation/stacks/spectral_cpu_stack.hpp
+++ b/include/openpfc/kernel/simulation/stacks/spectral_cpu_stack.hpp
@@ -78,7 +78,10 @@ public:
                             MPI_Comm comm = MPI_COMM_WORLD)
       : m_geometry({domain.size, domain.spacing, domain.origin, domain.periodic}),
         m_decomp(pfc::decomposition::create(domain, nproc)),
-        m_fft(pfc::fft::create(m_decomp, comm)),
+        // Pass rank explicitly: with Cray MPICH, MPI_Comm is `int`, so the
+        // two-argument fft::create(decomp, comm) would be ambiguous with the
+        // (decomp, rank_id, comm) overload. Naming rank_id selects it directly.
+        m_fft(pfc::fft::create(m_decomp, rank, comm)),
         m_u(pfc::data::field_from_inbox<double>(domain, m_fft.get_inbox_bounds())),
         m_rank(rank), m_nproc(nproc), m_comm(comm) {}
 

--- a/scripts/build_heffte_rocm.sh
+++ b/scripts/build_heffte_rocm.sh
@@ -1,0 +1,239 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: 2026 VTT Technical Research Centre of Finland Ltd
+# SPDX-License-Identifier: AGPL-3.0-or-later
+#
+# Build and install HeFFTe with the ROCm (HIP) backend on LUMI-G, and generate
+# a matching Lmod module so it can be loaded with:
+#
+#     module load heffte-rocm
+#
+# The install lands in ~/opt/heffte/<version>-rocm and the module file in
+# ~/privatemodules/heffte-rocm/<version>.lua (~/privatemodules is already on
+# this user's MODULEPATH). Re-run with a different --version (or HEFFTE_VERSION)
+# to build additional versions side by side; each gets its own install prefix
+# and modulefile, and the `heffte-rocm` default is updated to the newest build.
+#
+# This mirrors the verified recipe in docs/hpc/INSTALL.LUMI.md (§3). It is a
+# LUMI-G-specific counterpart to scripts/build_tohtori.sh (CUDA) and the CPU
+# scripts/install-heffte-ci.sh.
+
+set -Eeuo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# ---------------------------------------------------------------------------
+# Defaults (override via CLI flags or the matching environment variables)
+# ---------------------------------------------------------------------------
+HEFFTE_VERSION="${HEFFTE_VERSION:-2.4.1}"
+BUILD_TYPE="${BUILD_TYPE:-Release}"
+ROCM_ARCH="${ROCM_ARCH:-gfx90a}"
+JOBS="${JOBS:-16}"
+INSTALL_ROOT="${INSTALL_ROOT:-$HOME/opt/heffte}"
+MODULE_ROOT="${MODULE_ROOT:-$HOME/privatemodules/heffte-rocm}"
+# Build tree + sources: prefer the fast Lustre flash area, fall back to /tmp.
+WORK_ROOT="${WORK_ROOT:-/flash/project_462001519/$USER/heffte-build}"
+LUMI_STACK="${LUMI_STACK:-LUMI/25.09}"
+# Cray MPICH include dir for HIP translation units (mpi.h under hipcc). The
+# default below matches cpeGNU on LUMI/25.09; rediscover after a PE upgrade with
+#   CC -E -Wp,-v -xc++ /dev/null 2>&1 | grep mpich
+MPI_INC="${MPI_INC:-/opt/cray/pe/mpich/9.0.1/ofi/gnu/12.3/include}"
+GPU_AWARE_MPI="${GPU_AWARE_MPI:-ON}"
+KEEP_BUILD="${KEEP_BUILD:-0}"
+
+usage() {
+  cat <<EOF
+Usage: $0 [options]
+
+Build HeFFTe with the ROCm backend on LUMI-G and install a 'heffte-rocm' module.
+
+Options:
+  --version=X.Y.Z     HeFFTe version to build (default: ${HEFFTE_VERSION})
+  --build-type=TYPE   CMake build type (default: ${BUILD_TYPE})
+  --arch=GFX          CMAKE_HIP_ARCHITECTURES (default: ${ROCM_ARCH})
+  --jobs=N, -j N      Parallel build jobs (default: ${JOBS})
+  --install-root=DIR  Install prefixes go to DIR/<version>-rocm
+                      (default: ${INSTALL_ROOT})
+  --module-root=DIR   Modulefiles go to DIR/<version>.lua
+                      (default: ${MODULE_ROOT})
+  --work-root=DIR     Sources + build trees under DIR (default: ${WORK_ROOT})
+  --no-gpu-aware-mpi  Disable Heffte_ENABLE_GPU_AWARE_MPI (default: ON)
+  --keep-build        Keep the build tree after install (default: remove)
+  -h, --help          Show this help
+
+Environment variables mirror the CLI: HEFFTE_VERSION, BUILD_TYPE, ROCM_ARCH,
+JOBS, INSTALL_ROOT, MODULE_ROOT, WORK_ROOT, LUMI_STACK, MPI_INC, GPU_AWARE_MPI,
+KEEP_BUILD.
+
+Examples:
+  $0                          # build the default version
+  $0 --version=2.4.1 -j 32
+  HEFFTE_VERSION=2.5.0 $0     # build a new version side by side
+EOF
+}
+
+die() {
+  echo "ERROR: $*" >&2
+  exit 1
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --version=*) HEFFTE_VERSION="${1#*=}" ;;
+    --build-type=*) BUILD_TYPE="${1#*=}" ;;
+    --arch=*) ROCM_ARCH="${1#*=}" ;;
+    --jobs=*|-j) shift; JOBS="${1:-}" ;;
+    --jobs=*) JOBS="${1#*=}" ;;
+    --install-root=*) INSTALL_ROOT="${1#*=}" ;;
+    --module-root=*) MODULE_ROOT="${1#*=}" ;;
+    --work-root=*) WORK_ROOT="${1#*=}" ;;
+    --no-gpu-aware-mpi) GPU_AWARE_MPI="OFF" ;;
+    --keep-build) KEEP_BUILD=1 ;;
+    -h|--help) usage; exit 0 ;;
+    *) die "unknown option '$1' (use --help)" ;;
+  esac
+  shift
+done
+
+[[ "${JOBS}" =~ ^[1-9][0-9]*$ ]] || die "JOBS must be a positive integer"
+
+INSTALL_PREFIX="${INSTALL_ROOT}/${HEFFTE_VERSION}-rocm"
+MODULE_FILE="${MODULE_ROOT}/${HEFFTE_VERSION}.lua"
+SRC_DIR="${WORK_ROOT}/src/heffte-${HEFFTE_VERSION}"
+BUILD_DIR="${WORK_ROOT}/build/heffte-${HEFFTE_VERSION}-rocm"
+ARCHIVE="${WORK_ROOT}/src/v${HEFFTE_VERSION}.tar.gz"
+
+echo "HeFFTe ROCm build"
+echo "  version:      ${HEFFTE_VERSION}"
+echo "  build type:   ${BUILD_TYPE}"
+echo "  HIP arch:     ${ROCM_ARCH}"
+echo "  jobs:         ${JOBS}"
+echo "  install:      ${INSTALL_PREFIX}"
+echo "  modulefile:   ${MODULE_FILE}"
+echo "  work root:    ${WORK_ROOT}"
+echo "  GPU-aware MPI:${GPU_AWARE_MPI}"
+
+# ---------------------------------------------------------------------------
+# 1. Module environment (LUMI-G toolchain + ROCm)
+# ---------------------------------------------------------------------------
+if ! command -v module >/dev/null 2>&1; then
+  for init_file in /etc/profile.d/lmod.sh /usr/share/lmod/lmod/init/bash \
+                   /usr/share/Modules/init/bash /etc/profile.d/modules.sh; do
+    if [[ -f "${init_file}" ]]; then
+      # shellcheck source=/dev/null
+      source "${init_file}"
+      break
+    fi
+  done
+fi
+command -v module >/dev/null 2>&1 || die "Lmod 'module' command not found"
+
+module --force purge
+module load "${LUMI_STACK}" partition/G cpeGNU cray-fftw lumi-CrayPath
+export LD_LIBRARY_PATH="${CRAY_LD_LIBRARY_PATH:-}${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
+
+command -v hipcc >/dev/null 2>&1 || die "hipcc not found after loading ROCm (partition/G)"
+[[ -f "${MPI_INC}/mpi.h" ]] || die "Cray MPICH mpi.h not found at ${MPI_INC} (set MPI_INC)"
+
+# ROCm CMake packages (hip, rocfft, ...) come from the module's CMAKE_PREFIX_PATH.
+export CMAKE_PREFIX_PATH="${EBROOTROCM:-}${CMAKE_PREFIX_PATH:+:${CMAKE_PREFIX_PATH}}"
+
+# ---------------------------------------------------------------------------
+# 2. Fetch and unpack the HeFFTe source
+# ---------------------------------------------------------------------------
+mkdir -p "${WORK_ROOT}/src" "${WORK_ROOT}/build"
+if [[ ! -d "${SRC_DIR}" ]]; then
+  if [[ ! -f "${ARCHIVE}" ]]; then
+    echo "Downloading HeFFTe v${HEFFTE_VERSION} ..."
+    url="https://github.com/icl-utk-edu/heffte/archive/refs/tags/v${HEFFTE_VERSION}.tar.gz"
+    if command -v curl >/dev/null 2>&1; then
+      curl -fsSL -o "${ARCHIVE}" "${url}"
+    elif command -v wget >/dev/null 2>&1; then
+      wget -q -O "${ARCHIVE}" "${url}"
+    else
+      die "neither curl nor wget available to download HeFFTe"
+    fi
+  fi
+  tar xf "${ARCHIVE}" -C "${WORK_ROOT}/src"
+fi
+[[ -f "${SRC_DIR}/CMakeLists.txt" ]] || die "HeFFTe source not found at ${SRC_DIR}"
+
+# ---------------------------------------------------------------------------
+# 3. Configure, build, install
+# ---------------------------------------------------------------------------
+cmake -S "${SRC_DIR}" -B "${BUILD_DIR}" \
+  -DCMAKE_BUILD_TYPE="${BUILD_TYPE}" \
+  -DCMAKE_C_COMPILER=cc \
+  -DCMAKE_CXX_COMPILER=CC \
+  -DCMAKE_INSTALL_PREFIX="${INSTALL_PREFIX}" \
+  -DHeffte_ENABLE_FFTW=ON \
+  -DHeffte_ENABLE_ROCM=ON \
+  -DHeffte_ENABLE_CUDA=OFF \
+  -DHeffte_ENABLE_GPU_AWARE_MPI="${GPU_AWARE_MPI}" \
+  -DCMAKE_HIP_ARCHITECTURES="${ROCM_ARCH}" \
+  -DCMAKE_HIP_FLAGS="-I${MPI_INC}"
+
+cmake --build "${BUILD_DIR}" -j"${JOBS}"
+cmake --install "${BUILD_DIR}"
+
+# Locate the installed HeffteConfig.cmake to sanity-check the layout.
+HEFFTE_CMAKE_DIR=""
+for cand in "${INSTALL_PREFIX}/lib64/cmake/Heffte" "${INSTALL_PREFIX}/lib/cmake/Heffte"; do
+  if [[ -f "${cand}/HeffteConfig.cmake" ]]; then
+    HEFFTE_CMAKE_DIR="${cand}"
+    break
+  fi
+done
+[[ -n "${HEFFTE_CMAKE_DIR}" ]] || die "HeffteConfig.cmake not found under ${INSTALL_PREFIX}"
+
+# ---------------------------------------------------------------------------
+# 4. Generate the Lmod modulefile
+# ---------------------------------------------------------------------------
+mkdir -p "${MODULE_ROOT}"
+cat > "${MODULE_FILE}" <<LUA
+-- Name: heffte-rocm
+-- Version: ${HEFFTE_VERSION}
+-- Generated by scripts/build_heffte_rocm.sh on $(date +%Y-%m-%d)
+
+help([[Load HeFFTe ${HEFFTE_VERSION} built with the ROCm (HIP) backend for LUMI-G.
+Sets CMAKE_PREFIX_PATH, library and include paths, and HeFFTe_DIR/ROOT so that
+find_package(Heffte) picks up the ROCm-enabled install.]])
+
+local module_base = "${INSTALL_PREFIX}"
+
+-- HeFFTe runtime + build paths
+prepend_path("CMAKE_PREFIX_PATH", module_base)
+prepend_path("PATH", pathJoin(module_base, "bin"))
+prepend_path("LD_LIBRARY_PATH", pathJoin(module_base, "lib64"))
+prepend_path("LD_LIBRARY_PATH", pathJoin(module_base, "lib"))
+prepend_path("CPATH", pathJoin(module_base, "include"))
+prepend_path("INCLUDE", pathJoin(module_base, "include"))
+prepend_path("PKG_CONFIG_PATH", pathJoin(module_base, "lib64", "pkgconfig"))
+prepend_path("PKG_CONFIG_PATH", pathJoin(module_base, "lib", "pkgconfig"))
+setenv("HEFFTE_DIR", pathJoin(module_base, "lib64", "cmake", "Heffte"))
+setenv("HEFFTE_ROOT", module_base)
+
+whatis("Name: heffte-rocm")
+whatis("Version: ${HEFFTE_VERSION}")
+whatis("Description: HeFFTe ${HEFFTE_VERSION} ROCm/HIP backend (LUMI-G, ${ROCM_ARCH})")
+LUA
+
+# Make the bare `heffte-rocm` name resolve to the newest version we built.
+cat > "${MODULE_ROOT}/default" <<EOF
+${HEFFTE_VERSION}
+EOF
+
+if [[ "${KEEP_BUILD}" != "1" ]]; then
+  rm -rf "${BUILD_DIR}"
+fi
+
+echo
+echo "================================================================"
+echo "HeFFTe ROCm build: PASS"
+echo "  Install prefix: ${INSTALL_PREFIX}"
+echo "  HeffteConfig:   ${HEFFTE_CMAKE_DIR}/HeffteConfig.cmake"
+echo "  Modulefile:     ${MODULE_FILE}"
+echo
+echo "Load it with:"
+echo "  module use \$HOME/privatemodules   # if not already on MODULEPATH"
+echo "  module load heffte-rocm"
+echo "================================================================"

--- a/src/openpfc/runtime/cpu/fft.cpp
+++ b/src/openpfc/runtime/cpu/fft.cpp
@@ -7,6 +7,7 @@
 #include <iostream>
 #include <sstream>
 #include <stdexcept>
+#include <type_traits>
 
 #include <openpfc/kernel/data/domain.hpp>
 #include <openpfc/kernel/decomposition/decomposition.hpp>

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -27,7 +27,8 @@ else()
 endif()
 
 # Link against OpenPFC and Catch2, and add HeFFTe if available
-target_link_libraries(openpfc-tests PRIVATE OpenPFC Catch2::Catch2)
+target_link_libraries(openpfc-tests PRIVATE OpenPFC Catch2::Catch2
+                                              nlohmann_json::nlohmann_json)
 if(TARGET Heffte::Heffte)
   target_link_libraries(openpfc-tests PRIVATE Heffte::Heffte)
 elseif(TARGET Heffte)

--- a/tests/integration/scenarios/gpu_validation/test_cuda_vs_cpu_laplacian.cpp
+++ b/tests/integration/scenarios/gpu_validation/test_cuda_vs_cpu_laplacian.cpp
@@ -38,7 +38,7 @@ TEST_CASE("CPU vs CUDA Laplacian equivalence (double) [integration][gpu]", "[gpu
   auto decomp = decomposition::create(world, size);
 
   // CPU FFT
-  auto fft_cpu = fft::create(decomp, rank);
+  auto fft_cpu = fft::create(decomp, rank, MPI_COMM_WORLD);
 
   // CUDA FFT
   auto fft_gpu = fft::create_cuda(decomp, rank);

--- a/tests/integration/scenarios/gpu_validation/test_cuda_vs_cpu_laplacian_mpi.cpp
+++ b/tests/integration/scenarios/gpu_validation/test_cuda_vs_cpu_laplacian_mpi.cpp
@@ -41,7 +41,7 @@ TEST_CASE("CPU vs CUDA Laplacian equivalence (multi-rank) [integration][gpu][mpi
   auto decomp = decomposition::create(world, size);
 
   // CPU and CUDA FFT
-  auto fft_cpu = fft::create(decomp, rank);
+  auto fft_cpu = fft::create(decomp, rank, MPI_COMM_WORLD);
   auto fft_gpu = fft::create_cuda(decomp, rank);
 
   const auto n_in = fft_cpu.size_inbox();


### PR DESCRIPTION
## Problem

OpenPFC did not build with HIP enabled on Cray MPICH (LUMI-G, cpeGNU). Two distinct issues:

1. **`fft::create` ambiguity.** On Cray MPICH, `MPI_Comm` is a plain `int` (unlike OpenMPI/MPICH where it is a pointer/struct). The overloads
   ```cpp
   create(decomp, rank_id, comm = MPI_COMM_WORLD)
   create(decomp, comm = MPI_COMM_WORLD)
   ```
   become ambiguous for the two-argument call `create(decomp, rank)` when both `rank_id` and `MPI_Comm` are int-like, so those translation units fail to compile.

2. **Missing `__host__ __device__` for HIP.** `host_device.hpp` only defined `OPENPFC_HD` / `OPENPFC_INLINE_HD` for `__CUDACC__` (nvcc). Under `hipcc` / ROCm clang (`__HIP__` / `__HIPCC__`), functions called from device kernels were declared as plain host functions and failed to compile. A couple of missing includes / link libraries also surfaced once HIP TUs actually compiled.

## Changes (3 commits, one logical unit each)

- **`fix(fft): disambiguate fft::create calls for Cray MPICH`** — pass the communicator explicitly (`create(decomp, rank, MPI_COMM_WORLD)`) at each affected call site (tungsten scalability + cpu-vs-gpu tests, the parallel-FFT example, the CUDA-laplacian integration tests), and pass `rank, comm` in `SpectralCpuStack`. Behavior unchanged on other MPI stacks; this only makes the intended overload explicit.
- **`fix(hip): enable __host__ __device__ and fix HIP build/link`** — define `OPENPFC_HD`/`OPENPFC_INLINE_HD` for `__HIP__`/`__HIPCC__`; add missing `<type_traits>`; link `nlohmann_json` where its headers are used (kernel obj, an example, the test runner).
- **`build(scripts): add HeFFTe ROCm build script for LUMI-G`** — `scripts/build_heffte_rocm.sh`, the ROCm counterpart to `build_tohtori.sh` (CUDA) and `install-heffte-ci.sh` (CPU). Mirrors the verified recipe in `docs/hpc/INSTALL.LUMI.md` §3 and generates a `heffte-rocm` Lmod module.

## Verification (LUMI-G, MI250X, gfx90a, ROCm 6.4.4, Cray MPICH 9.0.1, HeFFTe 2.4.1 ROCm)

- Library, apps, and tests **build cleanly** from this branch.
- Full `ctest` suite **passes** on a dev-g node (results in the checks / comment below).
- The `heffte-rocm/2.4.1` module produced by the script was independently validated: `speed3d` strong scaling to 8 nodes / 64 GCDs, GPU-aware MPI ~2–2.7× faster than host-staged.

## Notes

- No behavior change on non-Cray / non-HIP builds; the MPI change only makes an implicit overload choice explicit, and the `host_device.hpp` change is inert unless `__HIP__`/`__HIPCC__` is defined.
- The `Code Quality` CI job fails for a **pre-existing, unrelated** reason (broken `ahojukka5/clang-format-action` reference in `ci.yml:31`); see PR #69 for details. This PR does not touch CI.