### PR TITLE
feat(ehd_film): nonlinear compliant lubrication with load and adhesion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,27 @@ SPDX-License-Identifier: AGPL-3.0-or-later
   `apps/common/include/openpfc_apps/structure_factor.hpp` now that a second
   application needs it.
 
+- EHD film science upgrade (`#116`): nonlinear compliant lubrication under a
+  flexible plate, `apps/ehd_film/src/ehd_film_nonlinear.cpp`, reusing the
+  shared conservative flux stepper introduced for the `thin_film` science
+  upgrade (`#114`, `apps/common/include/openpfc_apps/spectral_flux.hpp`). The
+  cubic mobility `M(h)=M0(h/h0)^3` replaces the constant-mobility linear
+  model in a full lubrication coupling `p = B∇⁴h - γ∇²h - Π(h) + p_ext(x,y,t)`,
+  with a localized Gaussian load applied and then removed so a run shows
+  loading followed by recovery/redistribution. The existing exact `k^6`
+  pure-bending decay stays the CI verifier, and the nonlinear flux solver is
+  asserted (not assumed) to reproduce it exactly at constant mobility. Two
+  256² science presets (`load_relaxation_stiff.json`,
+  `load_relaxation_compliant.json`, `B=640` vs `B=100` at fixed tension)
+  measure central deflection, pressure extrema, RMS spreading radius and
+  displaced volume vs time, and confirm total volume conservation to
+  round-off (`~7-8e-15` relative) under the nonlinear mobility, tension and
+  the time-dependent load. `EhdFilmPointwise` gained the `h_star`
+  adhesion-safe precursor disjoining form ported from `thin_film` (`#114`).
+  Host (CPU) only; the flux path has no HIP kernels yet, so the existing
+  constant-mobility `ehd_film_hip` binary is unchanged. The adhesive/unstable
+  film comparison (issue's case C) is deferred, along with energy
+  diagnostics and time-periodic loading.
 
 - Fe–Cr Cahn–Hilliard science upgrade (`#113`): Redlich–Kister excess free
   energy with the assessed bcc Cr–Fe interaction, a code-to-physical scale map

--- a/apps/ehd_film/CMakeLists.txt
+++ b/apps/ehd_film/CMakeLists.txt
@@ -37,6 +37,12 @@ endfunction()
 ehd_film_cpu_executable(ehd_film src/ehd_film.cpp)
 install(TARGETS ehd_film DESTINATION bin)
 
+# Science driver for #116: full nonlinear h^3 mobility, localized load and
+# adhesion through the shared conservative flux stepper. Host only; the flux
+# path has no device kernels (see apps/common/include/openpfc_apps/spectral_flux.hpp).
+ehd_film_cpu_executable(ehd_film_nonlinear src/ehd_film_nonlinear.cpp)
+install(TARGETS ehd_film_nonlinear DESTINATION bin)
+
 if(OpenPFC_ENABLE_HIP AND OpenPFC_HIP_AVAILABLE AND OpenPFC_ENABLE_HIP_SPECTRAL)
   ehd_film_hip_executable(ehd_film_hip src/hip/ehd_film.cpp)
   install(TARGETS ehd_film_hip DESTINATION bin)

--- a/apps/ehd_film/README.md
+++ b/apps/ehd_film/README.md
@@ -5,44 +5,136 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 
 # EHD film (`apps/ehd_film`)
 
-Elastohydrodynamic **thin film under a flexible plate**. This is the 0.2
-application for GitHub issue `#81`.
+Elastohydrodynamic **thin film under a flexible plate**. The linear
+constant-mobility model is the 0.2 application for GitHub issue `#81`; the
+nonlinear compliant-lubrication model below with a localized load and
+adhesion is the science upgrade for `#116`.
 
-Binaries: `ehd_film` (CPU); `ehd_film_hip` when `OpenPFC_ENABLE_HIP_SPECTRAL`
-is on.
+Binaries: `ehd_film` (CPU, linear verifier/demo), `ehd_film_nonlinear` (CPU,
+nonlinear science driver), `ehd_film_hip` when `OpenPFC_ENABLE_HIP_SPECTRAL`
+is on (linear model only — see "Nonlinear model" below for why).
 
-## Physics
+## Problem setup: localized load on a compliant lubricated plate
 
-A viscous gap \(h\) supports a Kirchhoff plate. Bending pressure, lubrication
-flow, and mass conservation give a sixth-order evolution:
+The `Problem setup` block the report contract (`#112`) asks every
+application to carry, for the `ehd_film_nonlinear` **science preset**
+(`inputs_json/load_relaxation_stiff.json` /
+`load_relaxation_compliant.json`). The compact single-mode `ehd_film`
+**verification preset** is described separately below.
 
-1. Plate curvature \(\kappa\sim\nabla^2 h\) stores bending energy
-   \(\tfrac12 B(\nabla^2 h)^2\).
-2. The variational pressure is \(p=B\nabla^4 h\) (plus optional tension
-   and disjoining).
-3. The pressure gradient drives a viscous flux \(M_0\nabla p\).
-4. Mass conservation \(\partial_t h=\nabla\cdot[M_0\nabla p]\) produces
-   \(\nabla^6\).
+| Item | Description |
+|---|---|
+| **Use case** | A viscous film squeezed between a substrate and a flexible plate (e.g. a compliant coating, a soft lubrication bearing, or a stamped/rolled film) receives a localized press, then the load lifts off and the film redistributes |
+| **Question** | How much does the gap thin under a localized load, how far does the disturbance spread, and how does that depend on the plate's bending stiffness? |
+| **Domain** | 2-D periodic patch, 256² cells, `dx = 1` (code length units) |
+| **Boundary conditions** | Periodic on both axes — see "Why periodic" below |
+| **Initial condition** | `h(x,y,0) = h0` (uniform gap); the disturbance comes entirely from the applied load, not the IC |
+| **Key parameters** | `h0=1`, `M0=1`, `gamma=10`, `A=0` (adhesion off in the science preset — see "Deferred" below); load `p0=0.5`, `a=8`, `t_load=60`; two bending stiffnesses `B=640` (stiff) and `B=100` (compliant) |
+| **Observable** | Central gap `h_center(t)` / deflection, pressure extrema, RMS spreading radius, displaced volume, total volume (conservation check) — all in the diagnostics CSV |
+| **Model maturity** | numerical verification: **analytical** (the `#81` linear \(k^6\) mode decay is an exact closed-form check that the nonlinear flux solver must reproduce at constant mobility, see Tests) · physical completeness: **reduced** (2-D lubrication + Kirchhoff bending + tension + optional adhesion; no plate inertia, no cavitation, no contact) · calibration: **none** — `B`, `gamma`, `M0`, the load shape and its amplitude are illustrative nondimensional grid-unit parameters, not fit to a material |
+
+### Why periodic
+
+A periodic patch represents a small window of a much larger plate/film far
+from any physical edge or support — the right idealisation for asking how a
+*local* disturbance decays and spreads, as opposed to how the plate responds
+globally to its actual boundary conditions (clamped edge, simply supported
+edge, etc.), which this app does not model.
+
+### Domain-adequacy check
+
+The patch must stay large compared with the disturbance over the reported
+interval, or the periodic images interact and the "spreading" measurement
+is really measuring the box size. Checked directly, not assumed: the
+domain half-width is `128` grid units; the RMS spreading radius (see
+`ehd_film::sample_ehd_film`) measured over the full `t in [0, 600]` run
+peaks at `27.4` (stiff plate) and `23.1` (compliant plate) — under 22% of
+the half-width in both cases.
+
+## Nonlinear model (`#116`)
 
 \[
-p=B\nabla^4 h-\gamma\nabla^2 h-\Pi(h),\qquad
-\partial_t h=\nabla\cdot\bigl[M_0\nabla p\bigr].
-\]
-
-With OpenPFC \(k_{\mathrm{lap}}=-|k|^2\),
-
-\[
-L(k)=M_0 B\,k_{\mathrm{lap}}^3-M_0\gamma\,k_{\mathrm{lap}}^2
-     -M_0\Pi'(h_0)\,k_{\mathrm{lap}},
+p = B\nabla^4h - \gamma\nabla^2h - \Pi(h) + p_{\mathrm{ext}}(x,y,t),
 \qquad
-\lambda(k)=-M_0 B k^6-M_0\gamma k^4+M_0\Pi'(h_0)k^2.
+\partial_t h = \nabla\cdot\bigl[M(h)\nabla p\bigr],
+\qquad
+M(h) = M_0\left(\frac{h}{h_0}\right)^{3}.
 \]
 
-Defaults \(A=\gamma=0\) are pure bending relaxation:
-\(h_k(t)=h_k(0)\exp(-M_0 B k^6 t)\). An explicit step on spacing
-\(\Delta x\) would need \(\Delta t\lesssim\Delta x^6/(M_0 B\pi^6)\);
-ETD treats \(k^6\) as a multiply. Optional \(A>0\) is van der Waals
-versus bending (a finite unstable band).
+`M(h)` is the cubic no-slip lubrication mobility (same law and
+normalisation as `thin_film`'s `#114` upgrade): exact at `h=h0`, so setting
+`A=gamma=0` and starting from a small perturbation must reproduce the exact
+\(k^6\) bending-relaxation verifier below — asserted in `test_ehd_film.cpp`,
+not assumed. `p_ext` is a localized applied load,
+
+\[
+p_{\mathrm{ext}}(x,y,t) =
+  \begin{cases}
+    p_0\exp(-r^2/2a^2) & 0\le t<t_{\mathrm{load}}\\
+    0 & t\ge t_{\mathrm{load}}
+  \end{cases}
+\]
+
+applied and then removed, so a run shows loading followed by
+recovery/redistribution. `Pi(h)` is the same disjoining pressure as
+`ehd_film`'s linear model, now with an optional `h_star` precursor form
+(ported from `thin_film`) so a plate held down by adhesion settles on a
+stable thin gap instead of the pressure diverging as `h -> 0`.
+
+### Sign conventions
+
+* `p` follows the existing linear model: flux down the pressure gradient,
+  so with OpenPFC's \(k_{\mathrm{lap}}=-|k|^2\) pure bending decays,
+  \(\lambda(k)=-M_0Bk^6<0\) (the verifier).
+* `p_ext > 0` is **a load pressing the plate down onto the film** (increased
+  applied pressure). A localized positive `p_ext` has
+  \(\nabla^2p_{\mathrm{ext}}<0\) at its centre, so
+  \(\partial_th=\nabla\cdot[M\nabla p]\approx M\nabla^2p_{\mathrm{ext}}<0\)
+  there: the gap thins under the load and thickens in the surrounding
+  annulus where the fluid is displaced to (squeeze flow). Asserted directly
+  in `test_ehd_film.cpp` ("localized load thins the gap...").
+* Adhesion enters with the same sign as bending and tension: `-Pi(h)` in
+  `p`. `A>0` is attractive at `h0`.
+
+### Numerics: why CPU only
+
+The nonlinear flux \(\nabla\cdot[M(h)\nabla p]\) is evaluated with the
+shared `pfc::apps::FluxETD` stepper
+(`apps/common/include/openpfc_apps/spectral_flux.hpp`, introduced for
+`#114`): a state-dependent mobility cannot be written as a reciprocal-space
+symbol, so it is applied in real space every step with Orszag 2/3
+dealiasing on the flux transform. That path is host (CPU) only — the
+device `Ops` layer has no complex-\(ik_d\) gradient kernels yet. The
+existing constant-mobility `ehd_film_hip` binary is untouched; the
+nonlinear science driver has no GPU twin.
+
+## Measured results
+
+`load_relaxation_stiff.json` (`B=640`) and `load_relaxation_compliant.json`
+(`B=100`), both `256²`, `gamma=10`, `A=0`, load `p0=0.5, a=8, t_load=60`,
+run to `t1=600` on 4 ranks (LUMI CPU, shared allocation):
+
+| Quantity | Stiff (`B=640`) | Compliant (`B=100`) |
+|---|---|---|
+| Deflection at end of loading (`t=60`) | `0.2525` | `0.3414` (35% more) |
+| Spreading radius at end of loading | `14.15` | `12.30` (more localized) |
+| Displaced volume at end of loading | `106.18` | `110.56` |
+| Deflection at `t=600` (540 after load-off) | `0.0409` (83.8% recovered) | `0.0608` (82.2% recovered) |
+| Spreading radius at `t=600` | `27.41` | `23.08` |
+| Volume relative drift, whole run (max over all reported steps) | `7.0e-15` | `8.0e-15` |
+
+The bending–tension crossover length \(\ell^*=\sqrt{B/\gamma}\) is `8.0`
+for the stiff case (equal to the load width `a`) and `3.16` for the
+compliant case (well below it), which is why `B` visibly changes the peak
+deflection and how far the load spreads while the two cases still recover
+at a similar *rate* — that rate is set mainly by `gamma`, not `B`, at this
+load width. **The physically interpretable trend requested by `#116`:** the
+stiffer plate deflects less and spreads the same load over a wider area;
+the more compliant plate deflects more and keeps the disturbance more
+localized — the classical plate-on-viscous-foundation picture. Both cases
+conserve total fluid volume to round-off, confirming the divergence-form
+flux is exact regardless of the nonlinear mobility, tension, or the
+time-dependent load.
 
 ## Run
 
@@ -50,28 +142,70 @@ versus bending (a finite unstable band).
 mkdir -p results/ehd_film
 mpirun -n 1 ./apps/ehd_film/ehd_film \
   ../apps/ehd_film/inputs_json/relaxation.json
+
+mkdir -p results/ehd_film_nonlinear
+mpirun -n 4 ./apps/ehd_film/ehd_film_nonlinear \
+  ../apps/ehd_film/inputs_json/load_relaxation_stiff.json
+mpirun -n 4 ./apps/ehd_film/ehd_film_nonlinear \
+  ../apps/ehd_film/inputs_json/load_relaxation_compliant.json
 ```
 
-The shipped input is a 128² corrugation under a stiff plate. VTK of `h`
-goes to `results/ehd_film/`. Short waves flatten first (\(k^6\)).
-
-JSON `model.params`: `h0`, `B`, `M0`, `gamma`, `A`. Initial condition
+`ehd_film` (verifier/demo): the shipped input is a 128² corrugation under a
+stiff plate; VTK of `h` goes to `results/ehd_film/`. JSON `model.params`:
+`h0`, `B`, `M0`, `gamma`, `A`, `h_star`. Initial condition
 `"type": "cosine_mode"` with `h0` / `amplitude` / `nx` / `ny` / `nz`.
+
+`ehd_film_nonlinear` (science driver): JSON `model.params` as above, plus
+`load.p0` / `load.a` / `load.t_load` (Gaussian load, centred, see above)
+and `diagnostics.csv` (one row per `saveat` with `time`, `h_center`,
+`deflection_center`, `p_max`, `p_min`, `spreading_radius`,
+`displaced_volume`, `volume`, `volume_rel_drift`).
 
 ## Tests
 
-`ctest -R ehd-film` checks \(L(k)=M_0 B k_{\mathrm{lap}}^3\), exact
-\(\exp(-M_0 B k^6 t)\), two-mode rate ratio 64, mean-gap conservation,
-and that \(A>0\) grows at low \(k\). HIP builds add `HIP_EhdFilmETD` and
-`ehd-film-hip-smoke`. LUMI-G smoke: job 21799835 (`small-g`, 16²,
-mean \(h=1\)).
+`ctest -R ehd-film` (single binary `test_ehd_film`) checks, for the linear
+model: \(L(k)=M_0 B k_{\mathrm{lap}}^3\), exact \(\exp(-M_0 B k^6 t)\),
+two-mode rate ratio 64, mean-gap conservation, and that \(A>0\) grows at
+low \(k\); and for the nonlinear model (`#116`): the cubic mobility reduces
+to `M0` at `h0`; the flux stepper reproduces the exact \(k^6\) decay at
+constant mobility (the point of keeping the linear verifier); volume
+conservation under bending + tension + adhesion together; the load's sign
+convention (thins the gap centre, conserves volume); and the load's
+on/off gating at `t_load`. HIP builds add `HIP_EhdFilmETD` and
+`ehd-film-hip-smoke` (linear model only). LUMI-G smoke: job 21799835
+(`small-g`, 16², mean \(h=1\)).
+
+## Deferred (not in this PR)
+
+Per `#116`'s stretch goals and the parts of its acceptance criteria this
+PR does not attempt:
+
+* **Case C (adhesive/unstable film under a compliant plate)** — comparing a
+  rigid/very-stiff and a compliant plate under a disjoining-pressure
+  instability. `A>0` and the `h_star` precursor form are implemented and
+  unit-tested (see Tests), but no dynamic science run drives the adhesive
+  instability to a measured rupture time or wavelength; the base branch's
+  experience with the `(9,3)` precursor power pair (stiff, easy to NaN once
+  `h` approaches `h_star`) made this a separate, riskier piece of work than
+  the load/relaxation case.
+* **Energy diagnostics** (bending/capillary/wetting contributions) — not
+  in this PR's measured CSV; only the mass/volume balance is reported.
+* **Time-periodic loading / frequency response** and **anisotropic plate
+  bending** — issue-listed stretch goals, not implemented.
+* **CPU/HIP agreement for the nonlinear model** — moot for now since the
+  nonlinear flux path has no HIP kernels (see "Numerics" above); the
+  existing CPU/HIP agreement is for the unchanged linear model only.
 
 ## Layout
 
 | Path | Role |
 |------|------|
-| `include/ehd_film/ehd_film_physics.hpp` | \(L(k)\) with \(k_{\mathrm{lap}}^3\) |
-| `include/ehd_film/ehd_film_pointwise.hpp` | \(\Pi\) remainder |
-| `include/ehd_film/ehd_film_session.hpp` | JSON session, field `h`, 2/3 dealias |
-| `src/ehd_film.cpp` / `src/hip/` | CPU / HIP `main` |
-| `inputs_json/relaxation.json` | Bending-driven leveling |
+| `include/ehd_film/ehd_film_physics.hpp` | Linear model: `L(k)` with \(k_{\mathrm{lap}}^3\), `h_star` schema |
+| `include/ehd_film/ehd_film_pointwise.hpp` | \(\Pi\) remainder, device-capable, now with the `h_star` precursor form |
+| `include/ehd_film/ehd_film_session.hpp` | JSON session, field `h`, 2/3 dealias (linear model) |
+| `include/ehd_film/nonlinear.hpp` | `#116`: cubic mobility, Gaussian load, `EhdFilmSample` diagnostics |
+| `src/ehd_film.cpp` / `src/hip/` | CPU / HIP `main` (linear model) |
+| `src/ehd_film_nonlinear.cpp` | CPU `main`, nonlinear science driver (`#116`) |
+| `inputs_json/relaxation.json` | Linear verifier/demo: bending-driven leveling |
+| `inputs_json/load_relaxation_stiff.json` | Nonlinear science preset, `B=640` |
+| `inputs_json/load_relaxation_compliant.json` | Nonlinear science preset, `B=100` |

--- a/apps/ehd_film/include/ehd_film/ehd_film_physics.hpp
+++ b/apps/ehd_film/include/ehd_film/ehd_film_physics.hpp
@@ -52,6 +52,7 @@ struct EhdFilmSchemaValues {
   double M0{1.0};    ///< mobility at h0
   double gamma{0.0}; ///< tension (0 = bending only)
   double A{0.0};     ///< disjoining strength (0 = no van der Waals)
+  double h_star{0.0};///< precursor thickness; >0 selects the adhesion-safe form
 };
 
 struct EhdFilmParams : EhdFilmSchemaValues {
@@ -61,7 +62,7 @@ struct EhdFilmParams : EhdFilmSchemaValues {
   EhdFilmParams() { recompute_derived(); }
 
   void recompute_derived() {
-    EhdFilmPointwise pw{.A = A, .h0 = h0};
+    EhdFilmPointwise pw{.A = A, .h0 = h0, .h_star = h_star};
     Pi0 = pw.Pi(h0);
     Pip0 = pw.Pi_prime(h0);
   }
@@ -100,6 +101,13 @@ inline pfc::sim::ParameterSchema<EhdFilmSchemaValues> make_ehd_film_schema() {
       .real(&EhdFilmSchemaValues::A,
             {.name = "A",
              .description = "disjoining strength; 0 is no van der Waals",
+             .required = false,
+             .min = 0.0,
+             .default_value = 0.0})
+      .real(&EhdFilmSchemaValues::h_star,
+            {.name = "h_star",
+             .description = "precursor thickness; >0 uses the adhesion-safe "
+                            "disjoining pressure with a stable thin gap",
              .required = false,
              .min = 0.0,
              .default_value = 0.0});
@@ -152,7 +160,8 @@ struct EhdFilmPhysics {
   }
 
   [[nodiscard]] EhdFilmPointwise pointwise() const {
-    return {.A = params.A, .h0 = params.h0, .Pi0 = params.Pi0, .Pip0 = params.Pip0};
+    return {.A = params.A, .h0 = params.h0, .h_star = params.h_star,
+            .Pi0 = params.Pi0, .Pip0 = params.Pip0};
   }
 
   /// Fastest-growing \(k^2\), or 0 when every mode decays.

--- a/apps/ehd_film/include/ehd_film/ehd_film_pointwise.hpp
+++ b/apps/ehd_film/include/ehd_film/ehd_film_pointwise.hpp
@@ -9,6 +9,16 @@
  *
  * \(n=\Pi(h)-\Pi(h_0)-\Pi'(h_0)(h-h_0)\). Same van der Waals plus repulsion
  * as the lubrication app; copied rather than shared.
+ *
+ * `h_star` adds the same rupture/adhesion-safe switch `thin_film` uses
+ * (`#114`): zero keeps the original two-term potential
+ * \(\Pi=A\bigl((h_0/h)^3-(h_0/h)^9\bigr)\), destabilizing at \(h_0\) but
+ * with no stable state as \(h\to0\); a positive value switches to the
+ * precursor form \(\Pi=A\bigl[(h_{\mathrm{star}} / h)^9
+ * -(h_{\mathrm{star}} / h)^3\bigr]\), repulsive below \(h_{\mathrm{star}}\)
+ * and attractive above it, so a plate pinned down by adhesion and load
+ * settles on a stable precursor gap instead of the pressure diverging.
+ * Default is `0`, so the existing `#81` linear verifier is unchanged.
  */
 
 #include <cmath>
@@ -21,6 +31,7 @@ namespace ehd_film {
 struct EhdFilmPointwise {
   double A{0.0};
   double h0{1.0};
+  double h_star{0.0};
   double Pi0{0.0};
   double Pip0{0.0};
 
@@ -31,6 +42,11 @@ struct EhdFilmPointwise {
   }
 
   [[nodiscard]] OPENPFC_HD double Pi(double h) const {
+    if (h_star > 0.0) {
+      const double v = h_star / clamp_h(h);
+      const double v3 = v * v * v;
+      return A * (v3 * v3 * v3 - v3);
+    }
     const double u = clamp_h(h) / h0;
     const double u3 = u * u * u;
     const double u9 = u3 * u3 * u3;
@@ -39,6 +55,11 @@ struct EhdFilmPointwise {
 
   [[nodiscard]] OPENPFC_HD double Pi_prime(double h) const {
     const double hh = clamp_h(h);
+    if (h_star > 0.0) {
+      const double v = h_star / hh;
+      const double v3 = v * v * v;
+      return A * (-9.0 * v3 * v3 * v3 + 3.0 * v3) / hh;
+    }
     const double u = hh / h0;
     const double u4 = u * u * u * u;
     const double u10 = u4 * u4 * u * u;

--- a/apps/ehd_film/include/ehd_film/nonlinear.hpp
+++ b/apps/ehd_film/include/ehd_film/nonlinear.hpp
@@ -1,0 +1,210 @@
+// SPDX-FileCopyrightText: 2026 VTT Technical Research Centre of Finland Ltd
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+#pragma once
+
+/**
+ * @file nonlinear.hpp
+ * @brief Nonlinear compliant lubrication: \f$h^3\f$ mobility, load, adhesion (`#116`).
+ *
+ * @details
+ * The shipped `ehd_film` preset freezes the hydrodynamic mobility at
+ * \f$M_0=M(h_0)\f$: exact for the linear \f$k^6\f$ bending-relaxation band,
+ * but not an elastohydrodynamic lubrication problem. This header adds the
+ * pieces the science case in `#116` needs on top of it:
+ *
+ * \f[
+ *   p = B\nabla^4h - \gamma\nabla^2h - \Pi(h) + p_{\mathrm{ext}}(x,y,t),
+ *   \qquad
+ *   \partial_t h = \nabla\cdot\bigl[M(h)\nabla p\bigr],
+ *   \qquad
+ *   M(h) = M_0\left(\frac{h}{h_0}\right)^{3}.
+ * \f]
+ *
+ * ## Sign conventions
+ *
+ * * `p` follows `ehd_film_physics.hpp`: \f$p=B\nabla^4h-\gamma\nabla^2h
+ *   -\Pi(h)\f$, flux down the pressure gradient
+ *   (\f$\partial_t h=\nabla\cdot[M\nabla p]\f$). With OpenPFC's
+ *   \f$k_{\mathrm{lap}}=-|k|^2\f$ this gives pure-bending decay
+ *   \f$\lambda(k)=-M_0Bk^6<0\f$ — the existing verifier.
+ * * \f$M(h)=M_0(h/h_0)^3\f$ is written in units of \f$M_0\f$, so it reduces
+ *   to the constant-mobility linear model at \f$h=h_0\f$; in dimensional
+ *   lubrication terms \f$M=h^3/(3\eta)\f$, \f$M_0=h_0^3/(3\eta)\f$ (same
+ *   normalisation as `thin_film::CubicMobility`).
+ * * \f$p_{\mathrm{ext}}>0\f$ is a **load pushing the plate down onto the
+ *   film** (a positive applied pressure). A localized positive
+ *   \f$p_{\mathrm{ext}}\f$ has \f$\nabla^2p_{\mathrm{ext}}<0\f$ at its
+ *   centre, so \f$\partial_th=\nabla\cdot[M\nabla p]\approx M\nabla^2
+ *   p_{\mathrm{ext}}<0\f$ there: the gap thins under the load and thickens
+ *   in the surrounding annulus where fluid is displaced to — squeeze flow,
+ *   not suction. This sign is asserted directly in
+ *   `test_ehd_film.cpp` ("p_ext enters..."), not merely assumed.
+ * * Adhesion is the same disjoining pressure as `thin_film`/`ehd_film`:
+ *   \f$\Pi(h)=A[(h_0/h)^3-(h_0/h)^9]\f$ (or the `h_star` precursor form,
+ *   see `ehd_film_pointwise.hpp`). \f$A>0\f$ is attractive van der Waals at
+ *   \f$h_0\f$; \f$-\Pi(h)\f$ enters `p` with the same sign as bending and
+ *   tension.
+ *
+ * ## Numerics
+ *
+ * The flux is evaluated with `pfc::apps::FluxETD`
+ * (`openpfc_apps/spectral_flux.hpp`): state-dependent \f$M\f$ cannot be
+ * written as a reciprocal-space symbol, so it is applied in real space every
+ * step with Orszag 2/3 dealiasing on the flux transform. Host (CPU) only —
+ * see that header for why. The existing constant-mobility `ehd_film_hip`
+ * binary is untouched; the nonlinear science preset has no GPU twin.
+ */
+
+#include <algorithm>
+#include <cmath>
+#include <cstddef>
+#include <limits>
+
+#include <mpi.h>
+
+#include <openpfc/kernel/data/domain.hpp>
+#include <openpfc/kernel/data/grid_field.hpp>
+
+#include <ehd_film/ehd_film_pointwise.hpp>
+
+namespace ehd_film {
+
+/// Cubic lubrication mobility, normalised so that \f$M(h_0)=M_0\f$. Same law
+/// as `thin_film::CubicMobility`; copied rather than shared (app convention).
+struct CubicMobility {
+  double M0{1.0};
+  double h0{1.0};
+  /// A plate pinned to near-zero gap must not give M <= 0.
+  static constexpr double kMinH = 1.0e-6;
+
+  [[nodiscard]] double operator()(double h) const {
+    const double u = std::max(h, kMinH) / h0;
+    return M0 * u * u * u;
+  }
+};
+
+/**
+ * @brief Localized external load, applied and then removed.
+ *
+ * \f[
+ *   p_{\mathrm{ext}}(x,y,t) =
+ *     \begin{cases}
+ *       p_0\exp\!\bigl(-r^2/2a^2\bigr) & 0\le t<t_{\mathrm{load}} \\
+ *       0 & t\ge t_{\mathrm{load}}
+ *     \end{cases}
+ * \f]
+ *
+ * models a stamp or roller pressing the plate onto the film for a finite
+ * dwell time, then lifting off so the run shows loading followed by
+ * recovery/redistribution (`#116`, computational experiment B).
+ */
+struct GaussianLoad {
+  double p0{0.0};      ///< peak applied pressure
+  double a{1.0};       ///< Gaussian width (code length units)
+  double t_load{0.0};  ///< dwell time; load is on for t in [0, t_load)
+  double cx{0.0}, cy{0.0};
+
+  [[nodiscard]] double operator()(double x, double y, double t) const {
+    if (p0 == 0.0 || !(t < t_load)) return 0.0;
+    const double dx = x - cx, dy = y - cy;
+    const double r2 = dx * dx + dy * dy;
+    return p0 * std::exp(-r2 / (2.0 * a * a));
+  }
+
+  /// Centre the load in @p domain.
+  static GaussianLoad centred(const pfc::Domain &domain, double p0, double a,
+                              double t_load) {
+    const auto size = pfc::domain::get_size(domain);
+    const auto dx = pfc::domain::get_spacing(domain);
+    return GaussianLoad{p0, a, t_load, 0.5 * size[0] * dx[0],
+                        0.5 * size[1] * dx[1]};
+  }
+};
+
+/// Observables a compliant-lubrication load/relaxation experiment reports.
+struct EhdFilmSample {
+  double h_center{};        ///< thickness at the domain centre
+  double p_max{}, p_min{};  ///< pressure extrema
+  double spreading_radius{};///< RMS radius of the disturbance about centre
+  double displaced_volume{};///< volume squeezed out from under the load
+  double volume{};          ///< total fluid volume (conservation check)
+};
+
+/**
+ * @brief Collective EHD-film observables at the domain centre and overall.
+ *
+ * @param h      thickness field
+ * @param p      pressure field, evaluated at the same instant as @p h
+ * @param domain grid geometry
+ * @param h0     reference (unloaded) thickness
+ * @param comm   communicator to reduce over
+ *
+ * `h_center` is read at the grid point nearest the domain centre — exact
+ * when the grid size is even, so each science/verifier case uses an even
+ * `Lx`, `Ly`. `spreading_radius` is the \f$(h-h_0)^2\f$-weighted RMS radius
+ * of the disturbance, the natural second-moment analogue of a spreading
+ * length for a localized depression/bump. `displaced_volume` is
+ * \f$\int\max(0,h_0-h)\,\mathrm dA\f$, the volume squeezed out from under
+ * the load; by exact volume conservation it must equal the volume gained in
+ * the surrounding annulus, up to the reported round-off drift in `volume`.
+ */
+[[nodiscard]] inline EhdFilmSample
+sample_ehd_film(pfc::data::Field<double> &h, pfc::data::Field<double> &p,
+                const pfc::Domain &domain, double h0, MPI_Comm comm) {
+  const auto size = pfc::domain::get_size(domain);
+  const auto dx = pfc::domain::get_spacing(domain);
+  const double cx = 0.5 * static_cast<double>(size[0]) * dx[0];
+  const double cy = 0.5 * static_cast<double>(size[1]) * dx[1];
+  const double cell = dx[0] * dx[1] * dx[2];
+
+  double local_h_center = 0.0;
+  double local_pmax = -std::numeric_limits<double>::infinity();
+  double local_pmin = std::numeric_limits<double>::infinity();
+  double local_num = 0.0, local_den = 0.0; // spreading-radius second moment
+  double local_displaced = 0.0;
+  double local_volume = 0.0;
+
+  const auto n = h.local_size();
+  for (int k = 0; k < n[2]; ++k) {
+    for (int j = 0; j < n[1]; ++j) {
+      for (int i = 0; i < n[0]; ++i) {
+        const auto x = h.coords(i, j, k);
+        const double hv = h(i, j, k);
+        const double pv = p(i, j, k);
+        local_volume += hv * cell;
+        local_displaced += std::max(0.0, h0 - hv) * cell;
+        local_pmax = std::max(local_pmax, pv);
+        local_pmin = std::min(local_pmin, pv);
+        const double dev = hv - h0;
+        const double w = dev * dev;
+        const double rdx = x[0] - cx, rdy = x[1] - cy;
+        local_num += w * (rdx * rdx + rdy * rdy);
+        local_den += w;
+        if (std::abs(x[0] - cx) <= 0.5 * dx[0] + 1.0e-9 &&
+            std::abs(x[1] - cy) <= 0.5 * dx[1] + 1.0e-9) {
+          local_h_center = hv; // exactly one grid point qualifies globally
+        }
+      }
+    }
+  }
+
+  double g_hcenter = 0.0, g_pmax = 0.0, g_pmin = 0.0;
+  double lsum[4]{local_num, local_den, local_displaced, local_volume};
+  double gsum[4]{};
+  MPI_Allreduce(&local_h_center, &g_hcenter, 1, MPI_DOUBLE, MPI_SUM, comm);
+  MPI_Allreduce(&local_pmax, &g_pmax, 1, MPI_DOUBLE, MPI_MAX, comm);
+  MPI_Allreduce(&local_pmin, &g_pmin, 1, MPI_DOUBLE, MPI_MIN, comm);
+  MPI_Allreduce(lsum, gsum, 4, MPI_DOUBLE, MPI_SUM, comm);
+
+  EhdFilmSample s;
+  s.h_center = g_hcenter;
+  s.p_max = g_pmax;
+  s.p_min = g_pmin;
+  s.spreading_radius = (gsum[1] > 0.0) ? std::sqrt(gsum[0] / gsum[1]) : 0.0;
+  s.displaced_volume = gsum[2];
+  s.volume = gsum[3];
+  return s;
+}
+
+} // namespace ehd_film

--- a/apps/ehd_film/inputs_json/load_relaxation_compliant.json
+++ b/apps/ehd_film/inputs_json/load_relaxation_compliant.json
@@ -1,0 +1,31 @@
+{
+    "model": {
+        "name": "ehd_film",
+        "params": {
+            "h0": 1.0,
+            "B": 100.0,
+            "M0": 1.0,
+            "gamma": 10.0,
+            "A": 0.0
+        }
+    },
+    "domain": {
+        "Lx": 256,
+        "Ly": 256,
+        "Lz": 1,
+        "dx": 1.0
+    },
+    "timestepping": {
+        "t1": 600.0,
+        "dt": 0.5,
+        "saveat": 10.0
+    },
+    "load": {
+        "p0": 0.5,
+        "a": 8.0,
+        "t_load": 60.0
+    },
+    "diagnostics": {
+        "csv": "results/ehd_film_nonlinear/load_relaxation_compliant.csv"
+    }
+}

--- a/apps/ehd_film/inputs_json/load_relaxation_compliant.json.license
+++ b/apps/ehd_film/inputs_json/load_relaxation_compliant.json.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: 2026 VTT Technical Research Centre of Finland Ltd
+SPDX-License-Identifier: AGPL-3.0-or-later

--- a/apps/ehd_film/inputs_json/load_relaxation_stiff.json
+++ b/apps/ehd_film/inputs_json/load_relaxation_stiff.json
@@ -1,0 +1,31 @@
+{
+    "model": {
+        "name": "ehd_film",
+        "params": {
+            "h0": 1.0,
+            "B": 640.0,
+            "M0": 1.0,
+            "gamma": 10.0,
+            "A": 0.0
+        }
+    },
+    "domain": {
+        "Lx": 256,
+        "Ly": 256,
+        "Lz": 1,
+        "dx": 1.0
+    },
+    "timestepping": {
+        "t1": 600.0,
+        "dt": 0.5,
+        "saveat": 10.0
+    },
+    "load": {
+        "p0": 0.5,
+        "a": 8.0,
+        "t_load": 60.0
+    },
+    "diagnostics": {
+        "csv": "results/ehd_film_nonlinear/load_relaxation_stiff.csv"
+    }
+}

--- a/apps/ehd_film/inputs_json/load_relaxation_stiff.json.license
+++ b/apps/ehd_film/inputs_json/load_relaxation_stiff.json.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: 2026 VTT Technical Research Centre of Finland Ltd
+SPDX-License-Identifier: AGPL-3.0-or-later

--- a/apps/ehd_film/src/ehd_film_nonlinear.cpp
+++ b/apps/ehd_film/src/ehd_film_nonlinear.cpp
@@ -1,0 +1,272 @@
+// SPDX-FileCopyrightText: 2026 VTT Technical Research Centre of Finland Ltd
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+/**
+ * @file ehd_film_nonlinear.cpp
+ * @brief Nonlinear compliant lubrication under a localized load (`#116`).
+ *
+ * The science driver for `#116`. The JSON-session binary `ehd_film` keeps
+ * the constant-mobility linear bending-relaxation model as the exact
+ * \f$k^6\f$ verifier; this binary solves the full nonlinear coupling
+ *
+ * \f[
+ *   p = B\nabla^4h - \gamma\nabla^2h - \Pi(h) + p_{\mathrm{ext}}(x,y,t),
+ *   \qquad
+ *   \partial_t h = \nabla\cdot\bigl[M(h)\nabla p\bigr],
+ *   \qquad
+ *   M(h) = M_0(h/h_0)^3,
+ * \f]
+ *
+ * with a Gaussian load applied for `0 <= t < t_load` and then removed, and
+ * reports central deflection, pressure, spreading radius, displaced volume
+ * and total volume conservation. See `ehd_film/nonlinear.hpp` for the sign
+ * conventions.
+ *
+ * Usage: `ehd_film_nonlinear CASE.json`
+ */
+
+#include <algorithm>
+#include <cmath>
+#include <complex>
+#include <cstdio>
+#include <cstdint>
+#include <filesystem>
+#include <fstream>
+#include <iomanip>
+#include <iostream>
+#include <limits>
+#include <locale>
+#include <memory>
+#include <sstream>
+#include <string>
+#include <vector>
+
+#include <mpi.h>
+#include <nlohmann/json.hpp>
+
+#include <openpfc/kernel/data/domain.hpp>
+#include <openpfc/kernel/data/grid_field.hpp>
+#include <openpfc/kernel/fft/kspace_iterator.hpp>
+#include <openpfc/kernel/simulation/stacks/spectral_cpu_stack.hpp>
+#include <openpfc_apps/spectral_flux.hpp>
+
+#include <ehd_film/ehd_film_physics.hpp>
+#include <ehd_film/nonlinear.hpp>
+
+namespace {
+
+using json = nlohmann::json;
+
+/// Deterministic broadband perturbation, identical on any decomposition.
+double hashed_noise(int i, int j, int k, const pfc::Int3 &n, std::uint64_t seed) {
+  std::uint64_t x = seed + std::uint64_t(i) +
+                    std::uint64_t(n[0]) *
+                        (std::uint64_t(j) + std::uint64_t(n[1]) * std::uint64_t(k));
+  x += 0x9e3779b97f4a7c15ULL;
+  x = (x ^ (x >> 30)) * 0xbf58476d1ce4e5b9ULL;
+  x = (x ^ (x >> 27)) * 0x94d049bb133111ebULL;
+  x = x ^ (x >> 31);
+  return 2.0 * (double(x >> 11) / double(1ULL << 53)) - 1.0;
+}
+
+} // namespace
+
+int main(int argc, char *argv[]) {
+  MPI_Init(&argc, &argv);
+  int rank = 0, nproc = 1;
+  MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+  MPI_Comm_size(MPI_COMM_WORLD, &nproc);
+  int status = 0;
+  try {
+    if (argc != 2)
+      throw std::invalid_argument("usage: ehd_film_nonlinear CASE.json");
+    std::ifstream in(argv[1]);
+    if (!in) throw std::runtime_error(std::string("cannot open ") + argv[1]);
+    json cfg = json::parse(in);
+
+    const auto &d = cfg.at("domain");
+    const int Lx = d.at("Lx"), Ly = d.at("Ly"), Lz = d.value("Lz", 1);
+    const double dx = d.value("dx", 1.0);
+    const auto domain = pfc::domain::create(pfc::GridSize({Lx, Ly, Lz}),
+                                            pfc::PhysicalOrigin({0.0, 0.0, 0.0}),
+                                            pfc::GridSpacing({dx, dx, dx}));
+
+    ehd_film::EhdFilmParams p;
+    ehd_film::apply_ehd_film_json(cfg.at("model").at("params"), p);
+
+    const auto &ts = cfg.at("timestepping");
+    const double t1 = ts.at("t1"), dt = ts.at("dt"), saveat = ts.value("saveat", -1.0);
+
+    const auto &ic = cfg.value("initial_conditions", json::object());
+    const double amp = ic.value("amplitude", 0.0);
+    const std::uint64_t seed = ic.value("seed", 1234u);
+
+    const auto &lc = cfg.value("load", json::object());
+    const double load_p0 = lc.value("p0", 0.0);
+    const double load_a = lc.value("a", 4.0);
+    const double load_t = lc.value("t_load", 0.0);
+
+    pfc::sim::stacks::SpectralCPUStack stack(domain, rank, nproc, MPI_COMM_WORLD);
+    auto &h = stack.u();
+
+    // h(x,y,0) = h0 (uniform gap): the disturbance in the science preset
+    // comes entirely from the applied load, not the initial condition.
+    // Optional broadband noise exercises the same path the k^6 verifier and
+    // the volume-conservation test use.
+    const auto n = pfc::domain::get_size(domain);
+    h.apply([&](const pfc::Real3 &x) {
+      const int i = int(std::lround(x[0] / dx));
+      const int j = int(std::lround(x[1] / dx));
+      const int k = int(std::lround(x[2] / dx));
+      const double xi = (amp != 0.0) ? hashed_noise(i, j, k, n, seed) : 0.0;
+      return p.h0 * (1.0 + amp * xi);
+    });
+
+    const auto load =
+        ehd_film::GaussianLoad::centred(domain, load_p0, load_a, load_t);
+
+    // ETD linear part: the constant-mobility operator about h0. The flux
+    // remainder carries everything the linearisation leaves out (cubic
+    // mobility, disjoining nonlinearity, the load), so with A=gamma=0 and a
+    // constant mobility the nonlinear solver reduces to the linear k^6
+    // verifier -- asserted in the tests, not assumed.
+    const double B = p.B, gamma = p.gamma, M0 = p.M0, Pip0 = p.Pip0;
+    pfc::apps::FluxETD stepper(domain, stack.fft(), dt, [=](double k_lap) {
+      const double k2 = k_lap * k_lap;
+      return M0 * B * k_lap * k2 - M0 * gamma * k2 - M0 * Pip0 * k_lap;
+    });
+
+    const ehd_film::CubicMobility mobility{p.M0, p.h0};
+    const ehd_film::EhdFilmPointwise pw{
+        .A = p.A, .h0 = p.h0, .h_star = p.h_star, .Pi0 = p.Pi0, .Pip0 = p.Pip0};
+
+    pfc::data::Field<double> pi_real(domain, stack.fft().get_inbox_bounds(), 0);
+    pfc::data::Field<std::complex<double>> pi_hat(
+        domain, stack.fft().get_outbox_bounds(), 0);
+    pfc::data::Field<double> pext_real(domain, stack.fft().get_inbox_bounds(), 0);
+    pfc::data::Field<std::complex<double>> pext_hat(
+        domain, stack.fft().get_outbox_bounds(), 0);
+    std::vector<double> k_lap(stack.fft().size_outbox(), 0.0);
+    pfc::fft::kspace::for_each_kpoint(
+        stack.fft().get_outbox_bounds(), domain,
+        [&](std::size_t i, double kx, double ky, double kz, int, int, int) {
+          k_lap[i] = -(kx * kx + ky * ky + kz * kz);
+        });
+
+    // Evaluated at this time whenever `potential` runs; the driver sets it
+    // to the instant the step (or the diagnostic sample) represents before
+    // calling into the stepper -- FluxETD's callback signature carries no
+    // time argument of its own.
+    double load_time = 0.0;
+
+    auto potential = [&](pfc::data::Field<std::complex<double>> &h_hat,
+                         pfc::data::Field<double> &hh,
+                         pfc::data::Field<std::complex<double>> &out) {
+      hh.with_host_view([&](double *hv, std::size_t cnt) {
+        pi_real.with_host_view([&](double *pv, std::size_t) {
+          for (std::size_t i = 0; i < cnt; ++i) pv[i] = pw.Pi(hv[i]);
+        });
+      });
+      pfc::sim::SpectralETDOps<pfc::HostSpace>::forward(stack.fft(), pi_real,
+                                                        pi_hat);
+
+      const auto nloc = pext_real.local_size();
+      for (int k = 0; k < nloc[2]; ++k)
+        for (int j = 0; j < nloc[1]; ++j)
+          for (int i = 0; i < nloc[0]; ++i) {
+            const auto x = pext_real.coords(i, j, k);
+            pext_real(i, j, k) = load(x[0], x[1], load_time);
+          }
+      pfc::sim::SpectralETDOps<pfc::HostSpace>::forward(stack.fft(), pext_real,
+                                                        pext_hat);
+
+      h_hat.with_host_view([&](std::complex<double> *hv, std::size_t m) {
+        pi_hat.with_host_view([&](std::complex<double> *piv, std::size_t) {
+          pext_hat.with_host_view([&](std::complex<double> *pev, std::size_t) {
+            out.with_host_view([&](std::complex<double> *o, std::size_t) {
+              for (std::size_t i = 0; i < m; ++i)
+                o[i] = B * k_lap[i] * k_lap[i] * hv[i] - gamma * k_lap[i] * hv[i] -
+                       piv[i] + pev[i];
+            });
+          });
+        });
+      });
+    };
+
+    // Diagnostics CSV, rank 0, never overwriting.
+    std::unique_ptr<std::FILE, int (*)(std::FILE *)> out(nullptr, std::fclose);
+    if (rank == 0 && cfg.contains("diagnostics")) {
+      const std::filesystem::path path =
+          cfg.at("diagnostics").at("csv").get<std::string>();
+      if (path.has_parent_path())
+        std::filesystem::create_directories(path.parent_path());
+      out.reset(std::fopen(path.string().c_str(), "w"));
+      if (!out) throw std::runtime_error("cannot open diagnostics csv");
+      std::fprintf(out.get(),
+                   "step,time,h_center,deflection_center,p_max,p_min,"
+                   "spreading_radius,displaced_volume,volume,"
+                   "volume_rel_drift\n");
+    }
+
+    double volume0 = -1.0;
+    double h_center_min = std::numeric_limits<double>::infinity();
+    double p_max_max = -std::numeric_limits<double>::infinity();
+    double spreading_radius_max = 0.0;
+    double volume_rel_drift_max = 0.0;
+
+    pfc::data::Field<std::complex<double>> h_hat_diag(
+        domain, stack.fft().get_outbox_bounds(), 0);
+    pfc::data::Field<std::complex<double>> p_hat_diag(
+        domain, stack.fft().get_outbox_bounds(), 0);
+    pfc::data::Field<double> p_real_diag(domain, stack.fft().get_inbox_bounds(), 0);
+
+    auto report = [&](int step, double t) {
+      load_time = t;
+      pfc::sim::SpectralETDOps<pfc::HostSpace>::forward(stack.fft(), h, h_hat_diag);
+      potential(h_hat_diag, h, p_hat_diag);
+      pfc::sim::SpectralETDOps<pfc::HostSpace>::backward(stack.fft(), p_hat_diag,
+                                                          p_real_diag);
+      auto s = ehd_film::sample_ehd_film(h, p_real_diag, domain, p.h0,
+                                         MPI_COMM_WORLD);
+      if (volume0 < 0.0) volume0 = s.volume;
+      const double drift = (volume0 != 0.0) ? (s.volume - volume0) / volume0 : 0.0;
+      h_center_min = std::min(h_center_min, s.h_center);
+      p_max_max = std::max(p_max_max, s.p_max);
+      spreading_radius_max = std::max(spreading_radius_max, s.spreading_radius);
+      volume_rel_drift_max = std::max(volume_rel_drift_max, std::abs(drift));
+      if (out) {
+        std::ostringstream line;
+        line.imbue(std::locale::classic());
+        line << std::setprecision(17) << step << ',' << t << ',' << s.h_center
+             << ',' << (p.h0 - s.h_center) << ',' << s.p_max << ',' << s.p_min
+             << ',' << s.spreading_radius << ',' << s.displaced_volume << ','
+             << s.volume << ',' << drift << '\n';
+        std::fputs(line.str().c_str(), out.get());
+        std::fflush(out.get());
+      }
+    };
+
+    report(0, 0.0);
+    double t = 0.0;
+    const int n_steps = int(std::llround(t1 / dt));
+    const int every =
+        (saveat > 0.0) ? std::max(1, int(std::llround(saveat / dt))) : n_steps;
+    for (int step = 1; step <= n_steps; ++step) {
+      load_time = t; // forcing over [t, t+dt) uses the pre-step time
+      t = stepper.step(t, h, potential, mobility);
+      if (step % every == 0 || step == n_steps) report(step, t);
+    }
+
+    if (rank == 0) {
+      std::printf("EHD_FILM_NONLINEAR h_center_min=%.17g p_max_max=%.17g "
+                  "spreading_radius_max=%.17g volume_rel_drift_max=%.17g\n",
+                  h_center_min, p_max_max, spreading_radius_max,
+                  volume_rel_drift_max);
+    }
+  } catch (const std::exception &e) {
+    if (rank == 0) std::cerr << "ehd_film_nonlinear: " << e.what() << "\n";
+    status = 2;
+  }
+  MPI_Finalize();
+  return status;
+}

--- a/apps/ehd_film/tests/test_ehd_film.cpp
+++ b/apps/ehd_film/tests/test_ehd_film.cpp
@@ -20,12 +20,15 @@
 
 #include <ehd_film/ehd_film_physics.hpp>
 #include <ehd_film/ehd_film_session.hpp>
+#include <ehd_film/nonlinear.hpp>
 #include <openpfc/kernel/data/domain.hpp>
 #include <openpfc/kernel/data/grid_field.hpp>
+#include <openpfc/kernel/fft/kspace_iterator.hpp>
 #include <openpfc/kernel/simulation/simulation_state.hpp>
 #include <openpfc/kernel/simulation/spectral_etd_system.hpp>
 #include <openpfc/kernel/simulation/stacks/spectral_cpu_stack.hpp>
 #include <openpfc/kernel/simulation/time.hpp>
+#include <openpfc_apps/spectral_flux.hpp>
 
 using Catch::Matchers::WithinAbs;
 using Catch::Matchers::WithinRel;
@@ -224,6 +227,221 @@ TEST_CASE("EhdFilmSession runs a short JSON case", "[ehd_film][session]") {
   ehd_film::EhdFilmSession session(settings, 0, 1, MPI_COMM_WORLD);
   session.run();
   REQUIRE(pfc::time::current(session.time()) == Catch::Approx(0.1).margin(1e-12));
+}
+
+// ---------------------------------------------------------------------------
+// Nonlinear compliant lubrication (#116)
+// ---------------------------------------------------------------------------
+
+TEST_CASE("EHD cubic mobility reduces to M0 at the reference thickness",
+          "[ehd_film][nonlinear]") {
+  const ehd_film::CubicMobility m{2.5, 1.3};
+  REQUIRE_THAT(m(1.3), WithinRel(2.5, 1e-14));
+  REQUIRE_THAT(m(2.6), WithinRel(2.5 * 8.0, 1e-14)); // (2h0)^3 = 8 M0
+  REQUIRE_THAT(m(0.65), WithinRel(2.5 / 8.0, 1e-14));
+  // A plate pinned near zero gap must still give a finite, positive mobility.
+  REQUIRE(m(0.0) > 0.0);
+  REQUIRE(m(-1.0) > 0.0);
+}
+
+TEST_CASE("EHD flux stepper reproduces the analytical k^6 decay",
+          "[ehd_film][nonlinear][flux]") {
+  if (world_size() != 1) {
+    SKIP("single-rank analytical comparison");
+  }
+  // The point of keeping the linear k^6 verifier: with a constant mobility,
+  // pure bending (gamma=A=0) and a small perturbation, the nonlinear flux
+  // solver must reproduce exp(-M0 B k^6 t) exactly, or the flux path -- and
+  // not just the linear ETD symbol -- is wrong.
+  constexpr int N = 32;
+  constexpr int nx = 2;
+  constexpr double h0 = 1.0, B = 1.0, M0 = 1.0;
+  constexpr double amp = 1.0e-6, dt = 0.02;
+  constexpr int steps = 20;
+
+  const auto domain = pfc::domain::create(pfc::GridSize({N, N, 1}),
+                                          pfc::PhysicalOrigin({0.0, 0.0, 0.0}),
+                                          pfc::GridSpacing({1.0, 1.0, 1.0}));
+  pfc::sim::stacks::SpectralCPUStack stack(domain, 0, 1, MPI_COMM_WORLD);
+  auto &h = stack.u();
+  const double twopi = 2.0 * std::numbers::pi;
+  const double L = static_cast<double>(N);
+  h.apply([&](double x, double, double) {
+    return h0 + amp * std::cos(twopi * nx * x / L);
+  });
+
+  std::vector<double> k_lap(stack.fft().size_outbox(), 0.0);
+  pfc::fft::kspace::for_each_kpoint(
+      stack.fft().get_outbox_bounds(), domain,
+      [&](std::size_t i, double kx, double ky, double kz, int, int, int) {
+        k_lap[i] = -(kx * kx + ky * ky + kz * kz);
+      });
+
+  // gamma = A = 0, so p = B lap^2 h. Constant mobility M0.
+  pfc::apps::FluxETD stepper(domain, stack.fft(), dt, [=](double kl) {
+    return M0 * B * kl * kl * kl;
+  });
+  auto potential = [&](pfc::data::Field<std::complex<double>> &h_hat,
+                       pfc::data::Field<double> &,
+                       pfc::data::Field<std::complex<double>> &out) {
+    h_hat.with_host_view([&](std::complex<double> *hv, std::size_t m) {
+      out.with_host_view([&](std::complex<double> *o, std::size_t) {
+        for (std::size_t i = 0; i < m; ++i) o[i] = B * k_lap[i] * k_lap[i] * hv[i];
+      });
+    });
+  };
+  auto constant_mobility = [=](double) { return M0; };
+
+  double t = 0.0;
+  for (int s = 0; s < steps; ++s)
+    t = stepper.step(t, h, potential, constant_mobility);
+
+  const double k = twopi * nx / L;
+  const double k6 = k * k * k * k * k * k;
+  const double expected = amp * std::exp(-M0 * B * k6 * t);
+  double num = 0.0, den = 0.0;
+  const auto n = h.local_size();
+  for (int j = 0; j < n[1]; ++j)
+    for (int i = 0; i < n[0]; ++i) {
+      const auto x = h.coords(i, j, 0);
+      const double w = std::cos(twopi * nx * x[0] / L);
+      num += (h(i, j, 0) - h0) * w;
+      den += w * w;
+    }
+  REQUIRE_THAT(num / den, WithinRel(expected, 1e-8));
+}
+
+TEST_CASE("EHD cubic mobility conserves liquid volume under bending, tension "
+          "and adhesion",
+          "[ehd_film][nonlinear]") {
+  if (world_size() != 1) {
+    SKIP("single-rank conservation check");
+  }
+  // Exercises Pi(h) through the flux path, not just B and gamma: the
+  // perturbation is bounded well away from h=0 (h in [0.8h0, 1.2h0]) so the
+  // default (no h_star) disjoining form -- known stiff near h -> 0 -- stays
+  // smooth here, per the thin_film #114 experience with this potential.
+  constexpr int N = 32;
+  constexpr double h0 = 1.0, B = 1.0, gamma = 0.1, A = 0.05, dt = 0.01;
+  const auto domain = pfc::domain::create(pfc::GridSize({N, N, 1}),
+                                          pfc::PhysicalOrigin({0.0, 0.0, 0.0}),
+                                          pfc::GridSpacing({1.0, 1.0, 1.0}));
+  pfc::sim::stacks::SpectralCPUStack stack(domain, 0, 1, MPI_COMM_WORLD);
+  auto &h = stack.u();
+  const double twopi = 2.0 * std::numbers::pi;
+  h.apply([&](double x, double y, double) {
+    return h0 * (1.0 + 0.2 * std::cos(twopi * 2 * x / N) *
+                           std::cos(twopi * 2 * y / N));
+  });
+
+  const ehd_film::EhdFilmPointwise pw{.A = A, .h0 = h0};
+  const double Pip0 = pw.Pi_prime(h0);
+
+  std::vector<double> k_lap(stack.fft().size_outbox(), 0.0);
+  pfc::fft::kspace::for_each_kpoint(
+      stack.fft().get_outbox_bounds(), domain,
+      [&](std::size_t i, double kx, double ky, double kz, int, int, int) {
+        k_lap[i] = -(kx * kx + ky * ky + kz * kz);
+      });
+
+  pfc::apps::FluxETD stepper(domain, stack.fft(), dt, [=](double kl) {
+    return B * kl * kl * kl - gamma * kl * kl - Pip0 * kl;
+  });
+  pfc::data::Field<double> pi_real(domain, stack.fft().get_inbox_bounds(), 0);
+  pfc::data::Field<std::complex<double>> pi_hat(
+      domain, stack.fft().get_outbox_bounds(), 0);
+  auto potential = [&](pfc::data::Field<std::complex<double>> &h_hat,
+                       pfc::data::Field<double> &hh,
+                       pfc::data::Field<std::complex<double>> &out) {
+    hh.with_host_view([&](double *hv, std::size_t cnt) {
+      pi_real.with_host_view([&](double *pv, std::size_t) {
+        for (std::size_t i = 0; i < cnt; ++i) pv[i] = pw.Pi(hv[i]);
+      });
+    });
+    pfc::sim::SpectralETDOps<pfc::HostSpace>::forward(stack.fft(), pi_real, pi_hat);
+    h_hat.with_host_view([&](std::complex<double> *hv, std::size_t m) {
+      pi_hat.with_host_view([&](std::complex<double> *piv, std::size_t) {
+        out.with_host_view([&](std::complex<double> *o, std::size_t) {
+          for (std::size_t i = 0; i < m; ++i)
+            o[i] = B * k_lap[i] * k_lap[i] * hv[i] - gamma * k_lap[i] * hv[i] -
+                   piv[i];
+        });
+      });
+    });
+  };
+  const ehd_film::CubicMobility mobility{1.0, h0};
+
+  pfc::data::Field<double> p_dummy(domain, stack.fft().get_inbox_bounds(), 0);
+  const auto v0 = ehd_film::sample_ehd_film(h, p_dummy, domain, h0, MPI_COMM_WORLD);
+  double t = 0.0;
+  for (int s = 0; s < 40; ++s) t = stepper.step(t, h, potential, mobility);
+  const auto v1 = ehd_film::sample_ehd_film(h, p_dummy, domain, h0, MPI_COMM_WORLD);
+
+  // A divergence form conserves the integral to round-off, whatever M does.
+  REQUIRE_THAT(v1.volume, WithinRel(v0.volume, 1e-11));
+  REQUIRE(v1.h_center != v0.h_center); // and the profile did evolve
+}
+
+TEST_CASE("EHD localized load thins the gap at its centre and conserves volume",
+          "[ehd_film][nonlinear][load]") {
+  if (world_size() != 1) {
+    SKIP("single-rank sign-convention check");
+  }
+  // Documents the sign in ehd_film/nonlinear.hpp: p_ext > 0 is a load
+  // pressing the plate down, so a positive Gaussian load must thin the gap
+  // at its centre (deflection > 0) and thicken it in the surrounding
+  // annulus, while the divergence-form flux still conserves total volume --
+  // this holds regardless of B, gamma, A because p_ext only ever enters
+  // inside grad(p).
+  constexpr int N = 64;
+  constexpr double h0 = 1.0, M0 = 1.0, dt = 0.02;
+  const auto domain = pfc::domain::create(pfc::GridSize({N, N, 1}),
+                                          pfc::PhysicalOrigin({0.0, 0.0, 0.0}),
+                                          pfc::GridSpacing({1.0, 1.0, 1.0}));
+  pfc::sim::stacks::SpectralCPUStack stack(domain, 0, 1, MPI_COMM_WORLD);
+  auto &h = stack.u();
+  h.apply([&](double, double, double) { return h0; });
+
+  // No bending, tension or adhesion here: isolate the load's own sign.
+  pfc::apps::FluxETD stepper(domain, stack.fft(), dt,
+                             [](double) { return 0.0; });
+  const auto load = ehd_film::GaussianLoad::centred(domain, /*p0=*/0.5,
+                                                     /*a=*/6.0, /*t_load=*/1.0e9);
+  pfc::data::Field<double> pext_real(domain, stack.fft().get_inbox_bounds(), 0);
+  auto potential = [&](pfc::data::Field<std::complex<double>> &,
+                       pfc::data::Field<double> &,
+                       pfc::data::Field<std::complex<double>> &out) {
+    const auto n = pext_real.local_size();
+    for (int k = 0; k < n[2]; ++k)
+      for (int j = 0; j < n[1]; ++j)
+        for (int i = 0; i < n[0]; ++i) {
+          const auto x = pext_real.coords(i, j, k);
+          pext_real(i, j, k) = load(x[0], x[1], 0.0);
+        }
+    pfc::sim::SpectralETDOps<pfc::HostSpace>::forward(stack.fft(), pext_real, out);
+  };
+  const ehd_film::CubicMobility mobility{M0, h0};
+
+  pfc::data::Field<double> p_dummy(domain, stack.fft().get_inbox_bounds(), 0);
+  const auto before = ehd_film::sample_ehd_film(h, p_dummy, domain, h0, MPI_COMM_WORLD);
+  double t = 0.0;
+  for (int s = 0; s < 10; ++s) t = stepper.step(t, h, potential, mobility);
+  const auto after = ehd_film::sample_ehd_film(h, p_dummy, domain, h0, MPI_COMM_WORLD);
+
+  REQUIRE(after.h_center < before.h_center); // gap thins under the load
+  REQUIRE_THAT(after.volume, WithinRel(before.volume, 1e-10));
+}
+
+TEST_CASE("GaussianLoad turns off at t_load", "[ehd_film][nonlinear]") {
+  const auto domain = pfc::domain::create(pfc::GridSize({32, 32, 1}),
+                                          pfc::PhysicalOrigin({0.0, 0.0, 0.0}),
+                                          pfc::GridSpacing({1.0, 1.0, 1.0}));
+  const auto load = ehd_film::GaussianLoad::centred(domain, 0.5, 4.0, 2.0);
+  REQUIRE_THAT(load(16.0, 16.0, 0.0), WithinRel(0.5, 1e-12)); // on, peak
+  REQUIRE(load(16.0, 16.0, 2.0) == 0.0);                      // off at t_load
+  REQUIRE(load(16.0, 16.0, 5.0) == 0.0);                      // stays off
+  const ehd_film::GaussianLoad none{};
+  REQUIRE(none(1.0, 2.0, 0.0) == 0.0);
 }
 
 int main(int argc, char *argv[]) {


### PR DESCRIPTION
## What changed

Adds the `#116` science upgrade for `apps/ehd_film` on top of the existing exact `k^6` pure-bending verifier, which is kept unchanged and unrenamed. New CPU binary `ehd_film_nonlinear` solves the full lubrication coupling

```
p = B lap^2 h - gamma lap h - Pi(h) + p_ext(x,y,t)
dh/dt = div( M(h) grad p ),   M(h) = M0 (h/h0)^3
```

by reusing the shared conservative flux stepper (`pfc::apps::FluxETD` / `SpectralFlux`, `apps/common/include/openpfc_apps/spectral_flux.hpp`) that the `thin_film` `#114` science upgrade on this base branch introduced. No second flux implementation was written. `apps/thin_film/src/thin_film_nonlinear.cpp` was the worked example this driver's structure follows.

* `p_ext` is a localized Gaussian load, `p0 * exp(-r^2/2a^2)` for `0 <= t < t_load`, then removed, so the science preset shows loading followed by recovery/redistribution.
* `EhdFilmPointwise` gained the `h_star` adhesion-safe precursor disjoining form ported from `thin_film`'s `#114` work (`Pi = A[(h_star/h)^9 - (h_star/h)^3]`), so a plate held down by adhesion settles on a stable thin gap instead of `Pi` diverging as `h -> 0`. Default `h_star = 0` keeps the original `#81` form and behaviour unchanged.
* Sign conventions are documented in `apps/ehd_film/include/ehd_film/nonlinear.hpp` and in the README, and asserted by a test, not just described: `p_ext > 0` presses the plate down, thinning the gap at the load centre and thickening the surrounding annulus (squeeze flow), while volume is exactly conserved regardless of `p_ext`, `B`, `gamma`, or `A`, because the equation is a divergence form in all cases.
* Host (CPU) only, as instructed — the flux path has no device kernels. The existing constant-mobility `ehd_film_hip` binary is untouched.

New Catch2 tests (`apps/ehd_film/tests/test_ehd_film.cpp`), all in the existing `test_ehd_film` binary, copying `thin_film`'s test structure for the equivalent cases:

* cubic mobility reduces to `M0` at `h0` (and stays positive as `h -> 0`);
* the nonlinear flux stepper reproduces the analytical `exp(-M0 B k^6 t)` decay exactly when `A = gamma = 0` and the mobility is constant — the actual point of keeping the linear verifier;
* volume conservation under bending + tension + adhesion together (exercises `Pi(h)` through the flux path, not just `B`/`gamma`);
* the load's sign convention (thins the gap centre, conserves volume) and its on/off gating at `t_load`.

## Measured numbers (actually run on the shared LUMI allocation)

`load_relaxation_stiff.json` (`B=640`) and `load_relaxation_compliant.json` (`B=100`), both `256^2`, `gamma=10`, `A=0`, load `p0=0.5, a=8, t_load=60`, `dt=0.5`, run to `t1=600` on 4 MPI ranks:

| Quantity | Stiff (B=640) | Compliant (B=100) |
|---|---|---|
| Deflection at end of loading (t=60) | 0.2525 | 0.3414 (35% more) |
| Spreading radius at end of loading | 14.15 | 12.30 (more localized) |
| Displaced volume at end of loading | 106.18 | 110.56 |
| Deflection at t=600 (540 after load-off) | 0.0409 (83.8% recovered) | 0.0608 (82.2% recovered) |
| Spreading radius at t=600 | 27.41 | 23.08 |
| Volume relative drift, whole run | 7.0e-15 | 8.0e-15 |

Domain-adequacy check (not assumed): the domain half-width is 128; the RMS spreading radius over the whole `t in [0,600]` run stays under 22% of that in both cases, so the periodic images do not interact with the disturbance over the reported interval.

`B` is chosen so the bending-tension crossover length `sqrt(B/gamma)` equals the load width `a=8` in the stiff case (`sqrt(640/10)=8`) and is well below it in the compliant case (`sqrt(100/10)=3.16`) — otherwise, at this load width, tension alone dominates the response and `B` has essentially no visible effect (checked: `B=1` vs `B=0.2` at the same `gamma=10` gave indistinguishable traces, which is why the shipped presets use `B=640`/`100` instead).

**Physically interpretable trend requested by `#116`:** the stiffer plate deflects less and spreads the load over a wider area; the more compliant plate deflects more and keeps the disturbance more localized — the classical plate-on-viscous-foundation picture. Both cases conserve total fluid volume to round-off.

Build + tests, run for real (not claimed without running):

```
./scripts/build.sh --machine=lumi --cpu --no-submit --no-test --jobs=16   --cmake-arg=-DOpenPFC_BUILD_TESTS=ON --build-dir=<build-dir>
# Build and test: PASS

SLURM_JOB_ID=$SHARED TMPDIR=... ctest -R ehd-film --output-on-failure
# ehd-film-all-tests: Passed (test_ehd_film, 10 test cases, 32 assertions, all green)
```

Both science presets were run via `srun --overlap -n 4` on the shared allocation; console `EHD_FILM_NONLINEAR ...` summary lines and the full diagnostics CSVs match the table above.

## `#116` acceptance criteria

- [x] Existing exact `k^6` verifier remains available and is labelled as such (`ehd_film` binary and `inputs_json/relaxation.json`, README section titled "verification preset", untouched physics).
- [x] Science case uses nonlinear `M(h)` (`ehd_film::CubicMobility`, `M(h) = M0(h/h0)^3`).
- [x] At least one localized-load/relaxation run is implemented (`p_ext` Gaussian load, on for `t < t_load`, then removed).
- [x] At least one parameter sweep produces a physically interpretable trend (`B=640` vs `B=100` at fixed `gamma`, see table above).
- [x] Pressure as well as film/plate deflection is output and reported (`p_max`, `p_min`, `h_center`, `deflection_center` columns in the CSV).
- [x] Total fluid volume is conserved to documented tolerance (`~7-8e-15` relative, round-off, both presets, checked not assumed).
- [ ] Energy/balance diagnostics — **not implemented**. The orchestrating task scope for this PR explicitly listed the diagnostics to add (central thickness/deflection, max pressure, spreading radius, displaced volume, volume conservation) and did not include energy diagnostics; deferred, noted in the README.
- [x] Domain, BCs, ICs, load and physical assumptions are explicit in README/report (`Problem setup` table per `#112`, "Why periodic", "Domain-adequacy check", "Nonlinear model" sections).
- [ ] CPU/HIP observables agree within tolerance for the nonlinear model — **moot/deferred**: the nonlinear flux path is CPU only by design (documented in `spectral_flux.hpp` on the base branch and repeated here), so there is no HIP nonlinear case to compare against. The existing linear model's CPU/HIP agreement is unchanged and not re-verified in this PR (no HIP build was run here; only the CPU build was built and tested, per the task's build instructions).

## What is deferred (stretch goals and part of computational experiment C)

* **Case C** (adhesive/unstable film under a compliant plate, rigid vs compliant comparison, rupture time/wavelength) — not attempted. `A > 0` and `h_star` are implemented and unit-tested, including through the nonlinear flux path, but no dynamic science run was made to drive the adhesive instability. The base branch's `thin_film` work found the `(9,3)` precursor power pair stiff and prone to NaN once `h` approaches `h_star`; doing this safely for EHD would need its own tuning pass, which this PR does not attempt.
* Energy/balance diagnostics (bending, capillary, wetting contributions).
* Time-periodic loading / frequency response and anisotropic plate bending (issue-listed stretch goals).
* HIP build/run of this branch's changes (CPU only, per task scope; the flux path itself has no HIP kernels regardless).

## Honesty notes

* `B`, `gamma`, `M0`, and the load shape/amplitude in the science presets are illustrative nondimensional grid-unit parameters, not calibrated to any material or process — labelled as such in the README's `Problem setup` table (`calibration: none`).
* I did not encounter the nonlinear-divergence failure mode the task asked me to watch for (steepening beyond grid resolution); the gap stays well away from zero in both presets (min measured `h_center` is `0.627` at the smallest, `B=100` trial with a stronger load, well above the `clamp_h` floor of `1e-4`/`1e-6`), so I have nothing to report there for this PR's runs.
* The `h_star` field added to `EhdFilmPointwise`/`EhdFilmSchemaValues` mirrors the already-shipped `thin_film` `ThinFilmPointwise` change on this base branch; it is exercised on CPU here but I did not build/run it under HIP in this PR.

Refs #116

Merge by **rebase**, not squash.