### PR TITLE
docs(apps): pin LUMI-G gradient_elasticity HIP smoke job

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,7 +36,8 @@ SPDX-License-Identifier: AGPL-3.0-or-later
   spectral \(2\times 2\) invert per \(\mathbf{k}\), not ETD. Catch2
   analytical Fourier \(\mathbf{u}\), \(\ell\to 0\) classical recovery,
   high-\(k\) reduction, and mean \(\mathbf{u}=0\). CPU binary plus
-  `gradient_elasticity_hip` when rocFFT HeFFTe is on.
+  `gradient_elasticity_hip` when rocFFT HeFFTe is on (LUMI-G smoke
+  job 21820023).
 - `ehd_film`: elastohydrodynamic film under a flexible plate on the 0.2
   spectral-ETD session (`#81`). Bending pressure \(B\nabla^4 h\) plus
   lubrication gives \(\lambda=-M_0 B k^6\). Catch2 exact \(k^6\) decay,

--- a/apps/gradient_elasticity/README.md
+++ b/apps/gradient_elasticity/README.md
@@ -87,7 +87,8 @@ longitudinal invert, \(k=0\) projection, \(\ell\to 0\) recovery of
 classical elasticity, analytical Fourier displacement for a cosine
 inclusion, high-\(k\) reduction at finite \(\ell\), and mean
 \(\mathbf{u}=0\). HIP builds add `HIP_GradientElasticity` and
-`gradient-elasticity-hip-smoke`.
+`gradient-elasticity-hip-smoke`. LUMI-G smoke: job 21820023 (`small-g`,
+16², mean \(\mathbf{u}=0\)).
 
 ## Layout
 


### PR DESCRIPTION
Pins the LUMI-G HIP smoke for `gradient_elasticity_hip` after #82 landed.

## HIP smoke

- Job **21820023** (`small-g`, nid007854, 42s, Exit 0:0)
- 16² cosine eigenstrain (`gradient_elasticity_hip_smoke.json`)
- `SPECTRAL_CHECKSUM field=ux sumsq=0.056445335888118342 l2=0.23758227183045105`
- `field=uy` is exactly 0
- CPU Tohtori sumsq `0.056445335888118391` (1 ULP); mean \(u\sim 0\)
- Only extra line: `CRAYBLAS_WARNING`

Merge by **rebase**, not squash. Do not rewrite `master`.