### PR TITLE
ci: shorter PR checks

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -15,35 +15,37 @@ Runs on: Push to master/main/develop, PRs to master/main
 
 Purpose: Primary continuous integration pipeline ensuring code quality and functionality.
 
-Jobs (sequential fail-fast): `code-quality` → `build-and-test`. If Code Quality fails, the build matrix is skipped.
+Jobs: `code-quality` → `build-and-test` + `packaging-smoke`. If Code Quality fails, the build matrix is skipped.
 
 1. Code Quality
- - clang-format 20 (advisory: reports formatting issues but does not fail the job)
- - REUSE compliance verification (must pass)
+ - clang-format 20 (advisory)
+ - REUSE compliance (must pass)
+ - kernel layering and GPU memcpy single-source checks
 
 2. CMake Build Matrix
- - OS: Ubuntu 24.04 LTS
- - Compilers: GCC 11, GCC 13
- - Build Types: Debug, Release
- - Caches HeFFTe installation
- - Runs full test suite with CTest
- - Uploads test logs on failure
+ - PRs: gcc-13 Debug + Release only
+ - Pushes to master/develop: also gcc-11 Debug
+ - Caches HeFFTe; full `ctest` including 2-rank MPI (`OpenPFC_MPI_TEST_MAX_WORLD_SIZE=2`)
 
-3. CI Status Check
- - Required status check for merging
- - Aggregates Code Quality and build-and-test only (clang-tidy is separate; see below)
+3. Packaging smoke (`find_package` consumer)
 
-Typical Duration: 20-30 minutes (with cache), 45-60 minutes (cold cache)
+4. CUDA/HIP compile-only: **push to master/develop only** (not PRs), `continue-on-error`
+
+5. CI Status
+ - Required for merging
+ - Aggregates Code Quality, build-and-test, and packaging-smoke
+
+Typical Duration: ~10–15 minutes on a PR (with HeFFTe cache)
 
 ---
 
 ### `clang-tidy.yml` - Static analysis (non-blocking)
 
-Runs on: Same triggers as `ci.yml` (push to master/main/develop, PRs to master/main).
+Runs on: weekly Sunday 03:00 UTC, and `workflow_dispatch`. Not on pull requests.
 
-Purpose: Run `scripts/run-clang-tidy.sh` with HeFFTe + `compile_commands.json`. Failures do not fail the main CI workflow or its CI Status job. Treat as advisory unless you add this workflow’s job as a required check in branch protection.
+Purpose: Run `scripts/run-clang-tidy.sh` with HeFFTe + `compile_commands.json`. A full-tree pass is ~45–60 min on GitHub runners and is `continue-on-error` until the WarningsAsErrors backlog is clear. Do not add this job as a required check.
 
-Typical Duration: ~15–20 minutes (similar HeFFTe cache key to the former in-repo job).
+Typical Duration: ~45–60 minutes.
 
 ---
 
@@ -81,9 +83,10 @@ Setup Required:
 
 Runs on:
 - Push to master/main/develop
-- PRs to master/main
 - Weekly schedule (Sunday 00:00 UTC)
 - Manual trigger (workflow_dispatch)
+
+Not on pull requests (duplicates a Debug `ctest` already in `ci.yml`).
 
 Purpose: Measure and report test coverage (target: >90%).
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,17 +67,12 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-24.04]
-        compiler: [gcc-11, gcc-13]
+        compiler: [gcc-13]
         build_type: [Debug, Release]
         include:
-          - compiler: gcc-11
-            cc: gcc-11
-            cxx: g++-11
           - compiler: gcc-13
             cc: gcc-13
             cxx: g++-13
-    # PRs: gcc-13 Debug+Release only. gcc-11 Debug runs on branch pushes.
-    if: ${{ matrix.compiler == 'gcc-13' || (github.event_name == 'push' && matrix.compiler == 'gcc-11' && matrix.build_type == 'Debug') }}
 
     steps:
       - name: Checkout repository
@@ -166,6 +161,62 @@ jobs:
         uses: actions/upload-artifact@v5
         with:
           name: test-results-${{ matrix.os }}-${{ matrix.compiler }}-${{ matrix.build_type }}
