### PR TITLE
fix(ci): skip 4-rank goldens when MPI world size is capped

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -130,6 +130,7 @@ jobs:
       - name: Run Tests
         working-directory: build
         run: |
+          set -o pipefail
           # Run tests with verbose output on failure
           ctest --output-on-failure -j2 \
             --exclude-regex "benchmark" \

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 
 ## [Unreleased]
 
+### Fixed
+
+- `tungsten-golden-4rank` and `aluminum-golden-4rank` honor
+  `OpenPFC_MPI_TEST_MAX_WORLD_SIZE` (CI sets 2). They were launching 4 ranks on
+  GitHub runners, which Open MPI rejects; gcc-13 jobs hid the same CTest
+  failures because `ctest | tee` dropped the exit code.
+
 ### Changed
 
 - Pull-request CI is gcc-13 Debug+Release, code-quality, packaging, and

--- a/apps/aluminumNew/CMakeLists.txt
+++ b/apps/aluminumNew/CMakeLists.txt
@@ -93,12 +93,19 @@ if(ALUMINUM_ENABLE_TESTS AND OpenPFC_BUILD_TESTS)
     add_test(NAME aluminum-etd-cpu-golden COMMAND aluminumTest
         "[seed_grid_fcc][session]")
     if(OpenPFC_RUN_MPI_SUITES AND MPIEXEC_EXECUTABLE)
-      add_test(NAME aluminum-golden-4rank
-        COMMAND ${MPIEXEC_EXECUTABLE} ${MPIEXEC_NUMPROC_FLAG} 4
-                $<TARGET_FILE:aluminumTest> "[golden][MPI]")
-      set_tests_properties(aluminum-golden-4rank PROPERTIES
-        TIMEOUT 180
-        RUN_SERIAL TRUE)
+      if(OpenPFC_MPI_TEST_MAX_WORLD_SIZE GREATER 0 AND
+         OpenPFC_MPI_TEST_MAX_WORLD_SIZE LESS 4)
+        message(STATUS
+          "Skipping aluminum-golden-4rank: OpenPFC_MPI_TEST_MAX_WORLD_SIZE="
+          "${OpenPFC_MPI_TEST_MAX_WORLD_SIZE}")
+      else()
+        add_test(NAME aluminum-golden-4rank
+          COMMAND ${MPIEXEC_EXECUTABLE} ${MPIEXEC_NUMPROC_FLAG} 4
+                  $<TARGET_FILE:aluminumTest> "[golden][MPI]")
+        set_tests_properties(aluminum-golden-4rank PROPERTIES
+          TIMEOUT 180
+          RUN_SERIAL TRUE)
+      endif()
     endif()
 
     if(OpenPFC_ENABLE_CUDA_SPECTRAL)

--- a/apps/tungsten/CMakeLists.txt
+++ b/apps/tungsten/CMakeLists.txt
@@ -112,12 +112,19 @@ if(TUNGSTEN_ENABLE_TESTS)
     add_test(NAME tungsten-cpu-golden COMMAND test_tungsten "[etd_cpu_golden]")
     add_test(NAME tungsten-etd-cpu-golden COMMAND test_tungsten "[etd_cpu_golden]")
     if(OpenPFC_RUN_MPI_SUITES AND MPIEXEC_EXECUTABLE)
-      add_test(NAME tungsten-golden-4rank
-        COMMAND ${MPIEXEC_EXECUTABLE} ${MPIEXEC_NUMPROC_FLAG} 4
-                $<TARGET_FILE:test_tungsten> "[golden][MPI]")
-      set_tests_properties(tungsten-golden-4rank PROPERTIES
-        TIMEOUT 180
-        RUN_SERIAL TRUE)
+      if(OpenPFC_MPI_TEST_MAX_WORLD_SIZE GREATER 0 AND
+         OpenPFC_MPI_TEST_MAX_WORLD_SIZE LESS 4)
+        message(STATUS
+          "Skipping tungsten-golden-4rank: OpenPFC_MPI_TEST_MAX_WORLD_SIZE="
+          "${OpenPFC_MPI_TEST_MAX_WORLD_SIZE}")
+      else()
+        add_test(NAME tungsten-golden-4rank
+          COMMAND ${MPIEXEC_EXECUTABLE} ${MPIEXEC_NUMPROC_FLAG} 4
+                  $<TARGET_FILE:test_tungsten> "[golden][MPI]")
+        set_tests_properties(tungsten-golden-4rank PROPERTIES
+          TIMEOUT 180
+          RUN_SERIAL TRUE)
+      endif()
     endif()
 
     if(OpenPFC_ENABLE_CUDA_SPECTRAL)

