### PR TITLE
fix(hpc): saveat<=0 and 1-GCD LUMI CPU bind

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 
 ### Added
 
+- JSON/TOML `saveat <= 0` is accepted and disables periodic saves, matching
+  `Time` and the spectral config reference. Negative sentinels such as
+  `saveat = -1` in LUMI I/O-off inputs no longer fail at parse.
 - Tungsten optional `G_grid` / `V_grid` / `x_initial` thermal drive (`#34`).
   Omitting the keys keeps the isothermal CPU goldens; CPU/CUDA/HIP share
   `TungstenPointwise`.
@@ -20,6 +23,9 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 
 ### Fixed
 
+- LUMI `tungsten_hip` scaling sbatch applies the 8-GCD `map_cpu` bind only
+  for 8-rank jobs. Prefixing that map on a 1-GCD `dev-g` allocation made
+  `srun` fail (`CPU binding outside of job step allocation`).
 - Docs `uv.lock` urllib3 2.7.0 and idna 3.19 (GHSA-qccp-gfcp-xxvc,
   GHSA-mf9v-mfxr-j63j, GHSA-65pc-fj4g-8rjx).
 - CUDA Field residency compile-check is an OBJECT library, not a Catch2 TU.

--- a/docs/lumi_slurm/tungsten_hip_scaling.sbatch
+++ b/docs/lumi_slurm/tungsten_hip_scaling.sbatch
@@ -62,14 +62,17 @@ exec "$@"
 EOF
 chmod +x "${RUNDIR}/select_gpu"
 
