### PR TITLE
feat(io): $ENV in result paths; LUMI tungsten_hip 1–8 GCD scaling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 - `FileResultsWriter` expands `$NAME` / `${NAME}` in result filename patterns
   at writer setup, then applies the existing increment template (`#65`).
   Unset, empty, or stray `$` fail closed.
+- LUMI-G `tungsten_hip` 1–8 GCD scaling recipe (`#87` first slice): I/O-off
+  TOML, parameterized sbatch, and [lumi_gpu_scaling.md](docs/hpc/lumi_gpu_scaling.md).
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 
 ## [Unreleased]
 
+### Added
+
+- `FileResultsWriter` expands `$NAME` / `${NAME}` in result filename patterns
+  at writer setup, then applies the existing increment template (`#65`).
+  Unset, empty, or stray `$` fail closed.
+
 ### Fixed
 
 - Docs `uv.lock` urllib3 2.7.0 and idna 3.19 (GHSA-qccp-gfcp-xxvc,

--- a/docs/hpc/README.md
+++ b/docs/hpc/README.md
@@ -19,6 +19,7 @@ Start with the [HPC operator guide](operator_guide.md).
 | MPI-IO paths and collective layout | [MPI-IO layout checklist](mpi_io_layout_checklist.md) |
 | Runtime instrumentation | [Performance profiling](performance_profiling.md) |
 | Profiling output contract | [Profiling export schema](profiling_export_schema.md) |
+| LUMI-G tungsten_hip 1–8 GCD campaign | [LUMI GPU scaling](lumi_gpu_scaling.md) |
 | First batch submission | [Slurm day one](../tutorials/hpc_slurm_day_one.md) |
 
 ## Site-specific guidance

--- a/docs/hpc/lumi_gpu_scaling.md
+++ b/docs/hpc/lumi_gpu_scaling.md
@@ -1,0 +1,113 @@
+<!--
+SPDX-FileCopyrightText: 2026 VTT Technical Research Centre of Finland Ltd
+SPDX-License-Identifier: AGPL-3.0-or-later
+-->
+
+# LUMI GPU scaling campaign (`tungsten_hip`)
+
+This page is the first slice of issue `#87`: make `tungsten_hip` busy on one
+LUMI-G GCD, then strong-scale that grid across 1, 2, 4, and 8 GCDs on one
+node. It is a campaign recipe, not a completed curve. Numbers belong in
+`BASELINES.md` and under scratch once jobs have run; they are not invented
+here.
+
+The reporting contract is [Scalability analysis plan](scalability_analysis_plan.md).
+Install and GPU-aware MPI notes are in [INSTALL.LUMI.md](INSTALL.LUMI.md).
+
+## What this slice answers
+
+For the shipped 3D spectral ETD app `tungsten_hip`, on LUMI-G (MI250X, HIP /
+rocFFT, one MPI rank per GCD):
+
+1. Which cubic grid makes one GCD compute-bound (`wall_step` clearly above
+   launch and sync noise, with memory recorded)?
+2. How does time per accepted step change from 1 to 8 GCDs on that global
+   grid (strong scaling, I/O off)?
+
+In-tree pins (256³ CUDA on Tohtori, 64³ CPU) are too small for this question.
+The older `docs/lumi_slurm/tungsten_gpu.sbatch` path is a 0.1.4 full-node
+1024³ example on `project_462001245` scratch; do not use it for this campaign.
+
+## What this slice does not answer
+
+Keep these comparisons separate, as `#87` states:
+
+| Comparison | Status in this slice |
+|------------|----------------------|
+| Same PDE, spectral vs finite difference (Heat3D HIP twins) | Not started. Needs HIP drivers that do not exist yet. |
+| Production FD envelope (`kobayashi_fd_hip`, 2D) | Later `#87` slice. Different PDE; report cells/s, not “FD is faster”. |
+| Multi-node (>8 GCD) and LUMI-C CPU control | After the one-node GPU curve. |
+| Float GPU path | `#11`, not this campaign. Precision is double. |
+
+## How to run (LUMI login node)
+
+Build a 0.2 HIP tree with [`scripts/build.sh`](../../scripts/build.sh)
+(`--machine=lumi --with-rocm`). Trees go under
+`/flash/project_462001519/juaho/build/`. Point `TUNGSTEN_HIP_BIN` at that
+`tungsten_hip`.
+
+Account is `project_462001519`. Job logs go to
+`/scratch/project_462001519/juaho/logs/`. Per-job working directories go to
+`/scratch/project_462001519/juaho/openpfc-scaling/runs/` (override with
+`OPENPFC_SCALING_ROOT`).
+
+```bash
+export TUNGSTEN_HIP_BIN=/flash/project_462001519/juaho/build/<tree>/apps/tungsten/tungsten_hip
+
+# 1. Size one GCD: 256³ … 768³, 20 steps, I/O off, profiling on.
+./docs/lumi_slurm/submit_tungsten_hip_scaling.sh size
+
+# 2. After picking Lx (wall_step busy, memory fits), strong-scale 1/2/4/8 GCDs.
+TUNGSTEN_LX=512 ./docs/lumi_slurm/submit_tungsten_hip_scaling.sh strong
+```
+
+`PARTITION` defaults to `small-g`. Use `dev-g` for bring-up. `standard-g` is
+the full-node queue; it is not required for a 1–8 GCD single-node curve.
+
+Each job writes `input.toml`, a copy of the sbatch script, `run_meta.txt`,
+and `timing_profile.json` in its run directory. Keep the Slurm job id with
+those files. Do not commit profiles.
+
+Inputs: [`docs/lumi_slurm/tungsten_hip_scaling.toml`](../lumi_slurm/tungsten_hip_scaling.toml)
+(`saveat = -1`, no `[[fields]]`). The wrapper substitutes `__LX__` and
+`__T1__`. Binding follows the LUMI-G one-rank-per-GCD map; GPU-aware MPI is
+`MPICH_GPU_SUPPORT_ENABLED=1`.
+
+## How to read a point
+
+From each `timing_profile.json` (schema v4 summary; see
+[Profiling export schema](profiling_export_schema.md)):
+
+- `wall_step` median over accepted steps after a short warmup (the first
+  frames include FFT planning);
+- `fft` region vs the rest of the step;
+- RSS / heap when `memory_samples` is true (sizing jobs).
+
+For a baseline `p0 = 1` GCD:
+
+```text
+speedup(p)    = time(1 GCD) / time(p GCD)
+efficiency(p) = speedup(p) / p
+```
+
+`p` is GCD count (equal to MPI ranks). Stop calling the curve “scaling” once
+efficiency falls through a stated floor (for example 50%) or the job will not
+start. That floor *is* the one-node limit for this problem.
+
+Correctness: compare a cheap observable (field checksum, L2, or HEX) at 1 GCD
+vs N GCD on the same grid and step count. A performance point without that
+check is not a valid `#87` result.
+
+## After this slice
+
+1. Record job ids, the chosen `Lx`, and the 1–8 GCD table in `BASELINES.md`.
+2. Extend the same recipe off-node (16, 32, … GCDs) until efficiency or
+   memory stops the run.
+3. Add the FD envelope (`kobayashi_fd_hip`) and, when HIP twins exist, the
+   Heat3D same-PDE comparison.
+
+## See also
+
+- [LUMI Slurm guide](../lumi_slurm/README.md)
+- [Performance profiling](performance_profiling.md)
+- [GPU path decision](gpu_path_decision.md)

--- a/docs/hpc/mpi_io_layout_checklist.md
+++ b/docs/hpc/mpi_io_layout_checklist.md
@@ -16,7 +16,7 @@ Use this before debugging “missing file” or **hang** issues on clusters.
 
 - [ ] Job script **`cd`**s to the directory where relative paths in JSON are valid.  
 - [ ] **`argv[1]`** config path is correct from that directory (or use an absolute path).  
-- [ ] **`fields[].data`** directories exist or are creatable; rank 0 creates parents in the default wiring ([`binary_field_io_spec.md`](../reference/binary_field_io_spec.md)).
+- [ ] **`fields[].data`** directories exist or are creatable; rank 0 creates parents in the default wiring ([`binary_field_io_spec.md`](../reference/binary_field_io_spec.md)). If the template uses `$NAME` / `${NAME}`, those variables must be set and non-empty in the job environment.
 
 ## Binary writers (`BinaryWriter`)
 

--- a/docs/hpc/scalability_analysis_plan.md
+++ b/docs/hpc/scalability_analysis_plan.md
@@ -142,6 +142,7 @@ benchmark source of truth.
 
 ## See also
 
+- [LUMI GPU scaling campaign](lumi_gpu_scaling.md) — first `tungsten_hip` 1–8 GCD slice
 - [Performance profiling](performance_profiling.md)
 - [GPU path decision](gpu_path_decision.md)
 - [MPI-IO layout checklist](mpi_io_layout_checklist.md)

--- a/docs/index.md
+++ b/docs/index.md
@@ -65,6 +65,7 @@ hpc/build_cpu_gpu
 hpc/mpi_io_layout_checklist
 hpc/performance_profiling
 hpc/profiling_export_schema
+hpc/lumi_gpu_scaling
 hpc/INSTALL.LUMI
 hpc/INSTALL.tohtori
 lumi_slurm/README

--- a/docs/lumi_slurm/README.md
+++ b/docs/lumi_slurm/README.md
@@ -5,9 +5,26 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 
 # Slurm: tungsten performance on LUMI
 
-Scripts and TOML inputs for running the tungsten performance case (`tungsten_performance.toml`–style settings) on LUMI-C (CPU / FFTW) and LUMI-G (HIP / rocFFT).
+Scripts and TOML inputs for running tungsten on LUMI-C (CPU / FFTW) and LUMI-G
+(HIP / rocFFT).
 
-## Layout
+## 0.2 GPU scaling campaign (start here)
+
+Issue `#87` first slice: size `tungsten_hip` on one GCD, then strong-scale
+1/2/4/8 GCDs with I/O off. Recipe, account, and scratch paths:
+[LUMI GPU scaling campaign](../hpc/lumi_gpu_scaling.md).
+
+```bash
+export TUNGSTEN_HIP_BIN=/path/to/tungsten_hip   # 0.2 HIP build
+./docs/lumi_slurm/submit_tungsten_hip_scaling.sh size
+TUNGSTEN_LX=512 ./docs/lumi_slurm/submit_tungsten_hip_scaling.sh strong
+```
+
+Files: `tungsten_hip_scaling.sbatch`, `tungsten_hip_scaling.toml`,
+`submit_tungsten_hip_scaling.sh`. Account `project_462001519`. Do not point
+these jobs at the 0.1.4 binaries or `project_462001245` scratch used below.
+
+## Layout (legacy 1024³ helpers)
 
 - This directory (under the git repo): `*.sbatch`, `submit_tungsten_performance.sh`, `verify_gpu_aware_mpi.sh`, and `tungsten_performance_*.toml`.
 - Domain size: `tungsten_performance_*.toml` use 1024³ grid points (heavy run; sbatch time limit 12 h).

--- a/docs/lumi_slurm/submit_tungsten_hip_scaling.sh
+++ b/docs/lumi_slurm/submit_tungsten_hip_scaling.sh
@@ -1,0 +1,80 @@
+#!/bin/bash
+# SPDX-FileCopyrightText: 2026 VTT Technical Research Centre of Finland Ltd
+# SPDX-License-Identifier: AGPL-3.0-or-later
+#
+# Submit the first #87 LUMI-G tungsten_hip slice from a LUMI login node.
+# This host (Tohtori) cannot reach the LUMI scheduler.
+#
+# Usage:
+#   TUNGSTEN_HIP_BIN=/path/to/tungsten_hip ./submit_tungsten_hip_scaling.sh size
+#   TUNGSTEN_HIP_BIN=/path/to/tungsten_hip TUNGSTEN_LX=512 \
+#     ./submit_tungsten_hip_scaling.sh strong
+#
+# Optional environment:
+#   PARTITION          default small-g (dev-g for bring-up)
+#   TUNGSTEN_LX        cubic grid; size tries several, strong uses this (512)
+#   TUNGSTEN_STEPS     accepted steps (default 20)
+#   OPENPFC_SCALING_ROOT  scratch parent for run directories
+#   ACCOUNT            default project_462001519
+
+set -euo pipefail
+
+: "${TUNGSTEN_HIP_BIN:?set TUNGSTEN_HIP_BIN to the 0.2 tungsten_hip binary}"
+if [[ ! -x "${TUNGSTEN_HIP_BIN}" ]]; then
+  echo "TUNGSTEN_HIP_BIN is not executable: ${TUNGSTEN_HIP_BIN}" >&2
+  exit 1
+fi
+
+MODE="${1:-}"
+if [[ "${MODE}" != "size" && "${MODE}" != "strong" ]]; then
+  echo "usage: $0 size|strong" >&2
+  exit 1
+fi
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SBATCH="${SCRIPT_DIR}/tungsten_hip_scaling.sbatch"
+TEMPLATE="${SCRIPT_DIR}/tungsten_hip_scaling.toml"
+PARTITION="${PARTITION:-small-g}"
+ACCOUNT="${ACCOUNT:-project_462001519}"
+STEPS="${TUNGSTEN_STEPS:-20}"
+export TUNGSTEN_HIP_BIN
+export TUNGSTEN_STEPS="${STEPS}"
+export TUNGSTEN_SCALING_TEMPLATE="${TEMPLATE}"
+export OPENPFC_SCALING_ROOT="${OPENPFC_SCALING_ROOT:-/scratch/project_462001519/juaho/openpfc-scaling}"
+
+submit_one() {
+  local n="$1"
+  local lx="$2"
+  local job_name="$3"
+  export TUNGSTEN_LX="${lx}"
+  sbatch \
+    --account="${ACCOUNT}" \
+    --partition="${PARTITION}" \
+    --nodes=1 \
+    --ntasks="${n}" \
+    --ntasks-per-node="${n}" \
+    --gpus-per-node="${n}" \
+    --job-name="${job_name}" \
+    --export=ALL \
+    "${SBATCH}"
+}
+
+case "${MODE}" in
+  size)
+    echo "Sizing 1 GCD (I/O off, ${STEPS} steps, partition=${PARTITION})"
+    for lx in 256 384 512 640 768; do
+      submit_one 1 "${lx}" "thip-size-${lx}"
+    done
+    ;;
+  strong)
+    LX="${TUNGSTEN_LX:-512}"
+    echo "Strong scaling ${LX}³ on 1/2/4/8 GCDs (I/O off, ${STEPS} steps, partition=${PARTITION})"
+    for n in 1 2 4 8; do
+      submit_one "${n}" "${LX}" "thip-strong-${n}gcd-lx${LX}"
+    done
+    ;;
+esac
+
+echo "Logs: /scratch/project_462001519/juaho/logs/"
+echo "Runs: ${OPENPFC_SCALING_ROOT}/runs/"
+echo "Keep job ids next to the profiles. See docs/hpc/lumi_gpu_scaling.md."

