### PR TITLE
fix(build): load cray-python so LUMI actually runs scripts/tests

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -574,6 +574,10 @@ setup_lumi_env() {
   if [[ -n "${HEFFTE_MODULE}" ]]; then
     module load "${HEFFTE_MODULE}"
   fi
+  # cray-python is the only interpreter on LUMI that satisfies scripts/tests:
+  # /usr/bin/python3 is 3.6, and python3.11/3.12 ship without pytest. Without
+  # it the Python suite silently reports "skipped" on every LUMI build.
+  module load cray-python || true
   export LD_LIBRARY_PATH="${CRAY_LD_LIBRARY_PATH:-}${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}"
   export MPICH_GPU_SUPPORT_ENABLED="${MPICH_GPU_SUPPORT_ENABLED:-1}"
   # FindMPI on Cray PE fails to populate MPI_C_LIB_NAMES unless the PE
@@ -865,8 +869,8 @@ if (( RUN_TESTS )); then
   FAILED_PHASE="tests"
   if [[ -d "${REPO_ROOT}/scripts/tests" ]]; then
     # check_doc_links.py needs Python 3.8+ (from __future__ import annotations).
-    # LUMI compute nodes often have /usr/bin/python3 = 3.6 plus a newer
-    # python3.11 without pytest — skip rather than fail a GPU job for that.
+    # setup_lumi_env loads cray-python so LUMI has one; a host that still lacks
+    # pytest is skipped rather than failing a GPU job for it.
     PYTEST_PYTHON=""
     for cand in ${PYTHON:-} python3.12 python3.11 python3; do
       [[ -n "${cand}" ]] || continue


### PR DESCRIPTION
Every LUMI build has been reporting `Python tests: skipped`, so a green LUMI build was never evidence the Python suite passed. The cause is only that `setup_lumi_env` does not load `cray-python`:

- `/usr/bin/python3` is **3.6** — too old for `scripts/bake_case.py` (`subprocess(text=)`) and below the 3.8 floor `check_doc_links.py` needs.
- `python3.11` and `python3.12` exist on PATH but **without pytest**.
- `cray-python` provides **3.11.7 with pytest 8.2.2**.

One `module load`, tolerant of a host that lacks the module. The existing interpreter search is unchanged, so a host with no usable pytest still skips rather than failing a GPU job.

## Verified on LUMI

Before: `Python tests:  skipped (need Python>=3.8 with pytest)`
After: `Python tests:  passed (python3.11)` — 50 passed.

`ctest` is **48/48** inside an allocation. On a login node nine tests fail with `srun: Unable to allocate resources: No partition specified`, which is the usual environmental artifact and unrelated to this change.

Two things this does **not** claim:

- `cahn-hilliard-diagnostics-workflow` is not registered in the configuration I tested (`--no-mpi-tests`), so 48/48 does not mean its known `/tmp`-is-node-local failure is fixed. It is not.
- The `openpfc-cli-*` tests were already being registered before this change — CMake only needs an interpreter, not pytest, and found `python3.11` on its own. This change affects the pytest suite only.

Merge by **rebase**, not squash.