+          path: build/Testing/Temporary/LastTest.log
+
+  # Second compiler on branch pushes only (not pull requests).
+  build-gcc11-debug:
+    name: ubuntu-24.04 / gcc-11 / Debug
+    if: github.event_name == 'push'
+    needs: [code-quality]
+    runs-on: ubuntu-24.04
+    env:
+      CC: gcc-11
+      CXX: g++-11
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+        with:
+          submodules: true
+      - name: Install dependencies (Ubuntu)
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y gcc-11 g++-11 cmake ninja-build \
+            libopenmpi-dev openmpi-bin libfftw3-dev libfftw3-mpi-dev \
+            nlohmann-json3-dev
+      - name: Cache HeFFTe
+        id: cache-heffte
+        uses: actions/cache@v5
+        with:
+          path: ~/opt/heffte/2.4.1-cpu
+          key: heffte-2.4.1-cpu-ubuntu-24.04-gcc-11-Debug
+      - name: Build and Install HeFFTe
+        if: steps.cache-heffte.outputs.cache-hit != 'true'
+        run: scripts/install-heffte-ci.sh Debug /tmp/heffte-build-openpfc-ci
+      - name: Configure OpenPFC
+        run: |
+          cmake -S . -B build \
+            -GNinja \
+            -DCMAKE_BUILD_TYPE=Debug \
+            -DCMAKE_PREFIX_PATH=$HOME/opt/heffte/2.4.1-cpu \
+            -DOpenPFC_BUILD_TESTS=ON \
+            -DOpenPFC_BUILD_EXAMPLES=ON \
+            -DOpenPFC_BUILD_APPS=ON \
+            -DOpenPFC_BUILD_DOCUMENTATION=OFF \
+            -DOpenPFC_RUN_MPI_SUITES=ON \
+            -DOpenPFC_MPI_TEST_MAX_WORLD_SIZE=2
+      - name: Build OpenPFC
+        run: cmake --build build -j2
+      - name: Run Tests
+        working-directory: build
+        run: |
+          ctest --output-on-failure -j2 \
+            --exclude-regex "benchmark" \
+            --timeout 300
+      - name: Upload test results
+        if: failure()
+        uses: actions/upload-artifact@v5
+        with:
+          name: test-results-ubuntu-24.04-gcc-11-Debug
           path: build/Testing/Temporary/LastTest.log
 
   # ============================================================================
@@ -308,6 +359,10 @@ jobs:
           fi
           if [[ "${{ needs.build-and-test.result }}" != "success" ]]; then
             echo "❌ Build and test failed"
+            exit 1
+          fi
+          if [[ "${{ needs.packaging-smoke.result }}" != "success" ]]; then
+            echo "❌ Packaging smoke failed"
             exit 1
           fi
           echo "✅ All CI checks passed"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,7 +63,6 @@ jobs:
     name: ${{ matrix.os }} / ${{ matrix.compiler }} / ${{ matrix.build_type }}
     needs: [code-quality]
     runs-on: ${{ matrix.os }}
-
     strategy:
       fail-fast: false
       matrix:
@@ -71,13 +70,14 @@ jobs:
         compiler: [gcc-11, gcc-13]
         build_type: [Debug, Release]
         include:
-          # Add specific compiler versions for each
           - compiler: gcc-11
             cc: gcc-11
             cxx: g++-11
           - compiler: gcc-13
             cc: gcc-13
             cxx: g++-13
+    # PRs: gcc-13 Debug+Release only. gcc-11 Debug runs on branch pushes.
+    if: ${{ matrix.compiler == 'gcc-13' || (github.event_name == 'push' && matrix.compiler == 'gcc-11' && matrix.build_type == 'Debug') }}
 
     steps:
       - name: Checkout repository
@@ -233,10 +233,11 @@ jobs:
   # / hipcc compile without one. Official devel images already ship the toolkit;
   # do not download or compile HeFFTe here (spectral GPU stays cluster-only).
   # OpenPFC_ENABLE_HEFFTE=OFF still builds FD/kernel CUDA and HIP TUs.
-  # continue-on-error until first validated on GitHub.
+  # Push to master/develop only (not PRs). continue-on-error.
   # ============================================================================
   cuda-compile:
     name: CUDA compile-only (no GPU)
+    if: github.event_name == 'push'
     needs: [code-quality]
     runs-on: ubuntu-24.04
     continue-on-error: true