--- a/docs/development/testing.md
+++ b/docs/development/testing.md
@@ -51,7 +51,7 @@ VTK writer tests and other targets may `add_test` separately under `tests/unit/f
 
 ## Application tests
 
-When `OpenPFC_BUILD_APPS=ON`, some apps register extra CTest entries (e.g. tungsten / aluminum checks). Those live next to each app’s `CMakeLists.txt`.
+When `OpenPFC_BUILD_APPS=ON`, some apps register extra CTest entries (e.g. tungsten / aluminum checks). Those live next to each app’s `CMakeLists.txt`. `tungsten-golden-4rank` and `aluminum-golden-4rank` follow `OpenPFC_MPI_TEST_MAX_WORLD_SIZE` (CI uses 2, so they are omitted on GitHub-hosted runners).
 
 Minimal new-test walkthrough: [`tutorials/add_catch2_test.md`](../tutorials/add_catch2_test.md).
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -54,7 +54,7 @@ Smaller binaries are used when **linking**, **launch**, or **isolation** differs
 - Tests that **require** multi-rank MPI behavior should be tagged **`[MPI]`** (and narrower tags like `[ring]`, `[grid]` where `tests/CMakeLists.txt` filters on them).
 - The default **`openpfc-all-tests`** run **excludes** `[MPI]` so serial/local runs stay simple.
 - If **`OpenPFC_RUN_MPI_SUITES=ON`** at configure time, extra CTest entries (e.g. `mpi_2procs_all`) run **`openpfc-tests`** under **`mpiexec`** with tag filters. The shared runner constructs one **`MPI_Worker`** per process; `MPI_Worker` initializes MPI only when needed and reuses the pre-initialized world when launched by `mpiexec`.
-- On hosts with **few logical CPUs**, CMake may **skip** registering 3- and 4-rank suites unless **`OpenPFC_MPI_TEST_REGISTER_HIGH_RANK_ALWAYS=ON`**. CI sets **`OpenPFC_MPI_TEST_MAX_WORLD_SIZE=2`** so only the 2-rank suite is registered on GitHub-hosted runners.
+- On hosts with **few logical CPUs**, CMake may **skip** registering 3- and 4-rank suites unless **`OpenPFC_MPI_TEST_REGISTER_HIGH_RANK_ALWAYS=ON`**. CI sets **`OpenPFC_MPI_TEST_MAX_WORLD_SIZE=2`** so only the 2-rank suite is registered on GitHub-hosted runners. App 4-rank goldens (`tungsten-golden-4rank`, `aluminum-golden-4rank`) use the same cap.
 
 ## Directory structure
 


### PR DESCRIPTION
The CI trim (PR #72) split gcc-11 Debug into a push-only job. That job does not pipe `ctest` through `tee`, so CTest failures actually fail the workflow.

`tungsten-golden-4rank` and `aluminum-golden-4rank` were still registered under `OpenPFC_MPI_TEST_MAX_WORLD_SIZE=2`. Open MPI on GitHub runners rejects `mpirun -n 4` (not enough slots). gcc-13 jobs had the same two failures and still passed because `ctest | tee` dropped the exit code.

This PR:
- omits those 4-rank goldens when the MPI world-size cap is below 4
- uses `set -o pipefail` on the gcc-13 CTest step

gcc-11 still runs only on `master` after merge.