--- a/docs/lumi_slurm/tungsten_hip_scaling.sbatch
+++ b/docs/lumi_slurm/tungsten_hip_scaling.sbatch
@@ -1,0 +1,88 @@
+#!/bin/bash
+# SPDX-FileCopyrightText: 2026 VTT Technical Research Centre of Finland Ltd
+# SPDX-License-Identifier: AGPL-3.0-or-later
+#
+#SBATCH --account=project_462001519
+#SBATCH --partition=small-g
+#SBATCH --nodes=1
+#SBATCH --ntasks=1
+#SBATCH --ntasks-per-node=1
+#SBATCH --gpus-per-node=1
+#SBATCH --time=01:00:00
+#SBATCH --output=/scratch/project_462001519/juaho/logs/%x-%j.out
+#
+# tungsten_hip on LUMI-G: one MPI rank per GCD. First #87 slice (size one
+# GCD, then strong-scale 1/2/4/8 GCDs on one node). I/O off. Submit with
+# docs/lumi_slurm/submit_tungsten_hip_scaling.sh so ntasks and gpus-per-node
+# match. Do not use the 0.1.4 / project_462001245 paths in tungsten_gpu.sbatch.
+#
+# Required in the job environment:
+#   TUNGSTEN_HIP_BIN   absolute path to a 0.2 tungsten_hip
+# Optional:
+#   TUNGSTEN_LX        cubic grid (default 512)
+#   TUNGSTEN_STEPS     accepted steps; t1 = steps with dt=1 (default 20)
+#   OPENPFC_SCALING_ROOT  scratch run parent
+#     (default /scratch/project_462001519/juaho/openpfc-scaling)
+
+set -euo pipefail
+
+: "${TUNGSTEN_HIP_BIN:?set TUNGSTEN_HIP_BIN to the 0.2 tungsten_hip binary}"
+
+LX="${TUNGSTEN_LX:-512}"
+STEPS="${TUNGSTEN_STEPS:-20}"
+JOBROOT="${OPENPFC_SCALING_ROOT:-/scratch/project_462001519/juaho/openpfc-scaling}"
+
+# Slurm runs a spool copy of this script; do not resolve the TOML relative to
+# BASH_SOURCE. The submit helper exports TUNGSTEN_SCALING_TEMPLATE.
+TEMPLATE="${TUNGSTEN_SCALING_TEMPLATE:-}"
+if [[ -z "${TEMPLATE}" || ! -f "${TEMPLATE}" ]]; then
+  echo "set TUNGSTEN_SCALING_TEMPLATE to docs/lumi_slurm/tungsten_hip_scaling.toml" >&2
+  exit 1
+fi
+
+module purge
+module load LUMI/25.09 partition/G cpeGNU cray-fftw lumi-CrayPath
+
+export LD_LIBRARY_PATH="${CRAY_LD_LIBRARY_PATH:-}${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
+export MPICH_GPU_SUPPORT_ENABLED=1
+
+NTASKS="${SLURM_NTASKS:?SLURM_NTASKS is not set}"
+RUNDIR="${JOBROOT}/runs/${SLURM_JOB_NAME}_${SLURM_JOB_ID}"
+mkdir -p "${RUNDIR}"
+
+sed -e "s/__LX__/${LX}/g" -e "s/__T1__/${STEPS}/g" "${TEMPLATE}" \
+  > "${RUNDIR}/input.toml"
+cp -f "${BASH_SOURCE[0]}" "${RUNDIR}/tungsten_hip_scaling.sbatch"
+cd "${RUNDIR}"
+
+cat << 'EOF' > "${RUNDIR}/select_gpu"
+#!/bin/bash
+export ROCR_VISIBLE_DEVICES=${SLURM_LOCALID}
+exec "$@"
+EOF
+chmod +x "${RUNDIR}/select_gpu"
+
+# Full-node 8-GCD map from LUMI-G docs. Prefix it when requesting fewer GCDs.
+GCD_CPUS=(49 57 17 25 1 9 33 41)
+if (( NTASKS > ${#GCD_CPUS[@]} )); then
+  echo "this slice is one node (max 8 GCDs); ntasks=${NTASKS}" >&2
+  exit 1
+fi
+BIND_LIST="$(IFS=,; echo "${GCD_CPUS[*]:0:${NTASKS}}")"
+CPU_BIND="map_cpu:${BIND_LIST}"
+
+{
+  echo "=== tungsten_hip scaling ==="
+  echo "job=${SLURM_JOB_ID} name=${SLURM_JOB_NAME}"
+  echo "nodes=${SLURM_NNODES} ntasks=${NTASKS} partition=${SLURM_JOB_PARTITION}"
+  echo "bin=${TUNGSTEN_HIP_BIN}"
+  echo "Lx=Ly=Lz=${LX} steps=${STEPS} cwd=${RUNDIR}"
+  echo "cpu-bind=${CPU_BIND}"
+  echo "MPICH_GPU_SUPPORT_ENABLED=${MPICH_GPU_SUPPORT_ENABLED}"
+} | tee "${RUNDIR}/run_meta.txt"
+
+srun --cpu-bind="${CPU_BIND}" "${RUNDIR}/select_gpu" \
+  "${TUNGSTEN_HIP_BIN}" "${RUNDIR}/input.toml"
+
+rm -f "${RUNDIR}/select_gpu"
+echo "=== done ==="

--- a/docs/lumi_slurm/tungsten_hip_scaling.toml
+++ b/docs/lumi_slurm/tungsten_hip_scaling.toml
@@ -1,0 +1,76 @@
+# SPDX-FileCopyrightText: 2026 VTT Technical Research Centre of Finland Ltd
+# SPDX-License-Identifier: AGPL-3.0-or-later
+#
+# Template for the LUMI-G tungsten_hip 1–8 GCD scaling slice (#87).
+# The sbatch wrapper substitutes __LX__ (cubic grid) and __T1__ (t0=0, dt=1
+# so this is the measured step count). Do not commit substituted copies.
+#
+# I/O is off: saveat = -1 and no [[fields]]. Profiling writes a schema-v4
+# JSON summary next to the job working directory. HIP FFTs use rocFFT
+# inside tungsten_hip; [plan_options].backend is unused on that path.
+
+[model]
+name = "tungsten"
+
+[model.params]
+n0 = -0.10
+alpha = 0.50
+n_sol = -0.047
+n_vap = -0.464
+T = 3300.0
+T0 = 156000.0
+Bx = 0.8582
+alpha_farTol = 0.001
+alpha_highOrd = 4
+lambda = 0.22
+stabP = 0.2
+shift_u = 0.3341
+shift_s = 0.1898
+p2 = 1.0
+p3 = -0.5
+p4 = 0.333333333
+q20 = -0.0037
+q21 = 1.0
+q30 = -12.4567
+q31 = 20.0
+q40 = 45.0
+
+[domain]
+Lx = __LX__
+Ly = __LX__
+Lz = __LX__
+dx = 1.1107207345395915
+dy = 1.1107207345395915
+dz = 1.1107207345395915
+origin = "center"
+
+[timestepping]
+t0 = 0.0
+t1 = __T1__
+dt = 1.0
+saveat = -1.0
+
+[[initial_conditions]]
+target = "psi"
+type = "constant"
+n0 = -0.4
+
+[[initial_conditions]]
+target = "psi"
+type = "single_seed"
+amp_eq = 0.216
+rho_seed = -0.047
+
+[profiling]
+enabled = true
+format = "json"
+output = "timing_profile"
+memory_samples = true
+print_report = true
+
+[plan_options]
+backend = "fftw"
+use_reorder = true
+reshape_algorithm = "p2p_plined"
+use_pencils = true
+use_gpu_aware = true

--- a/docs/reference/binary_field_io_spec.md
+++ b/docs/reference/binary_field_io_spec.md
@@ -14,7 +14,7 @@ This document describes the **raw binary** files produced by `pfc::BinaryWriter`
 Do not treat a lone headerless `BinaryWriter` file as the full checkpoint /
 restart contract.
 
-**Implementation references:** [`include/openpfc/frontend/io/binary_writer.hpp`](../../include/openpfc/frontend/io/binary_writer.hpp), [`include/openpfc/kernel/simulation/binary_reader.hpp`](../../include/openpfc/kernel/simulation/binary_reader.hpp), [`include/openpfc/frontend/utils/utils.hpp`](../../include/openpfc/frontend/utils/utils.hpp) (`format_with_number`).
+**Implementation references:** [`include/openpfc/frontend/io/binary_writer.hpp`](../../include/openpfc/frontend/io/binary_writer.hpp), [`include/openpfc/kernel/simulation/binary_reader.hpp`](../../include/openpfc/kernel/simulation/binary_reader.hpp), [`include/openpfc/frontend/utils/utils.hpp`](../../include/openpfc/frontend/utils/utils.hpp) (`expand_env_in_path`, `format_with_number`).
 
 ## File contents
 
@@ -38,11 +38,12 @@ Each `write(increment, field)` call:
 
 ## Filename template and `increment`
 
-The JSON `fields[].data` string is passed to `BinaryWriter` as the filename template.
+The JSON `fields[].data` string is passed to `BinaryWriter` as the filename template. `FileResultsWriter` resolves it at writer setup in this order:
 
-- If the string contains **`%`**, it is passed to `printf`-style formatting with the **integer `increment`** supplied by the simulator (see [`simulation_wiring_writers.hpp`](../../include/openpfc/frontend/ui/simulation_wiring_writers.hpp) and `BinaryWriter::write_mpi_binary`).  
-  Examples: `./psi_%d.bin`, `./data/u_%04d.bin`.  
-- If there is **no `%`**, the same path is used on every write (overwrites each time).
+1. **Environment expansion.** `$NAME` and `${NAME}` (POSIX name `[A-Za-z_][A-Za-z0-9_]*`) are replaced from the process environment. Unset or empty variables, and any stray `$`, fail closed with `std::invalid_argument` — they do not become a literal relative path. Example: `$RESULTS/data_%04d.bin` with `RESULTS=/scratch/run` becomes `/scratch/run/data_%04d.bin`.
+2. **Increment templating.** If the expanded string contains **`%`**, it is passed to `printf`-style formatting with the **integer `increment`** supplied by the simulator (see [`simulation_wiring_writers.hpp`](../../include/openpfc/frontend/ui/simulation_wiring_writers.hpp) and `BinaryWriter::write_mpi_binary`).  
+   Examples: `./psi_%d.bin`, `./data/u_%04d.bin`, `$RESULTS/data_%04d.bin`.  
+- If there is **no `%`** after expansion, the same path is used on every write (overwrites each time).
 
 The `increment` value is advanced by the simulator according to configuration (see [`app_pipeline.md`](../user_guide/app_pipeline.md) and the `simulator` section in JSON).
 

--- a/docs/reference/class_tour.md
+++ b/docs/reference/class_tour.md
@@ -50,7 +50,7 @@ The shortest useful mental model is:
 | `pfc::sim::run` / `SimulationDriver` | Time loop over physics `step` plus optional IC/BC/save hooks | `openpfc/kernel/simulation/simulation_driver.hpp` | `examples/05_simulator.cpp` |
 | `FieldModifier` + `apply_field_modifier` | Initial and boundary conditions on a host or device `Field` (JSON catalog or programmatic) | `openpfc/kernel/simulation/field_modifier.hpp`, `apply_field_modifier.hpp` | `examples/10_ui_register_ic.cpp` |
 | `ResultsWriter` | Stable interface for persisted simulation fields | `openpfc/kernel/simulation/results_writer.hpp` | `examples/11_write_results.cpp` |
-| `FileResultsWriter` | File sink with increment path templating | `openpfc/frontend/io/file_results_writer.hpp` | `BinaryWriter`, `VTKWriter` |
+| `FileResultsWriter` | File sink with `$ENV` expansion and increment path templating | `openpfc/frontend/io/file_results_writer.hpp` | `BinaryWriter`, `VTKWriter` |
 | `World` | Deprecated A0 adapter around `Domain` | `openpfc/kernel/data/world.hpp` | `examples/world_strong_types_example.cpp` uses `Domain` |
 | `SpectralCPUStack` | Owns the CPU domain, decomposition, FFT, and field stack | `openpfc/kernel/simulation/stacks/spectral_cpu_stack.hpp` | `user_guide/app_pipeline.md` |
 | `GPUSpectralStack` | Device FFT stack; JSON `plan_options` overlay like CPU | `openpfc/runtime/gpu/gpu_spectral_stack.hpp` | `tungsten_cuda`, session-matrix-cuda |

--- a/docs/reference/spectral_app_config_reference.md
+++ b/docs/reference/spectral_app_config_reference.md
@@ -54,7 +54,7 @@ When `saveat > 0` and `fields` is present, `parse_result_writers_from_json` cons
 | Key | Type | Meaning |
 |-----|------|---------|
 | `fields[].name` | string | Field identifier known to the simulator / model |
-| `fields[].data` | string | Filename template; if it contains `%`, `printf`-style formatting with the simulator’s output **increment** is applied (see [`binary_field_io_spec.md`](binary_field_io_spec.md)) |
+| `fields[].data` | string | Filename template. `$NAME` / `${NAME}` environment references are expanded first (unset or empty is a hard error). If the expanded string contains `%`, `printf`-style formatting with the simulator’s output **increment** is applied (see [`binary_field_io_spec.md`](binary_field_io_spec.md)) |
 | `fields[].writer` | string | Catalog key: `"binary"` (default), `"vtk"`, or `"hdf5"` when built with `OpenPFC_ENABLE_HDF5`. Unknown keys are a hard error. `"hdf5"` writes `/field` plus a `.xdmf` sidecar (parallel HDF5 MPI-IO, or gather-to-rank-0 when HDF5 is serial). |
 
 ## Initial / boundary conditions

--- a/docs/tutorials/hpc_slurm_day_one.md
+++ b/docs/tutorials/hpc_slurm_day_one.md
@@ -16,7 +16,7 @@ This page is a **minimal** pattern for running OpenPFC under **Slurm** on a typi
 
 Slurm starts the job in **`$SLURM_SUBMIT_DIR`** (where you ran `sbatch`) or a directory you set with `#SBATCH -D` / `cd` in the script.
 
-**Rule:** Paths in JSON (`fields[].data`, logs) are usually **relative to the job’s current working directory**. Use **absolute paths** if you prefer not to depend on `cd`.
+**Rule:** Paths in JSON (`fields[].data`, logs) are usually **relative to the job’s current working directory**. Use **absolute paths** if you prefer not to depend on `cd`. `fields[].data` may also use `$NAME` / `${NAME}` (for example `$RESULTS/psi_%04d.bin` or `${SLURM_JOB_ID}`) so the same input can write under scratch without rewriting the file; unset variables fail at writer setup.
 
 See also: [`../mpi_io_layout_checklist.md`](../hpc/mpi_io_layout_checklist.md).
 

--- a/docs/user_guide/io_results.md
+++ b/docs/user_guide/io_results.md
@@ -28,7 +28,7 @@ a mock writer; no simulator object is needed.
 
 ### JSON-driven `App` path
 
-[`simulation_wiring_writers.hpp`](../../include/openpfc/frontend/ui/simulation_wiring_writers.hpp) `parse_result_writers_from_json` takes a **`ResultsWriterCatalog`** at the call site (e.g. `default_results_writer_catalog()` for built-in `binary`). It returns named `BinaryWriter`s (or catalog `vtk`/`hdf5`): for each `fields[]` entry it uses `field["data"]` as the path template. Sessions attach those writers on the `on_save` hook.
+[`simulation_wiring_writers.hpp`](../../include/openpfc/frontend/ui/simulation_wiring_writers.hpp) `parse_result_writers_from_json` takes a **`ResultsWriterCatalog`** at the call site (e.g. `default_results_writer_catalog()` for built-in `binary`). It returns named `BinaryWriter`s (or catalog `vtk`/`hdf5`): for each `fields[]` entry it uses `field["data"]` as the path template. `$NAME` and `${NAME}` environment references are expanded when the writer is created (unset or empty variables are a hard error); increment templating (`%04d`) runs afterwards. Sessions attach those writers on the `on_save` hook.
 
 Requirements in settings: `saveat > 0`, `fields` array with `name` and `data`.
 

--- a/include/openpfc/frontend/io/file_results_writer.hpp
+++ b/include/openpfc/frontend/io/file_results_writer.hpp
@@ -11,7 +11,9 @@
  * Kernel `ResultsWriter` is format-agnostic (file, stdout, in-memory). Filename
  * patterns such as `output_%04d.bin` belong here so a non-file sink does not
  * need a dummy path. `BinaryWriter`, `VTKWriter`, and `HDF5Writer` derive from
- * this type.
+ * this type. `$NAME` / `${NAME}` environment references are expanded at
+ * construction (fail-closed); `formatted_path` then applies increment
+ * templating.
  */
 
 #include <string>
@@ -25,7 +27,7 @@ namespace pfc {
 class FileResultsWriter : public ResultsWriter {
 public:
   explicit FileResultsWriter(std::string filename_pattern)
-      : m_filename(std::move(filename_pattern)) {}
+      : m_filename(utils::expand_env_in_path(filename_pattern)) {}
 
   [[nodiscard]] const std::string &filename_pattern() const noexcept {
     return m_filename;

--- a/include/openpfc/frontend/ui/simulation_wiring_writers.hpp
+++ b/include/openpfc/frontend/ui/simulation_wiring_writers.hpp
@@ -24,6 +24,7 @@
 #include <nlohmann/json.hpp>
 #include <openpfc/frontend/ui/results_writer_catalog.hpp>
 #include <openpfc/frontend/ui/simulation_wiring_context.hpp>
+#include <openpfc/frontend/utils/utils.hpp>
 #include <openpfc/kernel/simulation/results_writer.hpp>
 #include <openpfc/kernel/utils/logging.hpp>
 
@@ -92,7 +93,8 @@ parse_result_writers_from_json(const nlohmann::json &settings,
   if (has_fields && saves) {
     for (const auto &field : settings["fields"]) {
       std::string name = field["name"];
-      std::string data = field["data"];
+      std::string data =
+          pfc::utils::expand_env_in_path(field["data"].get<std::string>());
       std::string writer_type = "binary";
       if (field.contains("writer") && field["writer"].is_string()) {
         writer_type = field["writer"].get<std::string>();

--- a/include/openpfc/frontend/utils/utils.hpp
+++ b/include/openpfc/frontend/utils/utils.hpp
@@ -33,6 +33,7 @@
 #ifndef PFC_UTILS_HPP
 #define PFC_UTILS_HPP
 
+#include <cstdlib>
 #include <mpi.h>
 #include <stdexcept>
 #include <string>
@@ -135,6 +136,103 @@ inline std::string format_with_number(const std::string &filename, int increment
     return string_format(filename, increment);
   }
   return filename;
+}
+
+/**
+ * @brief Expand `$NAME` / `${NAME}` POSIX environment references in a path
+ *
+ * @details
+ * A single left-to-right pass replaces each `$NAME` or `${NAME}` with
+ * `std::getenv(NAME)`. Names match `[A-Za-z_][A-Za-z0-9_]*`. Values are not
+ * re-scanned. This runs **before** `format_with_number` so a pattern such as
+ * `$RESULTS/data_%04d.bin` becomes `/scratch/run/data_%04d.bin` and then
+ * `/scratch/run/data_0007.bin`.
+ *
+ * Fail-closed: an unset or empty variable, or any `$` that is not a valid
+ * reference (including `$$`, a trailing `$`, `${}` , and unclosed `${…}`),
+ * throws `std::invalid_argument`. There is no silent fallback to a literal
+ * `$RESULTS/...` relative path.
+ *
+ * @param path Filename pattern, possibly containing environment references
+ * @return Path with environment references substituted
+ *
+ * @throws std::invalid_argument if a referenced variable is unset or empty,
+ *         or if the string contains a stray `$`
+ *
+ * @see format_with_number
+ * @see FileResultsWriter
+ */
+[[nodiscard]] inline std::string expand_env_in_path(const std::string &path) {
+  if (path.find('$') == std::string::npos) {
+    return path;
+  }
+  const auto is_name_start = [](unsigned char c) {
+    return (c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z') || c == '_';
+  };
+  const auto is_name_cont = [&](unsigned char c) {
+    return is_name_start(c) || (c >= '0' && c <= '9');
+  };
+  const auto stray_dollar = [&path]() {
+    return std::invalid_argument(
+        std::string("expand_env_in_path: stray '$' in filename pattern '") + path +
+        "'");
+  };
+  const auto posix_name = [&is_name_start, &is_name_cont](const std::string &name) {
+    if (name.empty() || !is_name_start(static_cast<unsigned char>(name.front()))) {
+      return false;
+    }
+    for (std::size_t i = 1; i < name.size(); ++i) {
+      if (!is_name_cont(static_cast<unsigned char>(name[i]))) {
+        return false;
+      }
+    }
+    return true;
+  };
+
+  std::string out;
+  out.reserve(path.size());
+  for (std::size_t i = 0; i < path.size();) {
+    if (path[i] != '$') {
+      out.push_back(path[i]);
+      ++i;
+      continue;
+    }
+    ++i;
+    std::string name;
+    if (i < path.size() && path[i] == '{') {
+      ++i;
+      const std::size_t name_begin = i;
+      while (i < path.size() && path[i] != '}') {
+        ++i;
+      }
+      if (i >= path.size()) {
+        throw stray_dollar();
+      }
+      name = path.substr(name_begin, i - name_begin);
+      ++i;
+      if (!posix_name(name)) {
+        throw stray_dollar();
+      }
+    } else {
+      if (i >= path.size() || !is_name_start(static_cast<unsigned char>(path[i]))) {
+        throw stray_dollar();
+      }
+      const std::size_t name_begin = i;
+      ++i;
+      while (i < path.size() && is_name_cont(static_cast<unsigned char>(path[i]))) {
+        ++i;
+      }
+      name = path.substr(name_begin, i - name_begin);
+    }
+    const char *value = std::getenv(name.c_str());
+    if (value == nullptr || value[0] == '\0') {
+      throw std::invalid_argument(
+          std::string("expand_env_in_path: environment variable '") + name +
+          "' is unset or empty in filename pattern '" + path + "'");
+    }
+    out.append(value);
+  }
+  return out;
 }
 
 template <typename T> size_t sizeof_vec(const std::vector<T> &V) {

--- a/tests/unit/frontend/io/test_binary_writer.cpp
+++ b/tests/unit/frontend/io/test_binary_writer.cpp
@@ -17,6 +17,7 @@
 #include <climits>
 #include <complex>
 #include <cstddef>
+#include <cstdlib>
 #include <filesystem>
 #include <stdexcept>
 #include <string>
@@ -97,6 +98,50 @@ TEST_CASE("FileResultsWriter formats increment into the path",
   BinaryWriter writer("out_%04d.bin");
   REQUIRE(writer.filename_pattern() == "out_%04d.bin");
   REQUIRE(writer.formatted_path(7) == "out_0007.bin");
+}
+
+TEST_CASE("FileResultsWriter expands $ENV before the increment template",
+          "[binary_writer][io]") {
+  const char *name = "OPENPFC_TEST_RESULTS";
+  const char *old = std::getenv(name);
+  REQUIRE(setenv(name, "/tmp/run", 1) == 0);
+  try {
+    BinaryWriter writer("$OPENPFC_TEST_RESULTS/data_%04d.bin");
+    REQUIRE(writer.filename_pattern() == "/tmp/run/data_%04d.bin");
+    REQUIRE(writer.formatted_path(0) == "/tmp/run/data_0000.bin");
+    REQUIRE(writer.formatted_path(7) == "/tmp/run/data_0007.bin");
+  } catch (...) {
+    if (old) {
+      setenv(name, old, 1);
+    } else {
+      unsetenv(name);
+    }
+    throw;
+  }
+  if (old) {
+    setenv(name, old, 1);
+  } else {
+    unsetenv(name);
+  }
+}
+
+TEST_CASE("FileResultsWriter fails at construction when $ENV is unset",
+          "[binary_writer][io]") {
+  const char *name = "OPENPFC_TEST_MISSING";
+  const char *old = std::getenv(name);
+  unsetenv(name);
+  try {
+    REQUIRE_THROWS_AS(BinaryWriter("$OPENPFC_TEST_MISSING/data_%04d.bin"),
+                      std::invalid_argument);
+  } catch (...) {
+    if (old) {
+      setenv(name, old, 1);
+    }
+    throw;
+  }
+  if (old) {
+    setenv(name, old, 1);
+  }
 }
 
 TEST_CASE("ResultsWriter default-constructs without a filename",

--- a/tests/unit/kernel/data/test_utils.cpp
+++ b/tests/unit/kernel/data/test_utils.cpp
@@ -1,7 +1,9 @@
-// SPDX-FileCopyrightText: 2025 VTT Technical Research Centre of Finland Ltd
+// SPDX-FileCopyrightText: 2026 VTT Technical Research Centre of Finland Ltd
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
+#include <cstdlib>
 #include <mpi.h>
+#include <string>
 
 #include <catch2/catch_test_macros.hpp>
 
@@ -140,6 +142,103 @@ TEST_CASE("utils - format_with_number validation accepts valid patterns", "[util
   SECTION("Accepts pattern with % in middle of text") {
     std::string result = utils::format_with_number("data_frame_%d_raw", 5);
     REQUIRE(result == "data_frame_5_raw");
+  }
+}
+
+namespace {
+
+struct EnvVarGuard {
+  std::string name_;
+  std::string original_;
+  bool was_set_;
+
+  EnvVarGuard(std::string name, const char *value) : name_(std::move(name)) {
+    const char *val = std::getenv(name_.c_str());
+    was_set_ = val != nullptr;
+    original_ = was_set_ ? val : "";
+    if (value == nullptr) {
+      unsetenv(name_.c_str());
+    } else {
+      setenv(name_.c_str(), value, 1);
+    }
+  }
+
+  ~EnvVarGuard() {
+    if (was_set_) {
+      setenv(name_.c_str(), original_.c_str(), 1);
+    } else {
+      unsetenv(name_.c_str());
+    }
+  }
+
+  EnvVarGuard(const EnvVarGuard &) = delete;
+  EnvVarGuard &operator=(const EnvVarGuard &) = delete;
+};
+
+} // namespace
+
+TEST_CASE("utils - expand_env_in_path", "[utils][unit]") {
+  SECTION("Returns paths without $ unchanged") {
+    REQUIRE(utils::expand_env_in_path("output_%04d.dat") == "output_%04d.dat");
+    REQUIRE(utils::expand_env_in_path("plain.dat") == "plain.dat");
+  }
+
+  SECTION("Expands $NAME and ${NAME}") {
+    EnvVarGuard results("OPENPFC_TEST_RESULTS", "/tmp/run");
+    REQUIRE(utils::expand_env_in_path("$OPENPFC_TEST_RESULTS/data_%04d.bin") ==
+            "/tmp/run/data_%04d.bin");
+    REQUIRE(utils::expand_env_in_path("${OPENPFC_TEST_RESULTS}/data_%04d.bin") ==
+            "/tmp/run/data_%04d.bin");
+  }
+
+  SECTION("Expands several references in one path") {
+    EnvVarGuard a("OPENPFC_TEST_A", "/scratch");
+    EnvVarGuard b("OPENPFC_TEST_B", "job42");
+    REQUIRE(utils::expand_env_in_path("$OPENPFC_TEST_A/${OPENPFC_TEST_B}/u.bin") ==
+            "/scratch/job42/u.bin");
+  }
+
+  SECTION("Does not treat a prefix as the full name") {
+    EnvVarGuard home("OPENPFC_TEST_HOME", "/home/user");
+    EnvVarGuard extra("OPENPFC_TEST_HOME_EXTRA", "/other");
+    REQUIRE(utils::expand_env_in_path("$OPENPFC_TEST_HOME_EXTRA/x") == "/other/x");
+  }
+
+  SECTION("Fails closed when the variable is unset") {
+    EnvVarGuard missing("OPENPFC_TEST_MISSING", nullptr);
+    REQUIRE_THROWS_AS(utils::expand_env_in_path("$OPENPFC_TEST_MISSING/data.bin"),
+                      std::invalid_argument);
+    try {
+      (void)utils::expand_env_in_path("$OPENPFC_TEST_MISSING/data.bin");
+      FAIL("Should have thrown std::invalid_argument");
+    } catch (const std::invalid_argument &e) {
+      const std::string msg = e.what();
+      REQUIRE(msg.find("OPENPFC_TEST_MISSING") != std::string::npos);
+      REQUIRE(msg.find("unset or empty") != std::string::npos);
+    }
+  }
+
+  SECTION("Fails closed when the variable is empty") {
+    EnvVarGuard empty("OPENPFC_TEST_EMPTY", "");
+    REQUIRE_THROWS_AS(utils::expand_env_in_path("${OPENPFC_TEST_EMPTY}/data.bin"),
+                      std::invalid_argument);
+  }
+
+  SECTION("Fails closed on stray $") {
+    REQUIRE_THROWS_AS(utils::expand_env_in_path("data$.bin"), std::invalid_argument);
+    REQUIRE_THROWS_AS(utils::expand_env_in_path("data$$.bin"), std::invalid_argument);
+    REQUIRE_THROWS_AS(utils::expand_env_in_path("$123/x.bin"), std::invalid_argument);
+    REQUIRE_THROWS_AS(utils::expand_env_in_path("${}/x.bin"), std::invalid_argument);
+    REQUIRE_THROWS_AS(utils::expand_env_in_path("${OPEN/x.bin"), std::invalid_argument);
+    REQUIRE_THROWS_AS(utils::expand_env_in_path("${bad-name}/x.bin"),
+                      std::invalid_argument);
+    try {
+      (void)utils::expand_env_in_path("out$.bin");
+      FAIL("Should have thrown std::invalid_argument");
+    } catch (const std::invalid_argument &e) {
+      const std::string msg = e.what();
+      REQUIRE(msg.find("stray '$'") != std::string::npos);
+    }
   }
 }
 


### PR DESCRIPTION
## Summary

Two 0.2.1 slices that were queued together:

1. **#65** — `FileResultsWriter` expands `$NAME` / `${NAME}` at writer setup, then applies the existing `%04d` increment template. Unset, empty, or stray `$` fail closed.
2. **#87 first slice only** — LUMI-G recipe to size `tungsten_hip` on one GCD and strong-scale 1/2/4/8 GCDs with I/O off. Does **not** close #87 (no Heat3D HIP twins, no FD curve, no numbers yet).

## #65

- `pfc::utils::expand_env_in_path` in `include/openpfc/frontend/utils/utils.hpp`
- Called from `FileResultsWriter` construction and `parse_result_writers_from_json` (so parent dirs are created from the expanded path)
- Tests in `test_utils.cpp` and `test_binary_writer.cpp`
- Docs: I/O guide, spectral config reference, binary field spec

Example: `$RESULTS/data_%04d.bin` with `RESULTS=/tmp/run` → `/tmp/run/data_0000.bin`.

## #87 first slice

On a **LUMI login node** (not Tohtori):

```bash
export TUNGSTEN_HIP_BIN=/path/to/tungsten_hip
./docs/lumi_slurm/submit_tungsten_hip_scaling.sh size
TUNGSTEN_LX=512 ./docs/lumi_slurm/submit_tungsten_hip_scaling.sh strong
```

Account `project_462001519`. Run dirs under `/scratch/project_462001519/juaho/openpfc-scaling/`. Recipe: `docs/hpc/lumi_gpu_scaling.md`. Legacy `tungsten_gpu.sbatch` (0.1.4 / `project_462001245`) is left in place.

## Tests

`./scripts/build.sh --machine=tohtori --build-type=Debug --build-dir=builds/debug` — 39/39 CTest batches + Python scripts.

Please merge by **rebase** (not squash).

Closes #65