### PR TITLE
feat(tungsten): optional G_grid thermal drive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 
 ### Added
 
+- Tungsten optional `G_grid` / `V_grid` / `x_initial` thermal drive (`#34`).
+  Omitting the keys keeps the isothermal CPU goldens; CPU/CUDA/HIP share
+  `TungstenPointwise`.
 - `FileResultsWriter` expands `$NAME` / `${NAME}` in result filename patterns
   at writer setup, then applies the existing increment template (`#65`).
   Unset, empty, or stray `$` fail closed.

--- a/apps/tungsten/README.md
+++ b/apps/tungsten/README.md
@@ -30,6 +30,8 @@ Install path when using `cmake --install`: `<prefix>/bin/`.
 
 Start from `inputs_json/tungsten_single_seed.json` or `inputs_toml/tungsten_single_seed.toml`. Heavy performance cases: `tungsten_performance.*`.
 
+Optional directional-solidification keys on `model.params` (same names as aluminum): `G_grid`, `V_grid`, `x_initial`. Default is isothermal (`G_grid = 0`). The linear operator stays at JSON `T`; the pointwise cubic uses `T + G (x' - x_initial - V t)`. CPU / CUDA / HIP share `tungsten_pointwise.hpp`.
+
 ## Run (from build tree)
 
 ```bash

--- a/apps/tungsten/include/tungsten/common/tungsten_params.hpp
+++ b/apps/tungsten/include/tungsten/common/tungsten_params.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 VTT Technical Research Centre of Finland Ltd
+// SPDX-FileCopyrightText: 2026 VTT Technical Research Centre of Finland Ltd
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
 #ifndef TUNGSTEN_PARAMS_HPP
@@ -55,6 +55,10 @@ private:
   double m_q30 = -12.4567;   ///< Vapor-model coefficient q30
   double m_q31 = 20.0;       ///< Vapor-model coefficient q31
   double m_q40 = 45.0;       ///< Vapor-model coefficient q40
+  double m_G_grid = 0.0;     ///< Thermal gradient along x (0 = isothermal)
+  double m_V_grid = 0.0;     ///< Frame velocity used in T_var(x, t)
+  double m_x_initial = 0.0;  ///< Initial solidification-front position
+  double m_xpos = 0.0;       ///< Current front position (starts as x_initial)
 
 public:
   /**
@@ -198,6 +202,33 @@ public:
    */
   void set_q40(double q40) { m_q40 = q40; }
 
+  /**
+   * @brief Set thermal gradient along x (JSON `G_grid`)
+   * @param G_grid Gradient; 0 disables the thermal drive
+   */
+  void set_G_grid(double G_grid) { m_G_grid = G_grid; }
+
+  /**
+   * @brief Set moving-frame velocity used in T_var (JSON `V_grid`)
+   * @param V_grid Frame velocity
+   */
+  void set_V_grid(double V_grid) { m_V_grid = V_grid; }
+
+  /**
+   * @brief Set initial front position (JSON `x_initial`)
+   * @param x_initial Front coordinate; also resets the current front
+   */
+  void set_x_initial(double x_initial) {
+    m_x_initial = x_initial;
+    m_xpos = x_initial;
+  }
+
+  /**
+   * @brief Set current front position used to unwrap T_var
+   * @param xpos Front coordinate
+   */
+  void set_xpos(double xpos) { m_xpos = xpos; }
+
   // ============================================================================
   // Getters for base parameters
   // ============================================================================
@@ -327,6 +358,11 @@ public:
    * @return Coefficient value
    */
   double get_q40() const { return m_q40; }
+
+  double get_G_grid() const { return m_G_grid; }
+  double get_V_grid() const { return m_V_grid; }
+  double get_x_initial() const { return m_x_initial; }
+  double get_xpos() const { return m_xpos; }
 
   // ============================================================================
   // Getters for derived parameters (calculated on-the-fly)

--- a/apps/tungsten/include/tungsten/tungsten_physics.hpp
+++ b/apps/tungsten/include/tungsten/tungsten_physics.hpp
@@ -15,7 +15,8 @@
  * - `nonlinear_symbol(k) = k` (PFC form \f$\partial_t\hat\psi =
  *   k(C\hat\psi + \hat N)\f$);
  * - `pointwise()` returns the device-capable `TungstenPointwise`
- *   (`tungsten_pointwise.hpp`), which includes the ETD stabilisation.
+ *   (`tungsten_pointwise.hpp`), which includes the ETD stabilisation and
+ *   optional `G_grid` / `V_grid` thermal drive (isothermal when omitted).
  *
  * No backend classes, no k-loops, no hand-written kernels.
  */
@@ -56,6 +57,9 @@ struct TungstenSchemaValues {
   double q30{-12.4567};
   double q31{20.0};
   double q40{45.0};
+  double G_grid{0.0};
+  double V_grid{0.0};
+  double x_initial{0.0};
 };
 
 inline void apply_schema_values(const TungstenSchemaValues &v, TungstenParams &p) {
@@ -80,6 +84,9 @@ inline void apply_schema_values(const TungstenSchemaValues &v, TungstenParams &p
   p.set_q30(v.q30);
   p.set_q31(v.q31);
   p.set_q40(v.q40);
+  p.set_G_grid(v.G_grid);
+  p.set_V_grid(v.V_grid);
+  p.set_x_initial(v.x_initial);
 }
 
 inline pfc::sim::ParameterSchema<TungstenSchemaValues> make_tungsten_schema() {
@@ -139,7 +146,22 @@ inline pfc::sim::ParameterSchema<TungstenSchemaValues> make_tungsten_schema() {
       .real(&TungstenSchemaValues::q31,
             {.name = "q31", .description = "q31", .required = true})
       .real(&TungstenSchemaValues::q40,
-            {.name = "q40", .description = "q40", .required = true});
+            {.name = "q40", .description = "q40", .required = true})
+      .real(&TungstenSchemaValues::G_grid,
+            {.name = "G_grid",
+             .description = "thermal gradient along x (0 = isothermal)",
+             .required = false,
+             .default_value = 0.0})
+      .real(&TungstenSchemaValues::V_grid,
+            {.name = "V_grid",
+             .description = "moving-frame velocity in T_var(x, t)",
+             .required = false,
+             .default_value = 0.0})
+      .real(&TungstenSchemaValues::x_initial,
+            {.name = "x_initial",
+             .description = "initial solidification-front position",
+             .required = false,
+             .default_value = 0.0});
   return s;
 }
 
@@ -199,17 +221,33 @@ struct TungstenPhysics {
   }
 
   [[nodiscard]] TungstenPointwise pointwise() const noexcept {
+    const auto size = pfc::domain::get_size(domain);
+    const auto spacing = pfc::domain::get_spacing(domain);
     return {.c_psi = -params.get_stabP(),
             .c_psi2 = params.get_p3_bar(),
             .c_psi3 = params.get_p4_bar(),
             .c_mf2 = params.get_q3_bar(),
-            .c_mf3 = params.get_q4_bar()};
+            .c_mf3 = params.get_q4_bar(),
+            .T = params.get_T(),
+            .T0 = params.get_T0(),
+            .q30_bar = params.get_q30_bar(),
+            .q31_bar = params.get_q31_bar(),
+            .G_grid = params.get_G_grid(),
+            .V_grid = params.get_V_grid(),
+            .x_initial = params.get_x_initial(),
+            .front_x = params.get_xpos(),
+            .length_x = static_cast<double>(size[0]) * spacing[0]};
   }
 
   /// Host convenience: \f$N(\psi,\psi_{\mathrm{MF}})\f$ via the pointwise functor.
-  [[nodiscard]] double nonlinearity(double psi, double psi_mf) const {
-    return pointwise().nonlinearity(
-        pfc::sim::SpectralCell{.psi = psi, .psi_mf = psi_mf});
+  [[nodiscard]] double nonlinearity(double psi, double psi_mf, double x = 0.0,
+                                    double t = 0.0) const {
+    return pointwise().nonlinearity(pfc::sim::SpectralCell{
+        .psi = psi, .psi_mf = psi_mf, .x = x, .t = t});
+  }
+
+  [[nodiscard]] double temperature_variation(double x, double t) const {
+    return pointwise().temperature_variation(x, t);
   }
 };
 

--- a/apps/tungsten/include/tungsten/tungsten_pointwise.hpp
+++ b/apps/tungsten/include/tungsten/tungsten_pointwise.hpp
@@ -11,12 +11,20 @@
  * \f$N(\psi,\psi_{\mathrm{MF}}) = -s\,\psi + \bar p_3\psi^2 + \bar p_4\psi^3
  *   + \bar q_3\psi_{\mathrm{MF}}^2 + \bar q_4\psi_{\mathrm{MF}}^3\f$
  *
+ * Optional thermal drive (same unwrap as aluminum):
+ * \f$T_{\mathrm{var}}(x,t) = G\,(x' - x_0 - V t)\f$. When \f$G = 0\f$ the
+ * mean-field cubic uses the reference \f$\bar q_3(T)\f$ so existing goldens
+ * stay bit-identical. When \f$G \ne 0\f$,
+ * \f$\bar q_3\f$ is rebuilt from \f$(T + T_{\mathrm{var}})/T_0\f$.
+ *
  * This header is intentionally tiny and JSON-free so a CUDA/HIP translation
  * unit can include it and instantiate the device launcher
  * (`OPENPFC_INSTANTIATE_SPECTRAL_POINTWISE(tungsten::TungstenPointwise)`).
  * The coefficients are filled by `TungstenPhysics::pointwise()` from
  * `TungstenParams`.
  */
+
+#include <cmath>
 
 #include <openpfc/kernel/data/host_device.hpp>
 #include <openpfc/kernel/simulation/spectral_pointwise.hpp>
@@ -27,15 +35,42 @@ struct TungstenPointwise {
   double c_psi{};  ///< \f$-\mathrm{stabP}\f$
   double c_psi2{}; ///< \f$\bar p_3\f$
   double c_psi3{}; ///< \f$\bar p_4\f$
-  double c_mf2{};  ///< \f$\bar q_3\f$
+  double c_mf2{};  ///< \f$\bar q_3\f$ at the JSON reference temperature
   double c_mf3{};  ///< \f$\bar q_4\f$
+  double T{};
+  double T0{1.0};
+  double q30_bar{};
+  double q31_bar{};
+  double G_grid{};
+  double V_grid{};
+  double x_initial{};
+  double front_x{};
+  double length_x{};
+
+  OPENPFC_HD double temperature_variation(double x, double t) const {
+    if (G_grid == 0.0) {
+      return 0.0;
+    }
+    if (length_x <= 0.0) {
+      return G_grid * (x - x_initial - V_grid * t);
+    }
+    const double fullruns = std::floor(front_x / length_x) * length_x;
+    const double steppoint = std::fmod(front_x, length_x);
+    const double dist = x + fullruns - (x > steppoint) * length_x;
+    return G_grid * (dist - x_initial - V_grid * t);
+  }
 
   OPENPFC_HD double nonlinearity(const pfc::sim::SpectralCell &c) const {
     const double u = c.psi;
     const double v = c.psi_mf;
     const double u2 = u * u;
     const double v2 = v * v;
-    return c_psi * u + c_psi2 * u2 + c_psi3 * u2 * u + c_mf2 * v2 + c_mf3 * v2 * v;
+    double q3 = c_mf2;
+    if (G_grid != 0.0) {
+      const double T_var = temperature_variation(c.x, c.t);
+      q3 = q31_bar * (T + T_var) / T0 + q30_bar;
+    }
+    return c_psi * u + c_psi2 * u2 + c_psi3 * u2 * u + q3 * v2 + c_mf3 * v2 * v;
   }
 };
 

--- a/apps/tungsten/tests/test_tungsten_physics.cpp
+++ b/apps/tungsten/tests/test_tungsten_physics.cpp
@@ -104,6 +104,50 @@ TEST_CASE("TungstenPhysics schema round-trips JSON params",
   tungsten::apply_schema_values(vals, p);
   REQUIRE(p.get_n0() == Approx(-0.12));
   REQUIRE(p.get_alpha_highOrd() == 4);
+  REQUIRE(p.get_G_grid() == Approx(0.0));
+  REQUIRE(p.get_V_grid() == Approx(0.0));
+  REQUIRE(p.get_x_initial() == Approx(0.0));
+}
+
+TEST_CASE("TungstenPhysics thermal gradient is off when G_grid is omitted",
+          "[tungsten][physics][temperature]") {
+  tungsten::TungstenPhysics<> phys;
+  phys.domain = pfc::domain::create({32, 32, 32});
+  REQUIRE(phys.temperature_variation(10.0, 1.0) == Approx(0.0));
+
+  const double u = 0.1;
+  const double v = -0.05;
+  const double n0 = phys.nonlinearity(u, v);
+  phys.params.set_G_grid(0.5);
+  phys.params.set_V_grid(0.1);
+  phys.params.set_x_initial(4.0);
+  REQUIRE(phys.temperature_variation(10.0, 2.0) != Approx(0.0));
+  REQUIRE(phys.nonlinearity(u, v, 10.0, 2.0) != Approx(n0));
+}
+
+TEST_CASE("TungstenSession non-zero G_grid 8^3 run differs from isothermal",
+          "[tungsten][physics][temperature][golden]") {
+  int nproc = 1;
+  MPI_Comm_size(MPI_COMM_WORLD, &nproc);
+  if (nproc != 1) {
+    return;
+  }
+  json iso = golden_settings(8, 0.05, 0.01);
+  json grad = iso;
+  grad["model"]["params"]["G_grid"] = 0.5;
+  grad["model"]["params"]["V_grid"] = 0.1;
+  grad["model"]["params"]["x_initial"] = 2.0;
+
+  tungsten::TungstenSession a(iso, 0, 1, MPI_COMM_WORLD);
+  a.run();
+  tungsten::TungstenSession b(grad, 0, 1, MPI_COMM_WORLD);
+  b.run();
+  const double sa = sumsq(a.psi().vec());
+  const double sb = sumsq(b.psi().vec());
+  REQUIRE(std::isfinite(sa));
+  REQUIRE(std::isfinite(sb));
+  REQUIRE(std::abs(sa - sb) > 1e-12);
+  REQUIRE(sb > 0.0);
 }
 
 TEST_CASE("TungstenPhysics ETD weights: zero mode, near-zero, long-dt",

--- a/docs/reference/spectral_app_config_reference.md
+++ b/docs/reference/spectral_app_config_reference.md
@@ -47,6 +47,16 @@ Object key `"plan_options"` (JSON) or `[plan_options]` (TOML). Passed to HeFFTe 
 
 Validation is **model-dependent** (see [`parameter_validation.md`](../user_guide/parameter_validation.md)).
 
+Tungsten (`apps/tungsten`) accepts optional thermal-drive keys on `model.params`. Omitting them is the isothermal 0.2.0 case (CPU goldens unchanged):
+
+| Key | Type | Meaning |
+|-----|------|---------|
+| `G_grid` | number | Thermal gradient along x. Default `0` (no T_var). |
+| `V_grid` | number | Frame velocity in `T_var(x,t) = G (x' - x_initial - V t)`. Default `0`. |
+| `x_initial` | number | Initial front position used to unwrap x. Default `0`. |
+
+The linear ETD symbol still uses the JSON reference `T`. Only the real-space mean-field cubic (`q3`) sees the local temperature. CPU, CUDA, and HIP share `TungstenPointwise`. See [`apps/tungsten/README.md`](../../apps/tungsten/README.md).
+
 ## Result writers
 
 When `saveat > 0` and `fields` is present, `parse_result_writers_from_json` constructs a catalog writer per entry (default `"binary"` → `BinaryWriter`):


### PR DESCRIPTION
## Summary

Closes #34. Tungsten directional solidification can set a thermal gradient without a second physics class.

- Optional JSON keys on `model.params`: `G_grid`, `V_grid`, `x_initial` (default 0).
- Linear ETD symbol stays at the JSON reference `T`.
- Pointwise cubic rebuilds `q3` from `T + G (x' - x_initial - V t)` when `G_grid != 0`.
- `G_grid = 0` uses the precomputed cubic so existing CPU goldens stay bit-identical.
- CPU / CUDA / HIP share `TungstenPointwise`.

## Tests

`./scripts/build.sh --machine=tohtori --build-type=Debug --build-dir=builds/debug` — 39/39. Includes `tungsten-cpu-golden` and a 1-rank 8³ run that differs from the isothermal case.

Please merge by **rebase**.