### PR TITLE
fix(tests): bare -isystem from Catch2's INSTALL_INTERFACE genex swallows -MD

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 
 ## [Unreleased]
 
+### Fixed
+
+- `ctest` can be registered in a `--no-heffte` CPU build again (`#105`). The
+  Catch2 `-isystem` loop in `tests/CMakeLists.txt` guarded on the unevaluated
+  string, so `$<INSTALL_INTERFACE:include>` passed the check and expanded to
+  nothing, emitting a bare `-isystem` that swallowed `-MD`. Install-interface
+  entries are now skipped. `heat3d`'s spectral Catch2 suite is gated on HeFFTe;
+  its FD operator-evaluation and rhs-pattern suites stay available.
+
 ### Changed
 
 - LUMI HIP work uses a clean `origin/master` clone at

--- a/apps/heat3d/CMakeLists.txt
+++ b/apps/heat3d/CMakeLists.txt
@@ -100,18 +100,27 @@ endif()
 if(HEAT3D_ENABLE_TESTS AND OpenPFC_BUILD_TESTS)
   find_package(Catch2 QUIET)
   if(TARGET Catch2::Catch2)
-    add_executable(test_heat3d tests/test_heat3d.cpp)
-    target_include_directories(test_heat3d PRIVATE ${HEAT3D_INCLUDE_DIR})
-    target_link_libraries(test_heat3d PRIVATE
-      OpenPFC
-      openpfc_apps_common
-      ${_heat3d_heffte_tgt}
-      Catch2::Catch2
-    )
     include(CTest)
-    # Run the whole heat3d suite in a single invocation to avoid per-test MPI
-    # init/finalize overhead (matches tungsten-all-tests / aluminum-all-tests).
-    add_test(NAME heat3d-all-tests COMMAND test_heat3d)
+    # test_heat3d.cpp covers the spectral propagator, so it includes
+    # fft_fftw.hpp (via spectral_cpu_stack.hpp) and cannot compile without
+    # HeFFTe. The operator-evaluation and rhs-pattern suites below are pure FD
+    # and stay available in a --no-heffte build.
+    if(OpenPFC_ENABLE_HEFFTE)
+      add_executable(test_heat3d tests/test_heat3d.cpp)
+      target_include_directories(test_heat3d PRIVATE ${HEAT3D_INCLUDE_DIR})
+      target_link_libraries(test_heat3d PRIVATE
+        OpenPFC
+        openpfc_apps_common
+        ${_heat3d_heffte_tgt}
+        Catch2::Catch2
+      )
+      # Run the whole heat3d suite in a single invocation to avoid per-test MPI
+      # init/finalize overhead (matches tungsten-all-tests / aluminum-all-tests).
+      add_test(NAME heat3d-all-tests COMMAND test_heat3d)
+    else()
+      message(STATUS
+        "heat3d-all-tests disabled: spectral suite needs HeFFTe")
+    endif()
 
     # Operator-evaluation contract tests
     add_executable(test_heat3d_operator_evaluation tests/test_heat3d_operator_evaluation.cpp)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -65,11 +65,17 @@ target_include_directories(openpfc-tests PRIVATE ${_catch2_include_dirs})
 # kernels) are not handed unrecognised flags by nvcc
 # — without this, nvcc fails with "A single input file is required for a
 # non-link phase when an outputfile is specified".
+# `if(dir)` tests the unevaluated string, so an `$<INSTALL_INTERFACE:...>`
+# entry passes the guard but expands to nothing in a build tree. That emits a
+# bare `-isystem`, which swallows whatever flag follows it on the command line
+# (`-MD`, and then cc1plus rejects `-MT`/`-MF` without `-M`). Install-interface
+# paths are meaningless here, so drop them.
 foreach(dir IN LISTS _catch2_include_dirs)
-  if(dir)
-    target_compile_options(openpfc-tests PRIVATE
-      "$<$<COMPILE_LANGUAGE:CXX>:SHELL:-isystem ${dir}>")
+  if(NOT dir OR dir MATCHES "^\\$<INSTALL_INTERFACE:")
+    continue()
   endif()
+  target_compile_options(openpfc-tests PRIVATE
+    "$<$<COMPILE_LANGUAGE:CXX>:SHELL:-isystem ${dir}>")
 endforeach()
 
 if(OpenPFC_ENABLE_CODE_COVERAGE)


### PR DESCRIPTION
Closes #105.

## The bug

`tests/CMakeLists.txt` walked Catch2's `INTERFACE_INCLUDE_DIRECTORIES` and
emitted one `-isystem` per entry, guarded by `if(dir)`. That guard tests the
**unevaluated string**, so `$<INSTALL_INTERFACE:include>` passed it — and then
expanded to nothing in a build tree, leaving a bare `-isystem` that consumed
the next token:

```
-isystem <catch2-src> -isystem <generated-includes> -isystem -MD -MT tests/...
                                                            ^^^ eaten
```

`cc1plus` then saw `-MT`/`-MF` with no `-M`, and `-Wfatal-errors` made it fatal.

Catch2 always comes from FetchContent, so the bare `-isystem` was emitted in
every configuration — it only became fatal where `-MD` happened to follow.

## The fix

Skip install-interface entries. Two lines, plus the comment explaining why the
obvious `target_include_directories(... SYSTEM ...)` isn't used here (the
existing comment documents the nvcc constraint).

## Second, independent gap this unmasked

With the build able to get past `tests/`, `apps/heat3d` then failed:
`test_heat3d.cpp` reaches `heffte.h` through `spectral_cpu_stack.hpp`, but its
test target was not HeFFTe-gated. Gated it. `test_heat3d_operator_evaluation`
and `test_heat3d_rhs_pattern` include no spectral headers and stay enabled in a
no-HeFFTe build.

Without this second change the first one doesn't deliver anything — the build
still fails, just later.

## Tests

LUMI, `--machine=lumi --cpu --no-heffte` with `-DOpenPFC_BUILD_TESTS=ON`:

- Build **PASS** (was: failed at `tests/runtests.cpp`, target 116 of 310).
- `ctest`: **29/29 PASS**, MPI suites included, run on an allocated `small`
  node (job 21828564). The build has to live on a shared filesystem for this —
  a node-local `/tmp` build dir fails every `srun` test with
  "couldn't chdir / execve(): No such file or directory".

Not re-run here: the HeFFTe-enabled configurations, which CI covers.

Merge by **rebase**, not squash.