@@ -264,6 +265,7 @@ jobs:
 
   hip-compile:
     name: HIP compile-only (no GPU)
+    if: github.event_name == 'push'
     needs: [code-quality]
     runs-on: ubuntu-24.04
     continue-on-error: true

--- a/.github/workflows/clang-tidy.yml
+++ b/.github/workflows/clang-tidy.yml
@@ -1,18 +1,16 @@
 # SPDX-FileCopyrightText: 2026 VTT Technical Research Centre of Finland Ltd
 # SPDX-License-Identifier: AGPL-3.0-or-later
 #
-# Optional static analysis: failures here do not block the main CI workflow (ci.yml).
-# For branch protection, do not mark this job as a required check if merges should
-# proceed when only clang-tidy is red. M12 still wants this required once the
-# WarningsAsErrors backlog is clear.
+# Optional static analysis. Not on pull requests: a full-tree clang-tidy pass
+# is ~45–60 min on GitHub runners and is continue-on-error until the
+# WarningsAsErrors backlog is cleared. Weekly + manual is enough until then.
 
 name: Clang-Tidy
 
 on:
-  push:
-    branches: ["master", "main", "develop"]
-  pull_request:
-    branches: ["master", "main"]
+  schedule:
+    - cron: "0 3 * * 0"
+  workflow_dispatch:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -6,8 +6,6 @@ name: Coverage
 on:
   push:
     branches: [ "master", "main", "develop" ]
-  pull_request:
-    branches: [ "master", "main" ]
   schedule:
     # Run coverage weekly on Sunday at 00:00 UTC
     - cron: '0 0 * * 0'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 
 ## [Unreleased]
 
+### Changed
+
+- Pull-request CI is gcc-13 Debug+Release, code-quality, packaging, and
+  path-filtered docs. gcc-11 Debug, CUDA/HIP compile-only, and coverage run on
+  `master` pushes (coverage also weekly). Clang-tidy is weekly plus
+  `workflow_dispatch`, not per PR.
+
 ## [0.2.0] - 2026-09-05
 
 Breaking architecture release. There is no `pfc::Model`, `pfc::Simulator`,

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -211,13 +211,13 @@ follows the message rules.
 
 ## CI (GitHub Actions)
 
-Pull requests run workflows under [`.github/workflows/`](.github/workflows):
-**`ci.yml`** (main build/test matrix on Ubuntu 24.04), **`docs.yml`**
-(markdown link check via `scripts/check_doc_links.py`, Doxygen when
-enabled), **`coverage.yml`**, **`asan.yml`**, **`clang-tidy.yml`**.
-Doc-only edits under `docs/**` still trigger the Documentation
-workflow's link job — run `python3 scripts/check_doc_links.py` locally
-before pushing.
+Pull requests run a **short** set under [`.github/workflows/`](.github/workflows):
+**`ci.yml`** code-quality, gcc-13 Debug+Release `ctest` (including 2-rank MPI),
+and packaging smoke; **`docs.yml`** when docs/headers/README change. Coverage
+and CUDA/HIP compile-only run on `master` pushes (coverage also weekly).
+Clang-tidy is weekly plus `workflow_dispatch`, not a PR gate. AddressSanitizer
+is `workflow_dispatch` only. Doc-only edits still trigger the Documentation
+link job — run `python3 scripts/check_doc_links.py` locally before pushing.
 
 Passing checks make a PR mergeable, not right. Fix only lint/test
 failures **this PR introduced**; fold those fixes into the commit that


### PR DESCRIPTION
PRs no longer run the jobs that do not gate merges.

**On every PR:** code-quality, gcc-13 Debug + Release (with 2-rank MPI), packaging smoke, and docs when those paths change.

**On `master` / `develop` push:** also gcc-11 Debug, CUDA/HIP compile-only, coverage.

**Weekly / manual:** clang-tidy (Sunday 03:00 UTC and `workflow_dispatch`). Coverage already had a Sunday cron; it is removed from PRs.

Clang-tidy was 45–60 minutes, `continue-on-error`, and unused for merge. The four-way GCC matrix and coverage duplicated Debug `ctest`.

If branch protection still requires `ubuntu-24.04 / gcc-11 / Debug` (or Release) by name, drop those required checks and keep **CI Status** plus gcc-13 / Code Quality / Packaging.