-# Full-node 8-GCD map from LUMI-G docs. Prefix it when requesting fewer GCDs.
-GCD_CPUS=(49 57 17 25 1 9 33 41)
-if (( NTASKS > ${#GCD_CPUS[@]} )); then
+# Full-node 8-GCD map from LUMI-G docs. Partial GCD allocations (dev-g /
+# small-g with 1–4 GPUs) do not own those CPUs; map_cpu:49 then fails.
+SRUN_BIND=()
+CPU_BIND="none"
+if (( NTASKS == 8 )); then
+  CPU_BIND="map_cpu:49,57,17,25,1,9,33,41"
+  SRUN_BIND=(--cpu-bind="${CPU_BIND}")
+elif (( NTASKS > 8 )); then
   echo "this slice is one node (max 8 GCDs); ntasks=${NTASKS}" >&2
   exit 1
 fi
-BIND_LIST="$(IFS=,; echo "${GCD_CPUS[*]:0:${NTASKS}}")"
-CPU_BIND="map_cpu:${BIND_LIST}"
 
 {
   echo "=== tungsten_hip scaling ==="
@@ -81,7 +84,7 @@ CPU_BIND="map_cpu:${BIND_LIST}"
   echo "MPICH_GPU_SUPPORT_ENABLED=${MPICH_GPU_SUPPORT_ENABLED}"
 } | tee "${RUNDIR}/run_meta.txt"
 
-srun --cpu-bind="${CPU_BIND}" "${RUNDIR}/select_gpu" \
+srun "${SRUN_BIND[@]}" "${RUNDIR}/select_gpu" \
   "${TUNGSTEN_HIP_BIN}" "${RUNDIR}/input.toml"
 
 rm -f "${RUNDIR}/select_gpu"

--- a/include/openpfc/frontend/ui/from_json_world_time.hpp
+++ b/include/openpfc/frontend/ui/from_json_world_time.hpp
@@ -240,11 +240,8 @@ template <> [[nodiscard]] inline Time from_json<Time>(const json &j) {
         "saveat", "snapshot output interval", "finite float",
         get_json_value_string(j, "saveat"), {}, "\"saveat\": 1.0"));
   }
-  if (saveat <= 0.0) {
-    throw std::invalid_argument(format_config_error(
-        "saveat", "snapshot output interval", "positive float",
-        get_json_value_string(j, "saveat"), {}, "\"saveat\": 1.0"));
-  }
+  // `saveat <= 0` disables periodic saves (`Time::do_save`); I/O-off
+  // campaign inputs use -1. Positive values must still be finite.
 
   // Parse integrator method (optional, defaults to Euler).
   pfc::sim::steppers::RKIntegratorMethod method =

--- a/tests/unit/frontend/ui/test_from_json_world_time_positivity.cpp
+++ b/tests/unit/frontend/ui/test_from_json_world_time_positivity.cpp
@@ -410,18 +410,20 @@ TEST_CASE("[world][positivity] from_json_world_with_nested_domain_accepts_valid_
   REQUIRE_NOTHROW(from_json<Domain>(j));
 }
 
-TEST_CASE("[time][positivity] from_json_time_rejects_zero_saveat") {
+TEST_CASE("[time][positivity] from_json_time_accepts_zero_saveat_to_disable_saves") {
   json j = {
       {"timestepping", {{"t0", 0.0}, {"t1", 10.0}, {"dt", 0.1}, {"saveat", 0.0}}}};
 
-  REQUIRE_THROWS_AS(from_json<Time>(j), std::invalid_argument);
+  const Time time = from_json<Time>(j);
+  REQUIRE(time.get_saveat() == 0.0);
 }
 
-TEST_CASE("[time][positivity] from_json_time_rejects_negative_saveat") {
+TEST_CASE("[time][positivity] from_json_time_accepts_negative_saveat_to_disable_saves") {
   json j = {
       {"timestepping", {{"t0", 0.0}, {"t1", 10.0}, {"dt", 0.1}, {"saveat", -1.0}}}};
 
-  REQUIRE_THROWS_AS(from_json<Time>(j), std::invalid_argument);
+  const Time time = from_json<Time>(j);
+  REQUIRE(time.get_saveat() == -1.0);
 }
 
 TEST_CASE("[time][positivity] from_json_time_accepts_valid_positive_saveat") {
@@ -432,8 +434,7 @@ TEST_CASE("[time][positivity] from_json_time_accepts_valid_positive_saveat") {
 }
 
 TEST_CASE("[time][positivity] from_json_time_error_message_names_saveat") {
-  json j = {
-      {"timestepping", {{"t0", 0.0}, {"t1", 10.0}, {"dt", 0.1}, {"saveat", 0.0}}}};
+  json j = {{"timestepping", {{"t0", 0.0}, {"t1", 10.0}, {"dt", 0.1}}}};
 
   try {
     (void)from_json<Time>(j);
@@ -441,7 +442,6 @@ TEST_CASE("[time][positivity] from_json_time_error_message_names_saveat") {
   } catch (const std::invalid_argument &e) {
     std::string msg = e.what();
     REQUIRE(msg.find("saveat") != std::string::npos);
-    REQUIRE(msg.find("snapshot output interval") != std::string::npos);
   }
 }
 
@@ -480,14 +480,15 @@ TEST_CASE("[time][positivity] from_json_time_error_message_names_t1_interval") {
   }
 }
 
-TEST_CASE("[time][positivity] from_json_time_with_flat_structure_rejects_non_positive_saveat") {
+TEST_CASE("[time][positivity] from_json_time_with_flat_structure_accepts_non_positive_saveat") {
   json j = {
       {"t0", 0.0},
       {"t1", 10.0},
       {"dt", 0.1},
       {"saveat", -0.5}};
 
-  REQUIRE_THROWS_AS(from_json<Time>(j), std::invalid_argument);
+  const Time time = from_json<Time>(j);
+  REQUIRE(time.get_saveat() == -0.5);
 }
 
 TEST_CASE("[time][positivity] from_json_time_with_flat_structure_rejects_t1_less_than_t0") {


### PR DESCRIPTION
## Summary

The first #87 1-GCD sizing jobs failed on LUMI:

1. `from_json<Time>` rejected `saveat = -1` (I/O-off sentinel). `Time` and the spectral config reference already treat `saveat <= 0` as disable-saves.
2. `srun --cpu-bind=map_cpu:49` is the full-node 8-GCD map. A 1-GCD `dev-g` allocation does not own those CPUs.

## Fix

- Accept finite `saveat <= 0` in `from_json<Time>`.
- Apply `map_cpu:49,57,…` only when `ntasks == 8`.

## Tests

`./scripts/build.sh --machine=tohtori --build-type=Debug --build-dir=builds/debug` — 39/39.

Please merge by **rebase**. Refs #87.