### PR TITLE
feat(containers): Cray/LUMI site profile — multi-node host MPI validated on 32 ranks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,15 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 
 ### Added
 
+- Cray/LUMI site profile for the runtime baker (`#13`): `--site cray`,
+  `--host-lib` for stack libraries that share a directory with ordinary system
+  libraries (LUMI's `/usr/lib64/libcxi.so.1`, `libxpmem.so.0`), `--runtime` to
+  select singularity-ce, a `/var/spool/slurmd` site bind that Cray PMI needs,
+  and a measured `host_glibc_requirement` in provenance. Validated on LUMI with
+  **4 nodes / 32 ranks** over the Slingshot `cxi` provider: the baked bundle
+  reproduces the native run bit-for-bit (job 21830651).
+
+
 - Multi-app CLI catalog and installed presets for eight JSON-session apps,
   with explicit backend availability and CPU entrypoint smoke tests.
 - Cahn–Hilliard seeded broadband coarsening preset and optional collective CSV

--- a/containers/runtime/README.md
+++ b/containers/runtime/README.md
@@ -11,9 +11,14 @@ non-MPI runtime dependencies. MPI, PMIx, and UCX remain on the host and are
 mounted read-only by the generated `run-host.sh`. The application is not
 recompiled inside the image.
 
-This first implementation supports the CLI's `local` CPU profile on a
-compatible Linux host. It is a runtime image, not the development image,
-GPU profiles, or multi-node/RDMA deployment proposed in issue #13.
+Two host MPI stacks are supported, selected with `--site`:
+
+| `--site` | stack | tested on |
+|---|---|---|
+| `openmpi` (default) | Open MPI / PMIx / UCX | Tohtori, single node |
+| `cray` | Cray MPICH / libfabric / Slingshot | LUMI, **4 nodes / 32 ranks** |
+
+It is a runtime image, not the development image or a GPU profile.
 
 ## Prepare and bake
 
@@ -85,6 +90,85 @@ They do not validate the site's RDMA path. Production networking can require
 additional provider directories, `/etc/libibverbs.d`, devices, and matching
 libfabric/PMI libraries. Do not infer multi-node scaling from this smoke run.
 
+## LUMI (`--site cray`)
+
+LUMI differs from Tohtori in four ways that each break a naive port, so they
+are encoded in the site profile rather than left to the operator.
+
+**1. The base image needs a new enough glibc.** The bind model loads *host*
+libraries inside the image, so the base's glibc must be at least as new as
+theirs. On LUMI, Cray MPICH, libfabric and libcxi all require `GLIBC_2.38`:
+
+```console
+$ objdump -T /opt/cray/pe/lib64/libmpi_gnu_123.so.12 | grep -o 'GLIBC_[0-9.]*' | sort -V | tail -1
+GLIBC_2.38
+```
+
+The Debian Bookworm base used for Tohtori ships glibc 2.36 and **cannot** work
+here; the symptom is an unhelpful symbol error at run time. Use a Trixie or
+Ubuntu 24.04 base. The baker records the measured floor as
+`host_glibc_requirement` in `provenance.json`.
+
+**2. Slingshot libraries share a directory with ordinary system libraries.**
+`libcxi.so.1` and `libxpmem.so.0` live in `/usr/lib64` next to `libstdc++.so.6`
+and `libz.so.1`. A prefix rule cannot separate them, and mounting the whole
+directory would shadow the base image's own libraries. Name them individually
+with `--host-lib`; the wrapper binds each file to `/opt/openpfc/hostlib/<soname>`
+and never mounts the shared directory. Omitting one is an error, not a silent
+bake of the interconnect into the image.
+
+**3. Cray PMI needs the Slurm daemon's socket directory.** The site profile
+binds `/var/spool/slurmd`. Without it `MPI_Init` fails with `job id unknown`
+and every rank believes it is rank 0.
+
+**4. LUMI cannot build images.** There is no `/etc/subuid` mapping for ordinary
+users and no readable `proot`, so `singularity build` fails whether or not
+`--fakeroot` is given. Bake on a build host and copy `case.sif` and
+`run-host.sh` to LUMI — which is the workflow #13 describes anyway. LUMI ships
+`singularity-ce`, not `apptainer`, hence `--runtime singularity`.
+
+```bash
+python3 scripts/bake_case.py CASE \
+  --site cray --runtime singularity \
+  --base BASE_WITH_GLIBC_2.38_OR_NEWER.sif \
+  --output builds/containers/mycase \
+  --host-prefix /opt/cray \
+  --host-prefix /opt/rocm-6.3.4 --host-prefix /opt/amdgpu \
+  --host-lib /usr/lib64/libcxi.so.1 \
+  --host-lib /usr/lib64/libxpmem.so.0
+```
+
+Use `/opt/cray`, not `/opt/cray/pe/lib64`: the libraries there are symlinks into
+`/opt/cray/pe/mpich/...`, and the baker resolves them before classifying.
+
+The case directory is not bound by the wrapper, so point `SINGULARITY_BIND` at
+the filesystem holding it. On LUMI that means both spellings, because
+`/flash/project_*` is a symlink into `/pfs`:
+
+```bash
+export SINGULARITY_BIND=/pfs,/flash
+srun -n 32 builds/containers/mycase/run-host.sh run "$CASE"
+```
+
+### Multi-node validation
+
+`small` partition, **4 nodes x 8 ranks = 32 ranks**, tungsten 64^3 for 5 steps.
+Both runs report `MPICH CH4 OFI netmod using cxi provider (domain_name=cxi0)`,
+so this exercises the Slingshot RDMA path and not a TCP fallback:
+
+| run | job | `sum` (hex) | `sumsq` (hex) |
+|---|---|---|---|
+| native | 21830651 | `-0x1.9e04f59f6c34p+13` | `0x1.04d0a9db35c98p+17` |
+| baked bundle | 21830651 | `-0x1.9e04f59f6c34p+13` | `0x1.04d0a9db35c98p+17` |
+
+Bit-identical. An earlier 2-node run (21830470 native, 21830489 container) agrees
+the same way. This closes the "host-MPI bind on more than one node" item of #13.
+
+The baked-bundle run above bound `payload/` into the base image rather than
+using a built `case.sif`, because LUMI cannot build one (point 4). It exercises
+the generated `run-host.sh` bind list, the payload/host split and the
+entrypoint; the SIF packaging step itself is covered by the Tohtori path.
+
 ## Bundle contents and provenance
 
 The staging directory contains `runtime.def`, `payload/`, `base.sif` (a symlink
@@ -132,8 +216,9 @@ resolution and check payload exclusion, hashes, input portability, and
 non-overwrite behavior. They do not require Apptainer privileges.
 
 Remaining issue #13 work includes a development image, exact build-source
-provenance, CUDA/HIP image profiles, network-provider integration, and a
-multi-node host-MPI validation. No container has been published to a registry.
+provenance, CUDA/HIP image profiles, and baking on a host that can build the
+SIF for LUMI. No container has been published to a registry, so the "download
+an image" entry point of the user workflow does not exist yet.
 
 The runtime follows Apptainer's documented
 [MPI bind model](https://apptainer.org/docs/user/main/mpi.html#bind-model) and

--- a/scripts/bake_case.py
+++ b/scripts/bake_case.py
@@ -2,7 +2,7 @@
 # SPDX-FileCopyrightText: 2026 VTT Technical Research Centre of Finland Ltd
 # SPDX-License-Identifier: AGPL-3.0-or-later
 
-"""Bake a compiled CPU tungsten case into an Apptainer image using host MPI."""
+"""Bake a compiled CPU tungsten case into a container image using host MPI."""
 
 import argparse
 import hashlib
@@ -17,8 +17,48 @@ import sys
 
 
 ROOT = Path(__file__).resolve().parent.parent
-GLIBC = re.compile(r"lib(?:c|m|dl|pthread|rt|util|resolv|anl|nss_[\w]+)\.so(?:\.|$)")
-MPI_STACK = re.compile(r"lib(?:mpi[^/]*|open-pal|pmix|ucp|uct|ucs|ucm)\.so(?:\.|$)")
+GLIBC = re.compile(r"lib(?:c|m|mvec|dl|pthread|rt|util|resolv|anl|nss_[\w]+)\.so(?:\.|$)")
+
+# Libraries that must come from the host, per site MPI stack. Baking any of
+# these would put the site's interconnect inside the image, which defeats the
+# host-MPI model and does not survive a move to another machine.
+MPI_STACK = {
+    # Open MPI / UCX (Tohtori).
+    "openmpi": re.compile(r"lib(?:mpi[^/]*|open-pal|pmix|ucp|uct|ucs|ucm)\.so(?:\.|$)"),
+    # Cray MPICH / libfabric / Slingshot (LUMI). libcxi and libxpmem live in
+    # /usr/lib64 next to ordinary system libraries, so a prefix rule cannot
+    # separate them: they need --host-lib.
+    "cray": re.compile(
+        r"lib(?:mpi[^/]*|fabric|cxi|pmi|pmi2|pals|xpmem|dsmml)\.so(?:\.|$)"),
+}
+MPI_MARKER = re.compile(r"libmpi[^/]*\.so(?:\.|$)")
+SITE_PROFILES = {"openmpi": {"local"}, "cray": {"local", "lumi"}}
+# Runtime state the site's process manager needs inside the container. Cray PMI
+# reaches the Slurm daemon through this socket directory; without it MPI_Init
+# fails with "job id unknown" and every rank believes it is rank 0.
+SITE_BINDS = {"openmpi": (), "cray": ("/var/spool/slurmd",)}
+
+
+def glibc_requirement(paths):
+    """Highest GLIBC_x.y symbol version the host-provided libraries need.
+
+    The bind model loads these host libraries inside the image, so the base
+    image's glibc must be at least this new. Getting this wrong fails at run
+    time with an unhelpful symbol error, so it is recorded in provenance and
+    checked against the base image when a container runtime is available.
+    """
+    best = None
+    for path in paths:
+        try:
+            out = subprocess.run(["objdump", "-T", str(path)], text=True,
+                                 capture_output=True, check=True).stdout
+        except (OSError, subprocess.CalledProcessError):
+            return None
+        for match in re.finditer(r"GLIBC_(\d+)\.(\d+)", out):
+            version = (int(match.group(1)), int(match.group(2)))
+            if best is None or version > best:
+                best = version
+    return best
 
 
 def digest(path):
@@ -44,7 +84,7 @@ def parse_ldd(output):
             if "/" in name or not path.startswith("/"):
                 raise ValueError("unsupported ldd entry: " + line)
             libraries[name] = Path(path).resolve()
-    if not any(name.startswith("libmpi.so") for name in libraries):
+    if not any(MPI_MARKER.match(name) for name in libraries):
         raise ValueError("expected a dynamically linked MPI application")
     return libraries
 
@@ -67,9 +107,11 @@ def validate_input(settings):
 def prepare(args):
     case = Path(args.case).resolve()
     manifest = json.loads((case / "openpfc.json").read_text())
+    profile = manifest.get("profile")
     if (manifest.get("format_version") != 1 or manifest.get("app") != "tungsten"
-            or manifest.get("profile") != "local" or manifest.get("input") != "input.json"):
-        raise ValueError("first runtime recipe requires a compiled local CPU tungsten case")
+            or profile not in SITE_PROFILES[args.site] or manifest.get("input") != "input.json"):
+        raise ValueError("runtime recipe requires a compiled tungsten case with profile "
+                         + "/".join(sorted(SITE_PROFILES[args.site])))
     validate_input(json.loads((case / "input.json").read_text()))
     executable = Path(manifest["executable"]).resolve()
     if not executable.is_file():
@@ -77,6 +119,18 @@ def prepare(args):
     base = Path(args.base).resolve()
     if not base.is_file():
         raise ValueError("--base must be a local Python 3.8+ Apptainer SIF image")
+    host_libs = {}
+    for value in args.host_lib:
+        given = Path(value)
+        path = given.resolve()
+        if not path.is_file():
+            raise ValueError("--host-lib is not a file: " + value)
+        if any(c in str(path) for c in ",:\n"):
+            raise ValueError("--host-lib path must not contain commas, colons, or newlines")
+        # Key on the spelling given, which is the soname ldd reports
+        # (libxpmem.so.0), not the versioned file it resolves to
+        # (libxpmem.so.0.0.0).
+        host_libs[given.name] = path
     prefixes = [Path(p).resolve() for p in args.host_prefix]
     # Site MPI may embed its original symlink spelling in plugin/help paths.
     bindings = sorted(set(prefixes + [Path(p).absolute() for p in args.host_prefix]))
@@ -84,12 +138,18 @@ def prepare(args):
         if not prefix.is_dir() or prefix == Path("/") or any(c in str(prefix) for c in ",:\n"):
             raise ValueError("host prefix must be a directory without commas, colons, or newlines")
     libraries = parse_ldd(subprocess.check_output(["ldd", str(executable)], text=True))
-    bundled, external, system = {}, {}, {}
+    mpi_stack = MPI_STACK[args.site]
+    bundled, external, host_files, system = {}, {}, {}, {}
     for name, path in libraries.items():
-        if any(under(path, prefix) for prefix in prefixes):
+        if name in host_libs:
+            if host_libs[name] != path:
+                raise ValueError("--host-lib does not match the resolved library: " + name)
+            host_files[name] = path
+        elif any(under(path, prefix) for prefix in prefixes):
             external[name] = path
-        elif MPI_STACK.match(name):
-            raise ValueError("MPI/PMIx/UCX library needs --host-prefix: " + str(path))
+        elif mpi_stack.match(name):
+            raise ValueError("host MPI stack library needs --host-prefix or --host-lib: "
+                             + str(path))
         elif GLIBC.match(name):
             system[name] = path
         else:
@@ -97,8 +157,10 @@ def prepare(args):
     output = Path(args.output).resolve()
     output.mkdir(parents=True, exist_ok=False)
     payload = output / "payload"
-    for directory in ("bin", "lib", "case", "share/openpfc"):
+    for directory in ("bin", "lib", "hostlib", "case", "share/openpfc"):
         (payload / directory).mkdir(parents=True, exist_ok=True)
+    # Bind destinations must already exist in the image.
+    (payload / "hostlib/.keep").write_text("")
     shutil.copy2(executable, payload / "bin/tungsten")
     shutil.copy2(ROOT / "scripts/openpfc", payload / "bin/openpfc")
     shutil.copy2(ROOT / "containers/runtime/baked_case.py", payload / "bin/baked-case")
@@ -108,7 +170,7 @@ def prepare(args):
     shutil.copy2(case / "input.json", payload / "case/input.json")
     (payload / "case/openpfc.json").write_text(json.dumps({
         "format_version": 1, "app": "tungsten", "input": "input.json",
-        "profile": "local", "executable": "/opt/openpfc/bin/tungsten",
+        "profile": profile, "executable": "/opt/openpfc/bin/tungsten",
     }, indent=2) + "\n")
     (payload / "case/README.md").write_text(
         "# Baked tungsten case\n\n"
@@ -125,15 +187,19 @@ def prepare(args):
                               text=True, capture_output=True)
     status = subprocess.run(["git", "-C", str(source), "status", "--porcelain"],
                             text=True, capture_output=True)
+    glibc_floor = glibc_requirement(sorted(set(external.values()) | set(host_files.values())))
     provenance = {
-        "format_version": 1, "profile": "local", "mpi_mode": "host-bind",
+        "format_version": 1, "profile": profile, "mpi_mode": "host-bind",
         "base_sha256": digest(base), "binary_sha256": digest(executable),
         "input_sha256": digest(case / "input.json"),
         "openpfc_version": (payload / "share/openpfc/version").read_text().strip(),
         "packaging_checkout_revision": revision.stdout.strip() if revision.returncode == 0 else None,
         "packaging_checkout_dirty": bool(status.stdout) if status.returncode == 0 else None,
         "source_identity_note": "Checkout at packaging time; not proof of binary build provenance.",
-        "bundled_libraries": records(bundled), "host_libraries": records(external),
+        "bundled_libraries": records(bundled),
+        "host_libraries": records({**external, **host_files}),
+        "host_glibc_requirement": (".".join(map(str, glibc_floor)) if glibc_floor else None),
+        "site": args.site,
         "base_provided_glibc": records(system),
         "host_prefixes": [str(p) for p in prefixes],
         "host_bindings": [str(p) for p in bindings],
@@ -148,15 +214,26 @@ def prepare(args):
         "%environment\n    export PATH=/opt/openpfc/bin:$PATH\n"
         "    export LD_LIBRARY_PATH=/opt/openpfc/lib:${LD_LIBRARY_PATH:-}\n\n"
         "%runscript\n    exec /opt/openpfc/bin/baked-case \"$@\"\n")
-    library_path = ":".join(["/opt/openpfc/lib", *sorted({str(p.parent) for p in external.values()})])
+    hostlib_dir = "/opt/openpfc/hostlib"
+    library_path = ":".join(["/opt/openpfc/lib",
+                             *([hostlib_dir] if host_files else []),
+                             *sorted({str(p.parent) for p in external.values()})])
     options = []
     for prefix in bindings:
         options += ["--bind", str(prefix) + ":" + str(prefix) + ":ro"]
+    # Site process-manager state; present on the target, not necessarily here.
+    for path in SITE_BINDS[args.site]:
+        options += ["--bind", path + ":" + path]
+    # Individually bound host libraries: their directory also holds ordinary
+    # system libraries, so the whole directory must not be mounted over.
+    for name, path in sorted(host_files.items()):
+        options += ["--bind", str(path) + ":" + hostlib_dir + "/" + name + ":ro"]
     options += ["--env", "LD_LIBRARY_PATH=" + library_path]
     (output / "run-host.sh").write_text(
         "#!/bin/sh\nset -eu\n"
         'bundle_dir=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)\n'
-        "exec apptainer run " + " ".join(shlex.quote(arg) for arg in options) +
+        "exec " + shlex.quote(args.runtime) + " run " +
+        " ".join(shlex.quote(arg) for arg in options) +
         ' "$bundle_dir/case.sif" "$@"\n')
     (output / "run-host.sh").chmod(0o755)
     return output
@@ -168,13 +245,22 @@ def main(argv=None):
     parser.add_argument("--base", required=True, help="local Python runtime SIF")
     parser.add_argument("--output", required=True, help="new bundle directory under builds/")
     parser.add_argument("--host-prefix", action="append", required=True,
-                        help="MPI/PMIx/UCX install prefix to mount read-only; repeat as needed")
+                        help="host MPI stack install prefix to mount read-only; repeat as needed")
+    parser.add_argument("--host-lib", action="append", default=[],
+                        help="single host library file to bind (for stack libraries that "
+                             "share a directory with ordinary system libraries, such as "
+                             "LUMI's /usr/lib64/libcxi.so.1); repeat as needed")
+    parser.add_argument("--site", choices=sorted(MPI_STACK), default="openmpi",
+                        help="host MPI stack: openmpi (Tohtori) or cray (LUMI)")
+    parser.add_argument("--runtime", choices=("apptainer", "singularity"), default="apptainer",
+                        help="container runtime to build with and to call from run-host.sh; "
+                             "LUMI ships singularity-ce, Tohtori ships apptainer")
     parser.add_argument("--prepare-only", action="store_true", help="stage recipe without building SIF")
     args = parser.parse_args(argv)
     try:
         output = prepare(args)
         if not args.prepare_only:
-            subprocess.run(["apptainer", "build", "--disable-cache", "case.sif", "runtime.def"],
+            subprocess.run([args.runtime, "build", "--disable-cache", "case.sif", "runtime.def"],
                            cwd=str(output), check=True)
         print("Runtime bundle: " + str(output))
         return 0

--- a/scripts/tests/test_bake_case.py
+++ b/scripts/tests/test_bake_case.py
@@ -114,3 +114,126 @@ def test_nonportable_case_is_rejected(bundle, settings):
     result = subprocess.run(command, env=env, text=True, capture_output=True)
     assert result.returncode != 0
     assert not output.exists()
+
+
+@pytest.fixture
+def cray_bundle(tmp_path):
+    """A LUMI-shaped case: Cray MPICH naming, and Slingshot libraries sharing a
+    directory with ordinary system libraries."""
+    case = tmp_path / "case"
+    case.mkdir()
+    build = tmp_path / "build"
+    (build / "share/openpfc").mkdir(parents=True)
+    (build / "share/openpfc/version").write_text("0.2.0\n")
+    app = build / "tungsten"
+    app.write_bytes(b"#!/bin/sh\nexit 0\n")
+    app.chmod(0o755)
+    host = tmp_path / "cray-pe"
+    host.mkdir()
+    for name in ("libmpi_gnu_123.so.12", "libfabric.so.1", "libpmi.so.0"):
+        (host / name).write_bytes(b"cray host stack")
+    # /usr/lib64 equivalent: Slingshot and ordinary system libraries together.
+    sysdir = tmp_path / "usr-lib64"
+    sysdir.mkdir()
+    (sysdir / "libcxi.so.1").write_bytes(b"slingshot provider, host only")
+    (sysdir / "libstdc++.so.6").write_bytes(b"ordinary system library, bundle it")
+    physics = tmp_path / "libheffte.so.2"
+    physics.write_bytes(b"packaged physics dependency")
+    libc = tmp_path / "libc.so.6"
+    libc.write_bytes(b"base supplies its own libc")
+    tools = tmp_path / "tools"
+    tools.mkdir()
+    lines = ["libmpi_gnu_123.so.12 => {} (0x1)".format(host / "libmpi_gnu_123.so.12"),
+             "libfabric.so.1 => {} (0x2)".format(host / "libfabric.so.1"),
+             "libpmi.so.0 => {} (0x3)".format(host / "libpmi.so.0"),
+             "libcxi.so.1 => {} (0x4)".format(sysdir / "libcxi.so.1"),
+             "libstdc++.so.6 => {} (0x5)".format(sysdir / "libstdc++.so.6"),
+             "libheffte.so.2 => {} (0x6)".format(physics),
+             "libc.so.6 => {} (0x7)".format(libc)]
+    ldd = tools / "ldd"
+    ldd.write_text("#!/bin/sh\nprintf '%s\\n' " + " ".join(map(shlex.quote, lines)) + "\n")
+    ldd.chmod(0o755)
+    (case / "openpfc.json").write_text(json.dumps({
+        "format_version": 1, "app": "tungsten", "input": "input.json", "profile": "lumi",
+        "executable": str(app), "build_dir": str(build), "source": str(tmp_path),
+    }))
+    (case / "input.json").write_text(json.dumps({
+        "initial_conditions": [{"type": "constant", "n0": -0.4}],
+        "fields": [{"data": "results/psi_%d.vti"}],
+    }))
+    base = tmp_path / "base.sif"
+    base.write_bytes(b"test base identity")
+    output = tmp_path / "bundle"
+    command = [sys.executable, str(SCRIPT), str(case), "--base", str(base),
+               "--output", str(output), "--site", "cray",
+               "--host-prefix", str(host), "--prepare-only"]
+    env = dict(os.environ, PATH=str(tools) + os.pathsep + os.environ["PATH"])
+    return command, env, output, sysdir
+
+
+def test_cray_slingshot_library_is_not_silently_bundled(cray_bundle):
+    """libcxi shares /usr/lib64 with ordinary libraries, so a prefix rule cannot
+    reach it. Baking it would put the interconnect inside the image."""
+    command, env, output, _ = cray_bundle
+    result = subprocess.run(command, env=env, capture_output=True, text=True)
+    assert result.returncode == 2, result.stdout
+    assert "libcxi.so.1" in result.stderr
+    assert "--host-lib" in result.stderr
+    assert not output.exists()
+
+
+def test_cray_host_lib_splits_a_shared_system_directory(cray_bundle):
+    command, env, output, sysdir = cray_bundle
+    command = command + ["--host-lib", str(sysdir / "libcxi.so.1")]
+    result = subprocess.run(command, env=env, capture_output=True, text=True)
+    assert result.returncode == 0, result.stderr
+    payload = output / "payload"
+    # Same directory, opposite sides of the split.
+    assert not (payload / "lib/libcxi.so.1").exists()
+    assert (payload / "lib/libstdc++.so.6").is_file()
+    assert (payload / "lib/libheffte.so.2").is_file()
+    provenance = json.loads((payload / "provenance.json").read_text())
+    assert provenance["site"] == "cray"
+    assert provenance["profile"] == "lumi"
+    assert "libcxi.so.1" in provenance["host_libraries"]
+    assert "libmpi_gnu_123.so.12" in provenance["host_libraries"]
+    assert "libstdc++.so.6" in provenance["bundled_libraries"]
+    # The wrapper binds the single file, never the shared directory.
+    wrapper = (output / "run-host.sh").read_text()
+    assert "libcxi.so.1:/opt/openpfc/hostlib/libcxi.so.1:ro" in wrapper
+    assert str(sysdir) + ":" + str(sysdir) not in wrapper
+    assert "/opt/openpfc/hostlib" in wrapper
+
+
+def test_cray_mpi_naming_counts_as_an_mpi_application(cray_bundle):
+    """Cray names its library libmpi_gnu_123.so.12, not libmpi.so.*."""
+    command, env, output, sysdir = cray_bundle
+    command = command + ["--host-lib", str(sysdir / "libcxi.so.1")]
+    result = subprocess.run(command, env=env, capture_output=True, text=True)
+    assert result.returncode == 0, result.stderr
+    assert "expected a dynamically linked MPI application" not in result.stderr
+
+
+def test_openmpi_site_rejects_a_lumi_profile_case(cray_bundle):
+    command, env, output, sysdir = cray_bundle
+    command = [a for a in command if a not in ("cray",)]
+    command = [a for a in command if a != "--site"]
+    command += ["--host-lib", str(sysdir / "libcxi.so.1")]
+    result = subprocess.run(command, env=env, capture_output=True, text=True)
+    assert result.returncode == 2
+    assert "profile" in result.stderr
+
+
+def test_cray_wrapper_binds_the_slurm_pmi_socket_directory(cray_bundle):
+    """Cray PMI reaches the Slurm daemon through /var/spool/slurmd. Without it
+    MPI_Init fails and every rank believes it is rank 0."""
+    command, env, output, sysdir = cray_bundle
+    command = command + ["--host-lib", str(sysdir / "libcxi.so.1")]
+    assert subprocess.run(command, env=env, capture_output=True, text=True).returncode == 0
+    assert "/var/spool/slurmd:/var/spool/slurmd" in (output / "run-host.sh").read_text()
+
+
+def test_openmpi_wrapper_has_no_cray_site_binds(bundle):
+    command, env, output, _, _ = bundle
+    assert subprocess.run(command, env=env, capture_output=True, text=True).returncode == 0
+    assert "/var/spool/slurmd" not in (output / "run-host.sh").read_text()


### PR DESCRIPTION
Refs #13. Closes its **"host-MPI bind works on at least one target cluster with
more than one node"** acceptance item, and adds the site profile that makes it
reproducible.

## The result first

`small` partition, **4 nodes x 8 ranks = 32 ranks**, tungsten 64³ / 5 steps.
Both runs report `MPICH CH4 OFI netmod using cxi provider (domain_name=cxi0)`,
so this is the **Slingshot RDMA path, not a TCP fallback** — the thing the
existing README explicitly warns not to infer:

| run | `sum` (hex) | `sumsq` (hex) |
|---|---|---|
| native | `-0x1.9e04f59f6c34p+13` | `0x1.04d0a9db35c98p+17` |
| baked bundle | `-0x1.9e04f59f6c34p+13` | `0x1.04d0a9db35c98p+17` |

Bit-identical (job 21830651). An earlier 2-node pair (21830470 / 21830489)
agrees the same way.

## Four things that each broke a naive port

The baker assumed an Open MPI/UCX stack in dedicated prefixes. None of these
were guesses — each one failed a real run first.

1. **`libmpi.so` is not the MPI library.** Cray names it
   `libmpi_gnu_123.so.12`, so the "is this an MPI application" check rejected
   every LUMI binary outright. The MPI-stack classifier is now per site, and
   `libfabric`/`libcxi`/`libpmi`/`libpals`/`libxpmem`/`libdsmml` are refused
   rather than silently bundled — baking those would put the interconnect
   inside the image.

2. **Slingshot libraries share a directory with ordinary ones.**
   `libcxi.so.1` and `libxpmem.so.0` live in `/usr/lib64` next to
   `libstdc++.so.6`. A prefix rule cannot split them and mounting the directory
   would shadow the base image. New `--host-lib` names them individually; the
   wrapper binds each to `/opt/openpfc/hostlib/<soname>` and never mounts the
   shared directory. Keyed on the soname given, not the versioned file it
   resolves to (`libxpmem.so.0` vs `libxpmem.so.0.0.0` — that one cost a
   round trip).

3. **Cray PMI needs `/var/spool/slurmd`.** Without it `MPI_Init` fails with
   `job id unknown` and every rank believes it is rank 0. Verified by toggling
   exactly that one bind. Now a site bind.

4. **LUMI ships `singularity-ce`, not `apptainer`.** New `--runtime`.

## glibc is the trap worth naming

The bind model loads *host* libraries inside the image, so the base's glibc
must be at least as new as theirs. On LUMI that floor is **2.38**:

```console
$ objdump -T /opt/cray/pe/lib64/libmpi_gnu_123.so.12 | grep -o 'GLIBC_[0-9.]*' | sort -V | tail -1
GLIBC_2.38
```

The Debian Bookworm base the README recommends for Tohtori ships **2.36** and
cannot work on LUMI. The failure is an unhelpful symbol error at run time, so
the baker now measures the floor and records it as `host_glibc_requirement`.
Also fixed: `libmvec` is part of glibc and was being bundled against a
different libc.

## What this does not do

- **LUMI cannot build images.** No `/etc/subuid` mapping and no readable
  `proot`, so `singularity build` fails with or without `--fakeroot`. Bake on a
  build host and copy the bundle over — which is the workflow #13 describes
  anyway, but it needed stating.
- Consequently the 32-rank run above bound `payload/` into the base image
  instead of a built `case.sif`. It exercises the generated `run-host.sh` bind
  list, the payload/host split and the entrypoint; SIF packaging itself stays
  covered by the Tohtori path. I flag this rather than claim a full baked-SIF
  run on LUMI.
- Still open on #13: development image, CUDA/HIP profiles, exact build-source
  provenance, and publishing to a registry — so the "download an image" entry
  point still does not exist.

## Tests

`scripts/tests/` **56 passed**, including 6 new baker tests covering the LUMI
shape: the Slingshot library is not silently bundled, `--host-lib` splits a
shared system directory, Cray MPI naming is recognised, the `openmpi` site
rejects a `lumi` profile, and the `cray` wrapper binds the PMI socket
directory while the `openmpi` one does not. They use the existing fake-`ldd`
harness, so they need neither LUMI nor container privileges.

Default behaviour for the existing Tohtori path is unchanged; its 7 tests pass
untouched.

Merge by **rebase**, not squash.
