### PR TITLE
feat(higher_order_pfc): crystal-selection benchmark with a real-space order metric

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,28 @@ SPDX-License-Identifier: AGPL-3.0-or-later
   constant-mobility `ehd_film_hip` binary is unchanged. The adhesive/unstable
   film comparison (issue's case C) is deferred, along with energy
   diagnostics and time-periodic loading.
+- `higher_order_pfc` crystal-selection benchmark (`#118`): a real-space
+  bond-orientational order metric (`order_parameter.hpp`, \(\psi_4\)/\(\psi_6\)
+  from detected density peaks) so square-vs-triangular selection is verified
+  structurally, not inferred from reciprocal-space ring power alone.
+  \(\psi_4\)/\(\psi_6\) are checked to \(10^{-9}\) against analytically
+  constructed ideal square and triangular lattices — the key acceptance test.
+  Cites the primary two-mode-PFC source, Wu, Adland & Karma, *Phys. Rev. E*
+  **81**, 061601 (2010) (arXiv:1001.1349), and maps OpenPFC's kernel to it
+  term by term; calibration is labelled representative, not quantitative (see
+  the app README for exactly what was and was not verified against the
+  primary source from this machine). Five 2D cases (`lattice_seed.hpp` adds
+  the controlled single-crystal seed IC; `diagnostics.hpp` adds free-energy
+  density + reciprocal peaks + \(\psi_4\)/\(\psi_6\) to a CSV) show the
+  two-mode `q1=√2, r1=0.02` kernel selecting real-space square order
+  (\(\psi_4\) local \(0.81\), mean neighbours \(4.04\)) against the
+  single-mode kernel's triangular order (\(\psi_6\) local \(0.85\), mean
+  neighbours \(5.87\)) from the same box/seed/quench, and confirms that the
+  degenerate `r1=0` kernel's \(\sqrt2\)-ring-dominated pattern is real-space
+  **triangular**, not square, despite the reciprocal-space power distribution
+  alone suggesting otherwise. Two `lattice_seed` single-crystal runs hold
+  their imposed symmetry to \(\psi_4\)/\(\psi_6=1.000\) over 2000 ETD steps.
+  3D crystal selection is deferred; see the PR.
 
 - Fe–Cr Cahn–Hilliard science upgrade (`#113`): Redlich–Kister excess free
   energy with the assessed bcc Cr–Fe interaction, a code-to-physical scale map

--- a/apps/higher_order_pfc/CMakeLists.txt
+++ b/apps/higher_order_pfc/CMakeLists.txt
@@ -56,7 +56,8 @@ if(HIGHER_ORDER_PFC_ENABLE_TESTS AND OpenPFC_BUILD_TESTS)
   find_package(Catch2 QUIET)
   if(TARGET Catch2::Catch2)
     higher_order_pfc_cpu_executable(test_higher_order_pfc
-      tests/test_higher_order_pfc.cpp)
+      tests/test_higher_order_pfc.cpp
+      tests/test_order_parameter.cpp)
     target_link_libraries(test_higher_order_pfc PRIVATE Catch2::Catch2)
     include(CTest)
     add_test(NAME higher-order-pfc-all-tests COMMAND test_higher_order_pfc)

--- a/apps/higher_order_pfc/README.md
+++ b/apps/higher_order_pfc/README.md
@@ -3,17 +3,81 @@ SPDX-FileCopyrightText: 2026 VTT Technical Research Centre of Finland Ltd
 SPDX-License-Identifier: AGPL-3.0-or-later
 -->
 
-# `higher_order_pfc` — eighth-order PFC correlation kernel
+# `higher_order_pfc` — two-mode PFC crystal-selection benchmark
 
-A deliberately **very high-order** phase-field-crystal example. The free-energy
-kernel runs through \((\nabla^2)^4\) (eighth order in space); conserved dynamics
-adds one more Laplacian, so the evolution operator runs through
-\((\nabla^2)^5\) — **tenth order**.
+A deliberately **very high-order** phase-field-crystal example, and (`#118`) a
+reproducible **crystal-selection experiment**: does a second correlation-
+function peak change which 2D lattice symmetry a periodic PFC quench selects,
+verified with a real-space structural metric rather than reciprocal-space ring
+power alone. The free-energy kernel runs through \((\nabla^2)^4\) (eighth
+order in space); conserved dynamics adds one more Laplacian, so the evolution
+operator runs through \((\nabla^2)^5\) — **tenth order**.
 
-The point of the example is not the physics alone. It is that in a spectral code
-a tenth-order operator is a five-term Horner loop, while the equivalent
-real-space stencil would be a wide, awkward, hard-to-scale object. **High
-differential order is not high implementation complexity here.**
+The high derivative order is not incidental, but it is not the physical story
+either: in a spectral code a tenth-order operator is a five-term Horner loop,
+while the equivalent real-space stencil would be a wide, awkward,
+hard-to-scale object. **High differential order is not high implementation
+complexity here.** The physical story is in the next section.
+
+## Problem setup
+
+| Item | Description |
+|---|---|
+| **Use case** | Crystal-symmetry selection in a periodic 2D solid: does a second correlation-function peak favour square order over the single-mode kernel's triangular default? |
+| **Question** | How does adding a second correlation length scale (`q1`, `r1`) change which lattice symmetry a PFC quench selects, and can that be verified in real space, not just from reciprocal-space ring power? |
+| **Domain** | 2D periodic, \(128\times128\) cells. Square box \(L_x=L_y=32\pi\) (\(dx=dy=2\pi/8\)) for the noise-seeded and square-seeded cases; a differently-shaped box \(L_x=32\pi,\ L_y=32\pi/\sqrt3\) (\(dx=2\pi/8,\ dy=\pi/(4\sqrt3)\)) for the triangular single-crystal seed. See "Why these box sizes" below. |
+| **Boundary conditions** | Periodic on both active axes |
+| **Initial condition** | Either `seeded_noise` (decomposition-independent hashed noise, polycrystalline nucleation-like) or `lattice_seed` (an explicit sum of 2–3 plane waves at the target symmetry's reciprocal vectors, a controlled single-crystal seed) |
+| **Key parameters** | `eps` (quench depth), `q1`/`r1` (second-peak position/weight), `n_modes` (1 = single-mode, 2 = two-mode); mean density \(\bar\psi\) (see below) |
+| **Observable** | Free-energy density after relaxation; reciprocal-space peak amplitudes at \(\|k\|=1\) and \(\|k\|=q_1\) (`pfc::apps::shell_average`); real-space bond-orientational order \(\psi_4\)/\(\psi_6\) (`order_parameter.hpp`) |
+| **Model maturity** | numerical verification: **analytical** (kernel/symbol tests, exact-lattice order-parameter tests) · physical completeness: **reduced** (2D, one order parameter, no elastic/thermal coupling) · calibration: **representative** — see "Literature model" below |
+
+## Literature model and mapping to OpenPFC's kernel
+
+**Source.** Kuo-An Wu, Ari Adland, Alain Karma, "Phase-field-crystal model for
+fcc ordering," *Phys. Rev. E* **81**, 061601 (2010),
+[10.1103/PhysRevE.81.061601](https://doi.org/10.1103/PhysRevE.81.061601)
+(arXiv:1001.1349). The paper's dimensionless free-energy density is
+
+\[
+  f = \frac\psi2\Bigl[-\epsilon+(\nabla^2+1)^2\bigl((\nabla^2+Q_1^2)^2+R_1\bigr)\Bigr]\psi
+      + \frac{\psi^4}{4},
+\]
+
+built from **two** correlation-function peaks so that a second family of
+reciprocal-lattice vectors, not just the first, can be independently tuned —
+their target application is fcc (`Q1 = 2/sqrt(3)`, coupling the \(\langle
+111\rangle\) and \(\langle200\rangle\) families), and their Appendix works the
+same construction for the 2D square lattice (`Q1 = sqrt(2)`, coupling
+\(\langle10\rangle\) and \(\langle11\rangle\)).
+
+**Term-by-term map.** \(\epsilon\leftrightarrow\)`eps`, \(Q_1\leftrightarrow\)`q1`,
+\(R_1\leftrightarrow\)`r1`. OpenPFC's
+\(\Lambda(\nabla^2)=-\varepsilon+(1+\nabla^2)^2[r_1+(q_1^2+\nabla^2)^2]\)
+(`correlation_kernel.hpp`) is the same expression with `r1` and the second
+bracket's square written in the other order — addition commutes, so this is
+notation only, not a different model. The `q1 = sqrt(2)` (2D square) and
+`q1 = 2/sqrt(3)` (3D fcc) values already documented below are exactly the
+paper's `Q1` choices, independently of this literature search — that
+agreement is what gives the mapping confidence, not just the shared algebraic
+form.
+
+**Honesty about what was and was not verified from this machine.** The
+functional form and the `Q1` values above were confirmed against the arXiv
+preprint (`ar5iv` HTML rendering of 1001.1349), fetched in this session; the
+published APS-typeset version was not accessible from this machine, and the
+2D-square appendix's solid-phase amplitude free energy came back through that
+fetch with rendering artefacts in its sub/superscripts that could not be
+cleanly resolved. So: the **reciprocal-space kernel structure and the `Q1`
+ratios** are treated as verified against the primary source; the paper's
+**quantitative phase diagram and elastic-constant fits** (e.g. their Ni/Fe
+parameter sets, or their reported `R1`/`eps` boundary between one-mode and
+two-mode stability) were not independently reproduced here and are not
+claimed. `eps`, `r1` and \(\bar\psi\) in this benchmark are chosen to
+demonstrate the phase-selection *mechanism* the paper's kernel provides, not
+fitted to its phase diagram — calibration is **representative**, not
+**quantitative**, and every number below is a real measurement from this
+repository's own code, not a reproduction of the paper's reported values.
 
 ## Free energy and the reciprocal-space kernel
 
@@ -101,6 +165,49 @@ mathematically tidy, but not a square lattice. From random noise on a periodic
 box the result is **polycrystalline**: several square-ordered grains at
 different orientations, not a single crystal.
 
+This table is exactly the complaint `#118` raises: it is a ring-power
+inference. Two peaks both carrying modes at \(\|k\|=\sqrt2\) says the pattern
+has *that wavelength*, not that it is *square* — the same ring is also
+populated by, say, a rotated square grain boundary or a modulated stripe
+phase. The next two sections add what a ring cannot give: a real-space
+symmetry check, and a reproducible experiment built on both together.
+
+## Real-space order metric
+
+`order_parameter.hpp` adds the check `#118` says is missing: a real-space
+bond-orientational order parameter, not another reciprocal-space proxy.
+Density peaks are treated as particles; for each one, the near neighbours'
+bond angles \(\theta\) feed
+
+\[
+  \psi_n(j) = \frac1{N_b(j)}\sum_{k\in\text{neighbours}(j)} e^{in\theta_{jk}} .
+\]
+
+\(n=4\) and \(n=6\) are the discriminator: a perfect square lattice (4
+neighbours, \(90^\circ\) apart) gives \(|\psi_4|=1,\ \psi_6=0\) **exactly**; a
+perfect triangular lattice (6 neighbours, \(60^\circ\) apart) gives the
+reverse, \(\psi_4=0,\ |\psi_6|=1\) **exactly** — algebra worked out in the
+header comment and checked against analytically constructed lattices in
+`tests/test_order_parameter.cpp`, independently of any peak detector. The
+neighbour cutoff (`1.3`× the point set's own median nearest-neighbour
+distance) sits strictly between both lattices' first shell and second shell,
+so it needs no lattice-specific tuning.
+
+Two averages are reported for each harmonic:
+
+- **global** — magnitude of the complex average of \(\psi_n(j)\) over every
+  peak. Misoriented grains point in different directions and partially
+  cancel, so this number answers "is this one crystal, or many grains" — it
+  is what tells a noise-seeded polycrystal from a `lattice_seed` single
+  crystal at otherwise identical `(psi4_local, psi6_local)`.
+- **local** — average of \(|\psi_n(j)|\), orientation-blind. Answers "is each
+  neighbourhood ordered at all", independent of whether grains agree.
+
+Peak detection (`detect_peaks`) is a periodic 8-neighbour local-maximum test
+at grid resolution — no sub-pixel refinement, so this module reports
+*symmetry* (a normalised ratio), not a calibrated lattice constant; the
+reciprocal-space peak positions from `shell_average` already give that.
+
 ## Timestepping: why ETD
 
 The \(k^{10}\) term makes this brutally stiff. On the shipped grid
@@ -141,6 +248,102 @@ takes roughly six times longer. Conserved dynamics never repairs a mean the
 initial condition got wrong, so `seeded_noise` removes its mean by an integer
 reduction over global cell indices — the same field on any number of ranks.
 
+`lattice_seed` (`lattice_seed.hpp`) is the other initial condition this
+benchmark adds: a controlled single-crystal seed, an explicit sum of 2–3
+plane waves at the target lattice's reciprocal vectors (integer grid modes,
+so every term is exactly periodic), rather than growing a pattern out of
+noise. Two modes at \(90^\circ\) seed a square lattice; three at \(120^\circ\)
+seed a triangular one.
+
+## Crystal-selection benchmark (`#118`)
+
+Five 2D runs, all \(128\times128\), `eps = 0.25`, `g = 0.5`, single rank (the
+real-space order metric needs the whole grid; see `diagnostics.hpp`).
+`diagnostics.csv` on every case reports mean density, free-energy density, the
+reciprocal-space peak amplitudes at \(\|k\|=1\) and \(\|k\|=q_1\), and
+\((\psi_4,\psi_6)\) every `saveat`.
+
+| case | kernel | IC | box | \(\bar\psi\) | role |
+|---|---|---|---|---|---|
+| `single_mode_triangular.json` | `n_modes=1` | noise | square | \(-0.15\) | single-mode reference **and** triangular-favouring control (2D single-mode PFC has one band, at \(\|k\|=1\); Elder et al., *Phys. Rev. Lett.* **88**, 245701 (2002), is the classical result that this selects triangular order) |
+| `two_mode_square.json` | `n_modes=2`, `q1=√2`, `r1=0.02` | noise | square | \(-0.15\) | two-mode square-favouring, matched box/IC/quench to the row above (issue's "same conditions" comparison) |
+| `two_mode_degenerate.json` | `n_modes=2`, `q1=√2`, `r1=0` | noise | square | \(-0.15\) | known-result re-check: degenerate bands, \(\|k\|=\sqrt2\) wins outright — **not** a clean square lattice (see "What the extra terms actually buy you") |
+| `single_mode_seed_triangular.json` | `n_modes=1` | `lattice_seed`, 3 modes at \(120^\circ\) | triangular | \(-0.15\) | clean single-crystal triangular check |
+| `two_mode_seed_square.json` | `n_modes=2`, `q1=√2`, `r1=0.02` | `lattice_seed`, 2 modes at \(90^\circ\) | square | \(-0.15\) | clean single-crystal square check |
+
+### Measured phase-selection table
+
+Real numbers from the shipped cases, `higher_order_pfc` CPU build, single
+rank, LUMI login node (see the PR body for the run log). \(f\) is free-energy
+density; \((\psi_4,\psi_6)\) are `(global, local)`, see "Real-space order
+metric" above; mean neighbours is the average bond count the order-parameter
+cutoff found (4 for square, 6 for triangular, in an ideal lattice).
+
+| case | \(f\): initial \(\to\) final | \(k_{\text{peak}}\) | \(S(\|k\|{=}1)\): initial \(\to\) final | \(S(\|k\|{=}q_1)\): initial \(\to\) final | \(\psi_4\) | \(\psi_6\) | mean nb. | real-space verdict |
+|---|---|---|---|---|---|---|---|---|
+| `single_mode_triangular` (noise, \(t{:}0\to400\)) | \(0.00970\to0.00585\) | \(1.031\) | \(0.15\to160132\) | \(0.14\to39.5\) | \((0.014,\ 0.094)\) | \((0.335,\ \mathbf{0.852})\) | \(5.87\) | **triangular**, polycrystalline (global ≪ local) |
+| `two_mode_square` (noise, \(t{:}0\to400\)) | \(0.2051\to0.0389\) | \(1.031\) | \(0.15\to111849\) | \(0.14\to27574\) | \((0.341,\ \mathbf{0.806})\) | \((0.022,\ 0.247)\) | \(4.04\) | **square**, mostly one orientation (global ≈ 0.4× local, not ≪) |
+| `two_mode_degenerate`, `r1=0` (noise, \(t{:}0\to400\)) | \(0.2048\to0.0398\) | \(1.406\approx\sqrt2\) | \(0.15\to3947\) | \(0.14\to156486\) | \((0.005,\ 0.122)\) | \((0.792,\ \mathbf{0.896})\) | \(5.70\) | ring at \(\sqrt2\) wins outright, but real space is **triangular**, confirming the README's "not a square lattice" claim directly rather than by ring-power inference |
+| `two_mode_seed_square` (`lattice_seed`, \(t{:}0\to100\)) | \(0.0430\to0.0377\) | \(1.031\) (unchanged) | \(41087\to419780\) | \(\approx0\to66685\) | \((\mathbf{1.000},\ \mathbf{1.000})\) | \((\approx0,\ \approx0)\) | \(4.00\) | **square** preserved exactly; the \(\sqrt2\) band grows in spontaneously on top of the imposed \((10)\) family |
+| `single_mode_seed_triangular` (`lattice_seed`, \(t{:}0\to100\)) | \(0.00891\to0.00511\) | \(1.028\) (unchanged) | \(17207\to322036\) | \(\approx0\to\approx0\) | \((\approx0,\ \approx0)\) | \((\mathbf{1.000},\ \mathbf{1.000})\) | \(6.00\) | **triangular** preserved exactly; no \(\sqrt2\) band exists for `n_modes=1` to grow |
+
+Reading down: free-energy density decreases monotonically in every run (the
+conserved gradient flow relaxing, as it must) — different kernels have
+different absolute \(\Lambda(0)\), so \(f\) is not meaningfully compared
+*across* rows, only *within* one. The columns that *are* directly comparable
+across kernels are \(\psi_4\) and \(\psi_6\), and they are the ones that
+settle the question: the two-mode `q1=√2, r1=0.02` kernel gives real-space
+square order (\(\psi_4\) dominant, \(4.04\) mean neighbours), the single-mode
+kernel gives real-space triangular order (\(\psi_6\) dominant, \(5.87\)
+neighbours) from the *same* box, seed and quench, and the degenerate
+`r1=0` kernel — despite putting nearly all reciprocal power on the
+\(\sqrt2\) ring, which a ring-power-only report would likely call "square
+harmonics" — is real-space **triangular**, exactly as `#118` warns a ring
+alone cannot tell you. Both `lattice_seed` runs hold their imposed symmetry
+to \(\psi\) at 3+ decimal places over 2000 ETD steps, the cleanest possible
+statement that a kernel *stabilises* the phase it is given, independent of
+whatever a noise-seeded run's grain structure happens to look like.
+
+What this benchmark does **not** measure: an explicit grain/orientation
+*count* for the noise-seeded runs. The global-vs-local \(\psi_n\) gap
+(`single_mode_triangular`: \(0.335\) vs \(0.852\); `two_mode_square`:
+\(0.341\) vs \(0.806\)) is used as a documented polycrystallinity proxy —
+smaller gap means more mutually aligned grains — but no per-grain
+segmentation/labelling algorithm was written; that is deferred (see the PR
+body).
+
+### Why these box sizes are commensurate
+
+The **square** box (\(L_x=L_y=32\pi\), \(128\) cells, \(dx=2\pi/8\)) puts
+\(\|k\|=1\) exactly on grid mode 16 (\(k=2\pi\cdot16/32\pi=1\)) and
+\(\|k\|=\sqrt2\) exactly on the diagonal mode \((16,16)\)
+(\(k=\sqrt{1^2+1^2}\)) — both correlation peaks land on exact grid
+frequencies, so neither is an artifact of interpolation between bins, and
+`lattice_seed`'s square modes are `[16,0,0]`/`[0,16,0]`.
+
+The **triangular** box uses a different aspect ratio because a triangular
+lattice's primitive cell is oblique: three \(\|k\|=1\) plane waves at
+\(0^\circ,120^\circ,240^\circ\), summed, have real-space period \(4\pi\) along
+\(x\) and \(4\pi/\sqrt3\) along \(y\) (expand
+\(\cos x+2\cos(x/2)\cos(y\sqrt3/2)\) and read off each factor's period).
+Replicating that unit cell \(8\times8\) and resolving it at \(128\) cells per
+side gives \(L_x=32\pi\) (\(dx=2\pi/8\), same as the square box) and
+\(L_y=32\pi/\sqrt3\) (\(dy=\pi/(4\sqrt3)\)) — an anisotropic grid spacing, not
+a smaller domain; still \(128\times128\) cells. `lattice_seed`'s triangular
+modes, `[16,0,0]`, `[-8,8,0]`, `[-8,-8,0]`, are the integer mode counts that
+put all three wavevectors exactly at \(\|k\|=1\) on *this* grid (checked
+directly: \(k_x=n_x/16\), \(k_y=n_y\sqrt3/16\) from the grid spacings above,
+so e.g. \((-8,8)\to(-\tfrac12,\tfrac{\sqrt3}2)\), magnitude 1).
+
+A square box forced onto the triangular seed would misalign the three plane
+waves with the periodic boundary and inject a spurious strain/defect at the
+seam — using each lattice's own commensurate box is what keeps the seeded
+single-crystal runs a clean test of *whether the kernel preserves the
+imposed symmetry*, not of *whether the box fights it*. Conversely, the two
+noise-seeded runs sharing the *same* square box (`single_mode_triangular` and
+`two_mode_square`) is deliberate: the issue's matched-conditions comparison
+needs one box, not each kernel's favourite.
+
 ## Running
 
 ```bash
@@ -155,6 +358,18 @@ mpirun -n 4 ./apps/higher_order_pfc/higher_order_pfc \
 
 Create `results/higher_order_pfc/` first. GPU builds also provide
 `higher_order_pfc_hip` when rocFFT HeFFTe is on.
+
+```bash
+# crystal-selection benchmark, single rank (order metric needs the whole grid)
+for case in single_mode_triangular two_mode_square two_mode_degenerate \
+            single_mode_seed_triangular two_mode_seed_square; do
+  ./apps/higher_order_pfc/higher_order_pfc \
+      ../apps/higher_order_pfc/inputs_json/${case}.json
+done
+# results/higher_order_pfc/<case>_diagnostics.csv: mean_psi, free_energy_density,
+# k1, domain_length, k_peak, dominant_wavelength, S_at_1, S_at_q1,
+# psi4_global, psi4_local, psi6_global, psi6_local, n_peaks, mean_neighbours
+```
 
 ### LUMI-G
 
@@ -189,6 +404,23 @@ golden dump:
 - A seeded run selects the preferred band and leaves out-of-band power three
   orders of magnitude below it.
 
+`#118` additions, all still checked against exact or analytical references,
+not golden dumps:
+
+- `bond_orientational_order` on an analytically constructed ideal square
+  lattice gives \((\psi_4,\psi_6)=(1,0)\) to \(10^{-9}\); an ideal triangular
+  lattice gives \((0,1)\) to \(10^{-9}\) — the key test the issue asks for.
+- The order parameter is orientation-blind (a rotated square lattice still
+  gives \(\psi_4=1\)) but sensitive to *relative* orientation: two square
+  grains at \(45^\circ\) to each other suppress the global average while the
+  local one stays near 1 — the polycrystal-vs-single-crystal distinction the
+  benchmark relies on.
+- Peak detection plus bond order on a `lattice_seed`-initialised field
+  recovers \(\psi_4\gtrsim0.8\) end-to-end, not just on hand-built points.
+- `FreeEnergySampler` matches the elementary \(k=0\) formula exactly on a
+  constant field, and its `mean_psi` tracks exact mass conservation through
+  ETD steps to \(10^{-12}\).
+
 ## Code layout
 
 | Piece | Location |
@@ -196,5 +428,8 @@ golden dump:
 | Polynomial kernel helper | [`correlation_kernel.hpp`](include/higher_order_pfc/correlation_kernel.hpp) |
 | Physics / schema / symbols | [`higher_order_pfc_physics.hpp`](include/higher_order_pfc/higher_order_pfc_physics.hpp) |
 | Local nonlinearity (host + device) | [`higher_order_pfc_pointwise.hpp`](include/higher_order_pfc/higher_order_pfc_pointwise.hpp) |
-| Session wiring | [`higher_order_pfc_session.hpp`](include/higher_order_pfc/higher_order_pfc_session.hpp) |
-| Initial conditions | [`cosine_mode.hpp`](include/higher_order_pfc/cosine_mode.hpp), [`seeded_noise.hpp`](include/higher_order_pfc/seeded_noise.hpp) |
+| Session wiring + diagnostics hook | [`higher_order_pfc_session.hpp`](include/higher_order_pfc/higher_order_pfc_session.hpp) |
+| Initial conditions | [`cosine_mode.hpp`](include/higher_order_pfc/cosine_mode.hpp), [`seeded_noise.hpp`](include/higher_order_pfc/seeded_noise.hpp), [`lattice_seed.hpp`](include/higher_order_pfc/lattice_seed.hpp) |
+| Free energy + reciprocal-space sample | [`free_energy.hpp`](include/higher_order_pfc/free_energy.hpp) |
+| Real-space bond-orientational order | [`order_parameter.hpp`](include/higher_order_pfc/order_parameter.hpp) |
+| Diagnostics sample + CSV | [`diagnostics.hpp`](include/higher_order_pfc/diagnostics.hpp) |

--- a/apps/higher_order_pfc/include/higher_order_pfc/diagnostics.hpp
+++ b/apps/higher_order_pfc/include/higher_order_pfc/diagnostics.hpp
@@ -1,0 +1,161 @@
+// SPDX-FileCopyrightText: 2026 VTT Technical Research Centre of Finland Ltd
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+#pragma once
+
+/**
+ * @file diagnostics.hpp
+ * @brief Crystal-selection benchmark sample: energy, reciprocal peaks, real-
+ *        space symmetry -- all three per `#118`, not ring power alone.
+ *
+ * @details
+ * Wraps `FreeEnergySampler` (free-energy density, mean density, the
+ * azimuthally averaged structure factor) and `bond_orientational_order`
+ * (real-space \f$\psi_4\f$/\f$\psi_6\f$) into one collective sample plus a
+ * never-overwriting rank-0 CSV, the same shape as
+ * `cahn_hilliard::Diagnostics`/`DiagnosticCSV`.
+ *
+ * The real-space order metric needs the whole grid on one rank -- finding a
+ * peak's nearest neighbours across a rank boundary is not a reduction, unlike
+ * the structure factor. So it is only computed when `nproc == 1`; on more
+ * ranks the sample still reports free energy and reciprocal peaks (both
+ * genuinely collective), and `psi4`/`psi6` come back `NaN` with `n_peaks =
+ * 0`, which is the honest signal that the real-space classification was not
+ * run, not that the crystal has no order. Every case shipped with this
+ * benchmark runs single-rank for exactly this reason; see the app README.
+ */
+
+#include <cmath>
+#include <cstdio>
+#include <filesystem>
+#include <iomanip>
+#include <limits>
+#include <locale>
+#include <memory>
+#include <sstream>
+#include <stdexcept>
+#include <string>
+
+#include <mpi.h>
+
+#include <higher_order_pfc/free_energy.hpp>
+#include <higher_order_pfc/higher_order_pfc_physics.hpp>
+#include <higher_order_pfc/order_parameter.hpp>
+
+namespace higher_order_pfc {
+
+struct DiagnosticSample {
+  double mean_psi{0.0};
+  double free_energy_density{0.0};
+  double k1{0.0}, domain_length{0.0}, k_peak{0.0}, dominant_wavelength{0.0};
+  double S_at_1{0.0}, S_at_q1{0.0};
+  double psi4_global{0.0}, psi4_local{0.0};
+  double psi6_global{0.0}, psi6_local{0.0};
+  double n_peaks{0.0};
+  double mean_neighbours{0.0};
+};
+
+template <class MemorySpace> class Diagnostics {
+  using Ops = pfc::sim::SpectralETDOps<MemorySpace>;
+
+public:
+  Diagnostics(const pfc::Domain &domain, typename Ops::FFT &fft, MPI_Comm comm)
+      : m_domain(domain), m_comm(comm), m_energy(domain, fft, comm) {}
+
+  DiagnosticSample sample(typename Ops::RealField &psi, const HigherOrderPFCParams &p,
+                          int sf_bins = 64, double neighbour_cutoff_factor = 1.3) {
+    DiagnosticSample out;
+    const auto fe = m_energy.sample(psi, p, sf_bins);
+    out.mean_psi = fe.mean_psi;
+    out.free_energy_density = fe.free_energy_density;
+    out.k1 = fe.sf.k1;
+    out.domain_length = fe.sf.domain_length();
+    out.k_peak = fe.sf.k_peak;
+    out.dominant_wavelength = fe.sf.dominant_wavelength();
+    out.S_at_1 = fe.S_at_1;
+    out.S_at_q1 = fe.S_at_q1;
+
+    int rank = 0, nproc = 1;
+    MPI_Comm_rank(m_comm, &rank);
+    MPI_Comm_size(m_comm, &nproc);
+    if (nproc == 1) {
+      const auto n = pfc::domain::get_size(m_domain);
+      const auto dx = pfc::domain::get_spacing(m_domain);
+      const auto peaks = detect_peaks(psi, n[0], n[1], dx[0], dx[1]);
+      const double Lx = dx[0] * double(n[0]);
+      const double Ly = dx[1] * double(n[1]);
+      const auto bo = bond_orientational_order(peaks, Lx, Ly, neighbour_cutoff_factor);
+      out.psi4_global = bo.psi4.global;
+      out.psi4_local = bo.psi4.local;
+      out.psi6_global = bo.psi6.global;
+      out.psi6_local = bo.psi6.local;
+      out.n_peaks = double(bo.n_points);
+      out.mean_neighbours = bo.mean_neighbours;
+    } else {
+      out.psi4_global = out.psi4_local = std::numeric_limits<double>::quiet_NaN();
+      out.psi6_global = out.psi6_local = std::numeric_limits<double>::quiet_NaN();
+      out.n_peaks = 0.0;
+    }
+    return out;
+  }
+
+private:
+  pfc::Domain m_domain;
+  MPI_Comm m_comm;
+  FreeEnergySampler<MemorySpace> m_energy;
+};
+
+/// Rank-zero CSV with collective failure propagation. Never replaces old data.
+class DiagnosticCSV {
+public:
+  DiagnosticCSV(const std::filesystem::path &path, MPI_Comm comm) : m_comm(comm) {
+    MPI_Comm_rank(comm, &m_rank);
+    int ok = 1;
+    if (m_rank == 0) {
+      try {
+        if (path.has_parent_path())
+          std::filesystem::create_directories(path.parent_path());
+        m_out.reset(std::fopen(path.string().c_str(), "wx"));
+        if (!m_out) throw std::runtime_error("open failed");
+        ok = publish(
+            "step,time,mean_psi,free_energy_density,k1,domain_length,k_peak,"
+            "dominant_wavelength,S_at_1,S_at_q1,psi4_global,psi4_local,"
+            "psi6_global,psi6_local,n_peaks,mean_neighbours\n");
+      } catch (const std::exception &) {
+        ok = 0;
+      }
+    }
+    MPI_Bcast(&ok, 1, MPI_INT, 0, comm);
+    if (!ok)
+      throw std::runtime_error("diagnostics: cannot create fresh CSV: " +
+                               path.string());
+  }
+
+  void write(int step, double time, const DiagnosticSample &s) {
+    int ok = 1;
+    if (m_rank == 0) {
+      std::ostringstream line;
+      line.imbue(std::locale::classic());
+      line << std::setprecision(17) << step << ',' << time << ',' << s.mean_psi
+           << ',' << s.free_energy_density << ',' << s.k1 << ',' << s.domain_length
+           << ',' << s.k_peak << ',' << s.dominant_wavelength << ',' << s.S_at_1
+           << ',' << s.S_at_q1 << ',' << s.psi4_global << ',' << s.psi4_local << ','
+           << s.psi6_global << ',' << s.psi6_local << ',' << s.n_peaks << ','
+           << s.mean_neighbours << '\n';
+      ok = publish(line.str());
+    }
+    MPI_Bcast(&ok, 1, MPI_INT, 0, m_comm);
+    if (!ok) throw std::runtime_error("diagnostics: CSV write failed");
+  }
+
+private:
+  bool publish(const std::string &line) {
+    return std::fputs(line.c_str(), m_out.get()) >= 0 &&
+           std::fflush(m_out.get()) == 0;
+  }
+  MPI_Comm m_comm;
+  int m_rank{};
+  std::unique_ptr<std::FILE, decltype(&std::fclose)> m_out{nullptr, &std::fclose};
+};
+
+} // namespace higher_order_pfc

--- a/apps/higher_order_pfc/include/higher_order_pfc/free_energy.hpp
+++ b/apps/higher_order_pfc/include/higher_order_pfc/free_energy.hpp
@@ -1,0 +1,157 @@
+// SPDX-FileCopyrightText: 2026 VTT Technical Research Centre of Finland Ltd
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+#pragma once
+
+/**
+ * @file free_energy.hpp
+ * @brief Free-energy density and reciprocal-space peak sampling for the
+ *        two-mode PFC crystal-selection benchmark (`#118`).
+ *
+ * @details
+ * Evaluates the same free energy the kernel comment in
+ * `higher_order_pfc_physics.hpp` writes down,
+ *
+ * \f[
+ *   f = \frac1V\int\Bigl[\tfrac12\psi\,\Lambda(\nabla^2)\,\psi
+ *                        -\tfrac{g}{3}\psi^3+\tfrac14\psi^4\Bigr]\,d\mathbf r ,
+ * \f]
+ *
+ * as a mean over grid cells (uniform `dx` makes the volume integral and the
+ * cell average the same number). The quadratic term is evaluated the way
+ * `cahn_hilliard::Diagnostics` evaluates its gradient energy: apply the
+ * kernel to the transform, invert, and dot with \f$\psi\f$ in real space,
+ * rather than trusting a hand-rolled Parseval normalisation. The same
+ * transform feeds `pfc::apps::shell_average` for the reciprocal-space report,
+ * so this costs one extra FFT pair per sample, not two.
+ *
+ * Single-rank use only (see `higher_order_pfc_benchmark.cpp`): the benchmark
+ * driver needs the whole grid on one rank anyway for the real-space order
+ * metric in `order_parameter.hpp`, so this sampler does not attempt a
+ * decomposition-aware gather.
+ */
+
+#include <cmath>
+#include <complex>
+#include <cstddef>
+#include <vector>
+
+#include <mpi.h>
+
+#include <openpfc/kernel/data/domain.hpp>
+#include <openpfc/kernel/data/grid_field.hpp>
+#include <openpfc/kernel/fft/kspace_iterator.hpp>
+#include <openpfc/kernel/simulation/spectral_etd_ops.hpp>
+
+#include <higher_order_pfc/higher_order_pfc_physics.hpp>
+#include <openpfc_apps/structure_factor.hpp>
+
+namespace higher_order_pfc {
+
+/// One diagnostic sample: mass, free-energy density and the reciprocal-space
+/// report needed to classify which correlation band(s) carry the pattern.
+struct FreeEnergySample {
+  double mean_psi{0.0};
+  double free_energy_density{0.0};
+  pfc::apps::StructureFactor sf{};
+  double S_at_1{0.0};   ///< shell power in the bin nearest \f$|k|=1\f$
+  double S_at_q1{0.0};  ///< shell power in the bin nearest \f$|k|=q_1\f$
+};
+
+/// Nearest-bin lookup: `sf.k`/`sf.S` are shell centres, not a dense grid, so
+/// picking a value at a target wavenumber means finding the closest shell.
+///
+/// A target that sits exactly on a bin boundary (as `k=1` does for the
+/// shipped grid's default `n_bins=64`, where the bin width divides 1 evenly)
+/// is equidistant from two shells. Break that tie towards the shell that
+/// actually carries power, not the lower-index one: for a sharp, nearly
+/// single-mode field (a `lattice_seed` run, say) the "wrong" neighbour of an
+/// exact-boundary target can be essentially empty, which would silently
+/// report zero at a wavenumber that is, in fact, the dominant peak.
+[[nodiscard]] inline double power_near(const pfc::apps::StructureFactor &sf,
+                                       double k_target) {
+  if (sf.k.empty()) return 0.0;
+  std::size_t best = 0;
+  double best_d = std::abs(sf.k[0] - k_target);
+  for (std::size_t i = 1; i < sf.k.size(); ++i) {
+    const double d = std::abs(sf.k[i] - k_target);
+    if (d < best_d || (d == best_d && sf.S[i] > sf.S[best])) {
+      best_d = d;
+      best = i;
+    }
+  }
+  return sf.S[best];
+}
+
+template <class MemorySpace = pfc::HostSpace> class FreeEnergySampler {
+  using Ops = pfc::sim::SpectralETDOps<MemorySpace>;
+
+public:
+  FreeEnergySampler(const pfc::Domain &domain, typename Ops::FFT &fft, MPI_Comm comm)
+      : m_domain(domain), m_fft(fft), m_comm(comm),
+        m_hat(domain, fft.get_outbox_bounds(), 0),
+        m_quad(domain, fft.get_inbox_bounds(), 0) {}
+
+  FreeEnergySample sample(typename Ops::RealField &psi, const HigherOrderPFCParams &p,
+                          int sf_bins = 64) {
+    FreeEnergySample out;
+    const auto n = pfc::domain::get_size(m_domain);
+    const double count = double(n[0]) * n[1] * n[2];
+
+    double local_mean = 0.0, local_local_terms = 0.0;
+    psi.with_host_view([&](double *v, std::size_t m) {
+      for (std::size_t i = 0; i < m; ++i) {
+        local_mean += v[i];
+        const double v2 = v[i] * v[i];
+        local_local_terms += -(p.g / 3.0) * v2 * v[i] + 0.25 * v2 * v2;
+      }
+    });
+
+    // Lambda(u) applied on the transform, inverted, dotted with psi in real
+    // space: the quadratic term of F, computed the same way the ETD system
+    // computes any other spectral multiplier, not via a separate Parseval sum.
+    Ops::forward(m_fft, psi, m_hat);
+    std::vector<double> weights(m_fft.size_outbox(), 0.0);
+    pfc::fft::kspace::for_each_kpoint(
+        m_fft.get_outbox_bounds(), m_domain,
+        [&](std::size_t i, double kx, double ky, double kz, int, int, int) {
+          weights[i] = p.kernel(-(kx * kx + ky * ky + kz * kz));
+        });
+    typename Ops::real_coeffs w;
+    Ops::upload(w, weights);
+    typename Ops::complex_scratch work = Ops::make_complex(m_fft.size_outbox());
+    Ops::multiply(m_hat, w, work);
+    Ops::backward(m_fft, work, m_quad);
+
+    double local_quad = 0.0;
+    psi.with_host_view([&](double *v, std::size_t m) {
+      m_quad.with_host_view(
+          [&](double *lv, std::size_t) {
+            for (std::size_t i = 0; i < m; ++i) local_quad += 0.5 * v[i] * lv[i];
+          });
+    });
+
+    m_hat.with_host_view([&](std::complex<double> *hat, std::size_t) {
+      out.sf = pfc::apps::shell_average(m_fft.get_outbox_bounds(), m_domain, hat,
+                                        m_comm, sf_bins);
+    });
+
+    double global[2]{};
+    double local[2] = {local_mean, local_local_terms + local_quad};
+    MPI_Allreduce(local, global, 2, MPI_DOUBLE, MPI_SUM, m_comm);
+    out.mean_psi = global[0] / count;
+    out.free_energy_density = global[1] / count;
+    out.S_at_1 = power_near(out.sf, 1.0);
+    out.S_at_q1 = power_near(out.sf, p.q1);
+    return out;
+  }
+
+private:
+  pfc::Domain m_domain;
+  typename Ops::FFT &m_fft;
+  MPI_Comm m_comm;
+  typename Ops::ComplexField m_hat;
+  typename Ops::RealField m_quad;
+};
+
+} // namespace higher_order_pfc

--- a/apps/higher_order_pfc/include/higher_order_pfc/higher_order_pfc_session.hpp
+++ b/apps/higher_order_pfc/include/higher_order_pfc/higher_order_pfc_session.hpp
@@ -13,15 +13,23 @@
  * without dealiasing the aliased content folds straight back onto the
  * \f$k\approx1\f$ band the kernel is trying to select.
  *
- * `register_catalog()` adds `cosine_mode` and `seeded_noise`. HIP builds also
- * define `HigherOrderPFCHIPSession` on `GPUSpectralStack<HIPSpace>`.
+ * `register_catalog()` adds `cosine_mode`, `seeded_noise` and `lattice_seed`
+ * (the controlled single-crystal seed used by the crystal-selection
+ * benchmark, `lattice_seed.hpp`). Optional `diagnostics.csv` samples free-
+ * energy density, the reciprocal-space peak report and, single-rank only, the
+ * real-space bond-orientational order parameter (`diagnostics.hpp`) -- the
+ * `#118` crystal-selection observables. HIP builds also define
+ * `HigherOrderPFCHIPSession` on `GPUSpectralStack<HIPSpace>` (no diagnostics;
+ * that session is exercised by the HIP smoke test only).
  */
 
 #include <mpi.h>
 #include <nlohmann/json.hpp>
 
 #include <higher_order_pfc/cosine_mode.hpp>
+#include <higher_order_pfc/diagnostics.hpp>
 #include <higher_order_pfc/higher_order_pfc_physics.hpp>
+#include <higher_order_pfc/lattice_seed.hpp>
 #include <higher_order_pfc/seeded_noise.hpp>
 #include <openpfc/frontend/ui/field_modifier_registry.hpp>
 #include <openpfc/frontend/ui/json_spectral_etd_session.hpp>
@@ -37,6 +45,7 @@ namespace higher_order_pfc {
 inline void register_catalog() {
   pfc::ui::register_field_modifier<CosineMode>("cosine_mode");
   pfc::ui::register_field_modifier<SeededNoise>("seeded_noise");
+  pfc::ui::register_field_modifier<LatticeSeed>("lattice_seed");
 }
 
 inline pfc::sim::SpectralETDOptions etd_options() {
@@ -46,6 +55,8 @@ inline pfc::sim::SpectralETDOptions etd_options() {
   return opt;
 }
 
+/// Adds the optional `diagnostics.csv` sampling hook to `SpectralETDSession`,
+/// the same shape as `cahn_hilliard::DiagnosticSession`.
 class HigherOrderPFCSession
     : public pfc::ui::SpectralETDSession<HigherOrderPFCPhysics<double, pfc::HostSpace>,
                                          pfc::sim::stacks::SpectralCPUStack> {
@@ -56,7 +67,31 @@ public:
 
   HigherOrderPFCSession(const nlohmann::json &settings, int rank, int nproc,
                         MPI_Comm comm = MPI_COMM_WORLD)
-      : Base(settings, rank, nproc, comm, etd_options()) {}
+      : Base(settings, rank, nproc, comm, etd_options()), m_comm(comm) {}
+
+  void run() {
+    if (!settings().contains("diagnostics")) {
+      Base::run();
+      return;
+    }
+    const auto path =
+        settings().at("diagnostics").at("csv").template get<std::string>();
+    if (path.empty()) throw std::invalid_argument("diagnostics.csv must not be empty");
+    const int sf_bins = settings()["diagnostics"].value("sf_bins", 64);
+    const double cutoff = settings()["diagnostics"].value("neighbour_cutoff_factor", 1.3);
+    DiagnosticCSV csv(path, m_comm);
+    Diagnostics<pfc::HostSpace> diagnostics(domain(), fft(), m_comm);
+    auto save = [&] {
+      csv.write(pfc::time::increment(time()), pfc::time::current(time()),
+                diagnostics.sample(psi(), system().physics().params, sf_bins, cutoff));
+    };
+    // Restarts do not invoke the driver's initial-state callback.
+    if (pfc::time::increment(time()) != 0 || pfc::time::done(time())) save();
+    Base::run(save);
+  }
+
+private:
+  MPI_Comm m_comm;
 };
 
 #if defined(OpenPFC_ENABLE_HIP_SPECTRAL)

--- a/apps/higher_order_pfc/include/higher_order_pfc/lattice_seed.hpp
+++ b/apps/higher_order_pfc/include/higher_order_pfc/lattice_seed.hpp
@@ -1,0 +1,123 @@
+// SPDX-FileCopyrightText: 2026 VTT Technical Research Centre of Finland Ltd
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+#pragma once
+
+/**
+ * @file lattice_seed.hpp
+ * @brief Controlled single-crystal initial condition: a sum of plane waves.
+ *
+ * @details
+ * `cosine_mode.hpp` seeds exactly one Fourier mode. `#118` also asks for a
+ * *controlled single-crystal seed* -- an initial condition that starts the
+ * run already at the target symmetry, so a clean run can confirm the kernel
+ * merely *preserves* that symmetry rather than having to *select* it out of
+ * noise. A single lattice is a small sum of plane waves, not one:
+ *
+ * \f[
+ *   \psi(\mathbf x) = \psi_0 + \frac{A}{M}\sum_{m=1}^{M}
+ *     \cos\Bigl(2\pi\bigl(\tfrac{n_x^{(m)}x}{L_x}+\tfrac{n_y^{(m)}y}{L_y}
+ *               +\tfrac{n_z^{(m)}z}{L_z}\bigr)\Bigr) .
+ * \f]
+ *
+ * Two modes at \f$90^\circ\f$ (e.g. \f$(n,0,0)\f$ and \f$(0,n,0)\f$) seed a
+ * square lattice; three at \f$120^\circ\f$ seed a triangular one. Integer
+ * mode counts keep every term exactly periodic, which is what "commensurate
+ * box" means in the case JSON comments -- the mode list is chosen so that
+ * `2*pi*n/L` lands exactly on the kernel's unstable wavenumber(s) for the box
+ * being used; see `apps/higher_order_pfc/README.md`.
+ *
+ * JSON `"type": "lattice_seed"`, `"modes": [[nx,ny,nz], ...]`.
+ */
+
+#include <array>
+#include <cmath>
+#include <numbers>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+#include <nlohmann/json.hpp>
+
+#include <openpfc/kernel/data/box3i.hpp>
+#include <openpfc/kernel/data/domain.hpp>
+#include <openpfc/kernel/field/operations.hpp>
+#include <openpfc/kernel/field/state_access.hpp>
+#include <openpfc/kernel/simulation/field_modifier.hpp>
+
+namespace higher_order_pfc {
+
+class LatticeSeed : public pfc::FieldModifier {
+public:
+  struct Mode {
+    int nx{0}, ny{0}, nz{0};
+  };
+
+  void set_psi0(double psi0) { m_psi0 = psi0; }
+  void set_amplitude(double amplitude) { m_amplitude = amplitude; }
+  void set_modes(std::vector<Mode> modes) { m_modes = std::move(modes); }
+
+  [[nodiscard]] double psi0() const { return m_psi0; }
+  [[nodiscard]] double amplitude() const { return m_amplitude; }
+  [[nodiscard]] const std::vector<Mode> &modes() const { return m_modes; }
+
+  const std::string &get_modifier_name() const override {
+    static const std::string k{"LatticeSeed"};
+    return k;
+  }
+
+  void apply(pfc::field::FieldOutput<double> field, const pfc::Domain &domain,
+             const pfc::Box3i &box, double /*time*/) override {
+    if (m_modes.empty())
+      throw std::invalid_argument("lattice_seed: need at least one mode");
+    const auto size = pfc::domain::get_size(domain);
+    const auto spacing = pfc::domain::get_spacing(domain);
+    const double Lx = spacing[0] * static_cast<double>(size[0]);
+    const double Ly = spacing[1] * static_cast<double>(size[1]);
+    const double Lz = spacing[2] * static_cast<double>(size[2]);
+    const double twopi = 2.0 * std::numbers::pi;
+    std::vector<std::array<double, 3>> k;
+    k.reserve(m_modes.size());
+    for (const auto &m : m_modes) {
+      k.push_back({(Lx > 0.0) ? twopi * static_cast<double>(m.nx) / Lx : 0.0,
+                   (Ly > 0.0) ? twopi * static_cast<double>(m.ny) / Ly : 0.0,
+                   (Lz > 0.0) ? twopi * static_cast<double>(m.nz) / Lz : 0.0});
+    }
+    const double psi0 = m_psi0;
+    const double amp = m_amplitude / static_cast<double>(k.size());
+    pfc::field::apply(field, domain, box, [=](const pfc::Real3 &x) {
+      double s = 0.0;
+      for (const auto &kv : k) s += std::cos(kv[0] * x[0] + kv[1] * x[1] + kv[2] * x[2]);
+      return psi0 + amp * s;
+    });
+  }
+
+private:
+  double m_psi0{0.0};
+  double m_amplitude{0.1};
+  std::vector<Mode> m_modes{};
+};
+
+inline void from_json(const nlohmann::json &j, LatticeSeed &ic) {
+  if (j.value("type", "") != "lattice_seed")
+    throw std::invalid_argument("lattice_seed: incorrect or missing 'type' field.");
+  if (!j.contains("psi0") || !j["psi0"].is_number())
+    throw std::invalid_argument("lattice_seed: missing or invalid 'psi0' field.");
+  if (!j.contains("amplitude") || !j["amplitude"].is_number())
+    throw std::invalid_argument("lattice_seed: missing or invalid 'amplitude' field.");
+  if (!j.contains("modes") || !j["modes"].is_array() || j["modes"].empty())
+    throw std::invalid_argument("lattice_seed: 'modes' must be a nonempty array "
+                                "of [nx, ny, nz] triples.");
+  ic.set_psi0(j["psi0"].get<double>());
+  ic.set_amplitude(j["amplitude"].get<double>());
+  std::vector<LatticeSeed::Mode> modes;
+  modes.reserve(j["modes"].size());
+  for (const auto &mode : j["modes"]) {
+    if (!mode.is_array() || mode.size() != 3)
+      throw std::invalid_argument("lattice_seed: each mode must be [nx, ny, nz].");
+    modes.push_back({mode.at(0).get<int>(), mode.at(1).get<int>(), mode.at(2).get<int>()});
+  }
+  ic.set_modes(std::move(modes));
+}
+
+} // namespace higher_order_pfc

--- a/apps/higher_order_pfc/include/higher_order_pfc/order_parameter.hpp
+++ b/apps/higher_order_pfc/include/higher_order_pfc/order_parameter.hpp
@@ -1,0 +1,261 @@
+// SPDX-FileCopyrightText: 2026 VTT Technical Research Centre of Finland Ltd
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+#pragma once
+
+/**
+ * @file order_parameter.hpp
+ * @brief Real-space bond-orientational order metric for PFC crystal
+ *        classification (`#118`).
+ *
+ * @details
+ * `#118`'s complaint is that the existing report infers "square" or
+ * "triangular" from which reciprocal-space ring carries power. A ring is a
+ * necessary but not sufficient witness: two independent plane-wave families
+ * at \f$|k|=1\f$ can beat together into several different real-space
+ * patterns, only one of which is actually square. This header adds the
+ * missing real-space check.
+ *
+ * The metric is the standard bond-orientational order parameter used to tell
+ * 2D crystal symmetries apart (Nelson & Halperin, Phys. Rev. B 19, 2457
+ * (1979), for the melting-transition context the parameter was introduced
+ * in): treat each density peak as a "particle", find its near neighbours, and
+ * average \f$e^{in\theta}\f$ over the bond angles \f$\theta\f$ to those
+ * neighbours,
+ *
+ * \f[
+ *   \psi_n(j) = \frac{1}{N_b(j)}\sum_{k \in \text{neighbours}(j)} e^{in\theta_{jk}} .
+ * \f]
+ *
+ * A perfect square lattice with its 4 nearest neighbours gives
+ * \f$|\psi_4|=1,\ \psi_6=0\f$ exactly (bond angles \f$0,\tfrac\pi2,\pi,
+ * \tfrac{3\pi}2\f$: \f$4\theta\f$ is a multiple of \f$2\pi\f$ every time,
+ * \f$6\theta\f$ alternates sign in pairs and cancels). A perfect triangular
+ * lattice with its 6 nearest neighbours gives the reverse, \f$\psi_4=0,\
+ * |\psi_6|=1\f$ exactly (bond angles \f$60^\circ\f$ apart). That clean
+ * separation, verified analytically in the test suite, is what makes
+ * \f$(\psi_4,\psi_6)\f$ a real structural classifier rather than another
+ * reciprocal-space proxy.
+ *
+ * Two averages are reported for each order:
+ *
+ * - **global**: the magnitude of the *complex* average of \f$\psi_n(j)\f$
+ *   over all peaks. Grains at different orientations have \f$\psi_n(j)\f$
+ *   pointing in different directions, so their contributions partially
+ *   cancel; a noise-seeded polycrystal gives a suppressed global value even
+ *   when every grain is locally well ordered. This is the number that
+ *   answers "is this one crystal or many misoriented grains".
+ * - **local**: the average of \f$|\psi_n(j)|\f$, orientation blind. This
+ *   answers "is each neighbourhood locally ordered at all", independent of
+ *   whether the grains agree with each other.
+ *
+ * Neighbours are found within a cutoff derived from the point set's own
+ * nearest-neighbour distance (`neighbour_cutoff_factor` times the median
+ * nearest-neighbour distance), not a value the caller has to know the
+ * lattice spacing to supply. `1.3` sits strictly between the square lattice's
+ * first shell (distance \f$a\f$) and its diagonal second shell
+ * (\f$a\sqrt2\approx1.41a\f$), and strictly below the triangular lattice's
+ * second shell (\f$a\sqrt3\approx1.73a\f$), so the default admits exactly the
+ * first neighbour shell for both lattices without extra tuning.
+ *
+ * Peak detection on a simulated field is a periodic 8-neighbour local-maximum
+ * test at grid resolution (no sub-cell refinement); see `detect_peaks`. That
+ * is coarser than a crystallographer would want for a lattice-constant
+ * measurement, which is why this module reports *symmetry* (a normalised
+ * ratio), not absolute peak positions -- the reciprocal-space report in
+ * `free_energy.hpp` already gives sub-bin-averaged wavenumbers for that.
+ */
+
+#include <algorithm>
+#include <cmath>
+#include <complex>
+#include <cstddef>
+#include <limits>
+#include <numbers>
+#include <vector>
+
+#include <openpfc/kernel/data/grid_field.hpp>
+
+namespace higher_order_pfc {
+
+/// A detected density peak, in physical (not grid-index) coordinates.
+struct Peak {
+  double x{0.0};
+  double y{0.0};
+};
+
+/// Bond-orientational order for one harmonic \f$n\f$, both averages.
+struct BondOrder {
+  double global{0.0};  ///< |mean_j psi_n(j)|      -- single-crystal check
+  double local{0.0};   ///< mean_j |psi_n(j)|       -- local-order check
+};
+
+/// \f$\psi_4\f$ and \f$\psi_6\f$ together, plus how many peaks/bonds went in.
+struct BondOrientationalOrder {
+  BondOrder psi4{};
+  BondOrder psi6{};
+  std::size_t n_points{0};
+  double mean_neighbours{0.0};
+};
+
+namespace detail {
+[[nodiscard]] inline double wrap(double d, double L) {
+  if (L <= 0.0) return d;
+  return d - L * std::round(d / L);
+}
+} // namespace detail
+
+/**
+ * @brief Bond-orientational order parameters for a periodic 2D point set.
+ *
+ * @param points  detected peak / lattice-site positions
+ * @param Lx, Ly  periodic box size (minimum-image convention)
+ * @param neighbour_cutoff_factor  cutoff = this * median nearest-neighbour
+ *        distance; see the file comment for why 1.3 separates both lattices'
+ *        first shell cleanly
+ *
+ * \f$O(N^2)\f$ in the number of points; fine for the peak counts a PFC
+ * benchmark grid produces (hundreds, not millions).
+ */
+[[nodiscard]] inline BondOrientationalOrder
+bond_orientational_order(const std::vector<Peak> &points, double Lx, double Ly,
+                         double neighbour_cutoff_factor = 1.3) {
+  BondOrientationalOrder out;
+  const std::size_t N = points.size();
+  out.n_points = N;
+  if (N < 2) return out;
+
+  // Median nearest-neighbour distance sets the cutoff, so the caller never
+  // has to know the lattice spacing in advance.
+  std::vector<double> nn(N, 0.0);
+  for (std::size_t i = 0; i < N; ++i) {
+    double best = std::numeric_limits<double>::infinity();
+    for (std::size_t j = 0; j < N; ++j) {
+      if (i == j) continue;
+      const double dx = detail::wrap(points[j].x - points[i].x, Lx);
+      const double dy = detail::wrap(points[j].y - points[i].y, Ly);
+      best = std::min(best, dx * dx + dy * dy);
+    }
+    nn[i] = std::sqrt(best);
+  }
+  std::vector<double> sorted_nn = nn;
+  std::sort(sorted_nn.begin(), sorted_nn.end());
+  const double median_nn = sorted_nn[sorted_nn.size() / 2];
+  const double r_cut = neighbour_cutoff_factor * median_nn;
+  const double r_cut2 = r_cut * r_cut;
+
+  std::complex<double> sum4{0.0, 0.0}, sum6{0.0, 0.0};
+  double local4 = 0.0, local6 = 0.0;
+  double total_neighbours = 0.0;
+  std::size_t counted = 0;
+  for (std::size_t i = 0; i < N; ++i) {
+    std::complex<double> p4{0.0, 0.0}, p6{0.0, 0.0};
+    std::size_t nb = 0;
+    for (std::size_t j = 0; j < N; ++j) {
+      if (i == j) continue;
+      const double dx = detail::wrap(points[j].x - points[i].x, Lx);
+      const double dy = detail::wrap(points[j].y - points[i].y, Ly);
+      if (dx * dx + dy * dy > r_cut2) continue;
+      const double theta = std::atan2(dy, dx);
+      p4 += std::complex<double>(std::cos(4.0 * theta), std::sin(4.0 * theta));
+      p6 += std::complex<double>(std::cos(6.0 * theta), std::sin(6.0 * theta));
+      ++nb;
+    }
+    if (nb == 0) continue;
+    p4 /= double(nb);
+    p6 /= double(nb);
+    sum4 += p4;
+    sum6 += p6;
+    local4 += std::abs(p4);
+    local6 += std::abs(p6);
+    total_neighbours += double(nb);
+    ++counted;
+  }
+  if (counted == 0) return out;
+  out.psi4.global = std::abs(sum4) / double(counted);
+  out.psi6.global = std::abs(sum6) / double(counted);
+  out.psi4.local = local4 / double(counted);
+  out.psi6.local = local6 / double(counted);
+  out.mean_neighbours = total_neighbours / double(counted);
+  return out;
+}
+
+/**
+ * @brief Ideal square lattice point set on a periodic \f$L\times L\f$ box.
+ *
+ * `n_cells` lattice constants per side, so `Lx = Ly = n_cells * a` is exactly
+ * periodic. Used only by the analytical unit tests -- the whole point is to
+ * check `bond_orientational_order` against a lattice built independently of
+ * any peak detector.
+ */
+[[nodiscard]] inline std::vector<Peak> ideal_square_lattice(double a, int n_cells) {
+  std::vector<Peak> pts;
+  pts.reserve(std::size_t(n_cells) * std::size_t(n_cells));
+  for (int j = 0; j < n_cells; ++j)
+    for (int i = 0; i < n_cells; ++i) pts.push_back({i * a, j * a});
+  return pts;
+}
+
+/**
+ * @brief Ideal triangular lattice point set on a periodic box.
+ *
+ * Primitive vectors \f$a_1=(a,0)\f$, \f$a_2=(a/2,a\sqrt3/2)\f$, so the
+ * commensurate rectangular box is \f$L_x=n_x a\f$,
+ * \f$L_y=n_y a\sqrt3\f$ with \f$n_y\f$ rows of two offset sub-rows each.
+ */
+[[nodiscard]] inline std::vector<Peak> ideal_triangular_lattice(double a, int n_x,
+                                                                int n_y) {
+  std::vector<Peak> pts;
+  const double row_h = a * std::numbers::sqrt3 / 2.0;
+  for (int j = 0; j < 2 * n_y; ++j) {
+    const double y = j * row_h;
+    const double x_offset = (j % 2 == 0) ? 0.0 : 0.5 * a;
+    for (int i = 0; i < n_x; ++i) pts.push_back({i * a + x_offset, y});
+  }
+  return pts;
+}
+
+/**
+ * @brief Local density maxima on a periodic 2D real-space field.
+ *
+ * A grid point is a peak if it is `>=` all 8 periodic neighbours and strictly
+ * above the field mean (drops flat/interstitial regions in a disordered or
+ * still-relaxing field). Grid resolution only, no sub-cell refinement -- see
+ * the file comment for why that is acceptable here.
+ *
+ * @param psi   whole-domain field (single rank; box must cover the domain)
+ * @param nx,ny grid size
+ * @param dx,dy grid spacing
+ */
+[[nodiscard]] inline std::vector<Peak>
+detect_peaks(const pfc::data::Field<double> &psi, int nx, int ny, double dx,
+            double dy) {
+  double mean = 0.0;
+  for (int j = 0; j < ny; ++j)
+    for (int i = 0; i < nx; ++i) mean += psi(i, j, 0);
+  mean /= double(nx) * double(ny);
+
+  std::vector<Peak> peaks;
+  for (int j = 0; j < ny; ++j) {
+    for (int i = 0; i < nx; ++i) {
+      const double v = psi(i, j, 0);
+      if (v <= mean) continue;
+      bool is_peak = true;
+      for (int dj = -1; dj <= 1 && is_peak; ++dj) {
+        for (int di = -1; di <= 1; ++di) {
+          if (di == 0 && dj == 0) continue;
+          const int ii = ((i + di) % nx + nx) % nx;
+          const int jj = ((j + dj) % ny + ny) % ny;
+          if (psi(ii, jj, 0) > v) {
+            is_peak = false;
+            break;
+          }
+        }
+      }
+      if (is_peak) peaks.push_back({i * dx, j * dy});
+    }
+  }
+  return peaks;
+}
+
+} // namespace higher_order_pfc

--- a/apps/higher_order_pfc/inputs_json/single_mode_seed_triangular.json
+++ b/apps/higher_order_pfc/inputs_json/single_mode_seed_triangular.json
@@ -15,32 +15,32 @@
         "Ly": 128,
         "Lz": 1,
         "dx": 0.7853981633974483,
-        "dy": 0.7853981633974483,
+        "dy": 0.45344984105855446,
         "dz": 0.7853981633974483,
         "origin": "corner"
     },
     "timestepping": {
         "t0": 0.0,
-        "t1": 400.0,
+        "t1": 100.0,
         "dt": 0.05,
         "saveat": 20.0
     },
     "fields": [
         {
             "name": "psi",
-            "data": "results/higher_order_pfc/single_mode_%04d.vti"
+            "data": "results/higher_order_pfc/single_mode_seed_triangular_%04d.vti"
         }
     ],
     "initial_conditions": [
         {
             "target": "psi",
-            "type": "seeded_noise",
+            "type": "lattice_seed",
             "psi0": -0.15,
-            "amplitude": 0.01,
-            "seed": 42
+            "amplitude": 0.2,
+            "modes": [[16, 0, 0], [-8, 8, 0], [-8, -8, 0]]
         }
     ],
     "diagnostics": {
-        "csv": "results/higher_order_pfc/single_mode_triangular_diagnostics.csv"
+        "csv": "results/higher_order_pfc/single_mode_seed_triangular_diagnostics.csv"
     }
 }

--- a/apps/higher_order_pfc/inputs_json/single_mode_seed_triangular.json.license
+++ b/apps/higher_order_pfc/inputs_json/single_mode_seed_triangular.json.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: 2026 VTT Technical Research Centre of Finland Ltd
+SPDX-License-Identifier: AGPL-3.0-or-later

--- a/apps/higher_order_pfc/inputs_json/two_mode_degenerate.json
+++ b/apps/higher_order_pfc/inputs_json/two_mode_degenerate.json
@@ -7,7 +7,7 @@
             "r1": 0.0,
             "M": 1.0,
             "g": 0.5,
-            "n_modes": 1
+            "n_modes": 2
         }
     },
     "domain": {
@@ -23,12 +23,12 @@
         "t0": 0.0,
         "t1": 400.0,
         "dt": 0.05,
-        "saveat": 20.0
+        "saveat": 40.0
     },
     "fields": [
         {
             "name": "psi",
-            "data": "results/higher_order_pfc/single_mode_%04d.vti"
+            "data": "results/higher_order_pfc/two_mode_degenerate_%04d.vti"
         }
     ],
     "initial_conditions": [
@@ -41,6 +41,6 @@
         }
     ],
     "diagnostics": {
-        "csv": "results/higher_order_pfc/single_mode_triangular_diagnostics.csv"
+        "csv": "results/higher_order_pfc/two_mode_degenerate_diagnostics.csv"
     }
 }

--- a/apps/higher_order_pfc/inputs_json/two_mode_degenerate.json.license
+++ b/apps/higher_order_pfc/inputs_json/two_mode_degenerate.json.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: 2026 VTT Technical Research Centre of Finland Ltd
+SPDX-License-Identifier: AGPL-3.0-or-later

--- a/apps/higher_order_pfc/inputs_json/two_mode_seed_square.json
+++ b/apps/higher_order_pfc/inputs_json/two_mode_seed_square.json
@@ -4,10 +4,10 @@
         "params": {
             "eps": 0.25,
             "q1": 1.4142135623730951,
-            "r1": 0.0,
+            "r1": 0.02,
             "M": 1.0,
             "g": 0.5,
-            "n_modes": 1
+            "n_modes": 2
         }
     },
     "domain": {
@@ -21,26 +21,26 @@
     },
     "timestepping": {
         "t0": 0.0,
-        "t1": 400.0,
+        "t1": 100.0,
         "dt": 0.05,
         "saveat": 20.0
     },
     "fields": [
         {
             "name": "psi",
-            "data": "results/higher_order_pfc/single_mode_%04d.vti"
+            "data": "results/higher_order_pfc/two_mode_seed_square_%04d.vti"
         }
     ],
     "initial_conditions": [
         {
             "target": "psi",
-            "type": "seeded_noise",
+            "type": "lattice_seed",
             "psi0": -0.15,
-            "amplitude": 0.01,
-            "seed": 42
+            "amplitude": 0.2,
+            "modes": [[16, 0, 0], [0, 16, 0]]
         }
     ],
     "diagnostics": {
-        "csv": "results/higher_order_pfc/single_mode_triangular_diagnostics.csv"
+        "csv": "results/higher_order_pfc/two_mode_seed_square_diagnostics.csv"
     }
 }

--- a/apps/higher_order_pfc/inputs_json/two_mode_seed_square.json.license
+++ b/apps/higher_order_pfc/inputs_json/two_mode_seed_square.json.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: 2026 VTT Technical Research Centre of Finland Ltd
+SPDX-License-Identifier: AGPL-3.0-or-later

--- a/apps/higher_order_pfc/inputs_json/two_mode_square.json
+++ b/apps/higher_order_pfc/inputs_json/two_mode_square.json
@@ -39,5 +39,8 @@
             "amplitude": 0.01,
             "seed": 42
         }
-    ]
+    ],
+    "diagnostics": {
+        "csv": "results/higher_order_pfc/two_mode_square_diagnostics.csv"
+    }
 }

--- a/apps/higher_order_pfc/tests/test_order_parameter.cpp
+++ b/apps/higher_order_pfc/tests/test_order_parameter.cpp
@@ -1,0 +1,267 @@
+// SPDX-FileCopyrightText: 2026 VTT Technical Research Centre of Finland Ltd
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+/**
+ * @file test_order_parameter.cpp
+ * @brief Catch2 tests for the real-space bond-orientational order metric
+ *        and the free-energy/structure-factor sampler added for `#118`.
+ *
+ * @details
+ * The key test the issue asks for: `bond_orientational_order` on
+ * *analytically constructed* ideal square and triangular lattices (not on
+ * anything peak-detected from a simulated field) returns the exact values
+ * derived in `order_parameter.hpp`'s file comment,
+ * \f$(\psi_4,\psi_6)=(1,0)\f$ for square and \f$(0,1)\f$ for triangular. That
+ * is what makes \f$(\psi_4,\psi_6)\f$ usable as a real structural classifier.
+ * A looser end-to-end test then checks the same thing through the actual
+ * peak detector on a `lattice_seed`-initialised field, and
+ * `FreeEnergySampler` is checked against a constant field, where the free
+ * energy density is elementary algebra.
+ *
+ * This file has no `main()`; it links into `test_higher_order_pfc`, which
+ * owns the Catch2 session and `MPI_Init`/`MPI_Finalize`.
+ */
+
+#include <catch2/catch_approx.hpp>
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_floating_point.hpp>
+
+#include <cmath>
+#include <mpi.h>
+#include <numbers>
+
+#include <nlohmann/json.hpp>
+
+#include <higher_order_pfc/free_energy.hpp>
+#include <higher_order_pfc/higher_order_pfc_physics.hpp>
+#include <higher_order_pfc/lattice_seed.hpp>
+#include <higher_order_pfc/order_parameter.hpp>
+#include <higher_order_pfc/seeded_noise.hpp>
+#include <openpfc/kernel/data/domain.hpp>
+#include <openpfc/kernel/simulation/apply_field_modifier.hpp>
+#include <openpfc/kernel/simulation/spectral_etd_system.hpp>
+#include <openpfc/kernel/simulation/stacks/spectral_cpu_stack.hpp>
+
+using Catch::Matchers::WithinAbs;
+using nlohmann::json;
+
+namespace hop = higher_order_pfc;
+
+namespace {
+int world_size() {
+  int n = 1;
+  MPI_Comm_size(MPI_COMM_WORLD, &n);
+  return n;
+}
+} // namespace
+
+// ---------------------------------------------------------------------------
+// The key test: analytically constructed lattices (acceptance criterion 6)
+// ---------------------------------------------------------------------------
+
+TEST_CASE("Bond-orientational order is exactly (1,0) for an ideal square lattice",
+          "[higher_order_pfc][order][analytical]") {
+  constexpr double a = 1.3; // lattice constant is arbitrary; a ratio is measured
+  constexpr int n_cells = 12;
+  const auto pts = hop::ideal_square_lattice(a, n_cells);
+  REQUIRE(pts.size() == std::size_t(n_cells) * std::size_t(n_cells));
+
+  const auto bo = hop::bond_orientational_order(pts, a * n_cells, a * n_cells, 1.3);
+  REQUIRE(bo.n_points == pts.size());
+  REQUIRE_THAT(bo.mean_neighbours, WithinAbs(4.0, 1e-9)); // 4 nearest neighbours
+  REQUIRE_THAT(bo.psi4.global, WithinAbs(1.0, 1e-9));
+  REQUIRE_THAT(bo.psi4.local, WithinAbs(1.0, 1e-9));
+  REQUIRE_THAT(bo.psi6.global, WithinAbs(0.0, 1e-9));
+  REQUIRE_THAT(bo.psi6.local, WithinAbs(0.0, 1e-9));
+}
+
+TEST_CASE("Bond-orientational order is exactly (0,1) for an ideal triangular lattice",
+          "[higher_order_pfc][order][analytical]") {
+  constexpr double a = 0.9;
+  constexpr int n_x = 12, n_y = 12;
+  const auto pts = hop::ideal_triangular_lattice(a, n_x, n_y);
+  REQUIRE(pts.size() == std::size_t(n_x) * std::size_t(2 * n_y));
+
+  const double Lx = a * n_x;
+  const double Ly = a * std::numbers::sqrt3 * n_y;
+  const auto bo = hop::bond_orientational_order(pts, Lx, Ly, 1.3);
+  REQUIRE(bo.n_points == pts.size());
+  REQUIRE_THAT(bo.mean_neighbours, WithinAbs(6.0, 1e-9)); // 6 nearest neighbours
+  REQUIRE_THAT(bo.psi6.global, WithinAbs(1.0, 1e-9));
+  REQUIRE_THAT(bo.psi6.local, WithinAbs(1.0, 1e-9));
+  REQUIRE_THAT(bo.psi4.global, WithinAbs(0.0, 1e-9));
+  REQUIRE_THAT(bo.psi4.local, WithinAbs(0.0, 1e-9));
+}
+
+TEST_CASE("A rotated square lattice still gives psi4 = 1: the metric is "
+          "orientation-blind, only the box need not be",
+          "[higher_order_pfc][order][analytical]") {
+  // Rotate every point by a fixed angle about the origin; bond angles shift by
+  // the same amount, which leaves |psi_4| invariant. Skip periodicity (huge
+  // box) so the rotation cannot wrap oddly at the edges.
+  constexpr double a = 1.0;
+  constexpr int n_cells = 10;
+  constexpr double theta = 0.37;
+  auto pts = hop::ideal_square_lattice(a, n_cells);
+  const double c = std::cos(theta), s = std::sin(theta);
+  for (auto &p : pts) {
+    const double x = p.x, y = p.y;
+    p.x = c * x - s * y;
+    p.y = s * x + c * y;
+  }
+  const auto bo = hop::bond_orientational_order(pts, 1.0e6, 1.0e6, 1.3);
+  REQUIRE_THAT(bo.psi4.global, WithinAbs(1.0, 1e-9));
+  REQUIRE_THAT(bo.psi6.global, WithinAbs(0.0, 1e-9));
+}
+
+TEST_CASE("A polycrystalline mix of two square grains suppresses the global "
+          "order parameter but not the local one",
+          "[higher_order_pfc][order][analytical]") {
+  // Two square grains at very different orientations, side by side (each
+  // large enough that its own periodic image dominates its neighbour search).
+  // Global psi4 averages the two grains' *complex* order parameters, which
+  // point in different directions and partially cancel; local psi4 does not
+  // care about relative orientation and stays near 1 in both grains.
+  constexpr double a = 1.0;
+  constexpr int n_cells = 10;
+  auto grain_a = hop::ideal_square_lattice(a, n_cells);
+  auto grain_b = hop::ideal_square_lattice(a, n_cells);
+  constexpr double theta = std::numbers::pi / 4.0; // 45 degrees: maximally different
+  const double c = std::cos(theta), s = std::sin(theta);
+  const double shift = a * n_cells * 3.0; // grains far enough apart, own images
+  for (auto &p : grain_b) {
+    const double x = p.x, y = p.y;
+    p.x = c * x - s * y + shift;
+    p.y = s * x + c * y;
+  }
+  std::vector<hop::Peak> both = grain_a;
+  both.insert(both.end(), grain_b.begin(), grain_b.end());
+  const double L = 1.0e7; // effectively non-periodic across the two grains
+  const auto bo = hop::bond_orientational_order(both, L, L, 1.3);
+  REQUIRE(bo.psi4.local > 0.9);   // each grain is still locally square
+  REQUIRE(bo.psi4.global < 0.5);  // but the two grains disagree on orientation
+}
+
+// ---------------------------------------------------------------------------
+// End-to-end: peak detection on a lattice_seed field (looser tolerance)
+// ---------------------------------------------------------------------------
+
+TEST_CASE("Peak detection + bond order recover psi4 ~ 1 on a lattice_seed square field",
+          "[higher_order_pfc][order][pipeline]") {
+  if (world_size() != 1) {
+    SKIP("single-rank whole-grid peak detection");
+  }
+  constexpr int N = 64;
+  constexpr double dx = 2.0 * std::numbers::pi / 8.0; // |k|=1 on mode N/8
+  const auto domain =
+      pfc::domain::create(pfc::GridSize({N, N, 1}), pfc::PhysicalOrigin({0.0, 0.0, 0.0}),
+                          pfc::GridSpacing({dx, dx, dx}));
+  pfc::sim::stacks::SpectralCPUStack stack(domain, 0, 1, MPI_COMM_WORLD);
+  auto &psi = stack.u();
+
+  hop::LatticeSeed seed;
+  seed.set_psi0(0.0);
+  seed.set_amplitude(0.6);
+  seed.set_modes({{N / 8, 0, 0}, {0, N / 8, 0}}); // |k|=1 square: (10) family
+  pfc::apply_field_modifier(seed, psi, 0.0);
+
+  const auto peaks = hop::detect_peaks(psi, N, N, dx, dx);
+  REQUIRE(peaks.size() > 4); // more than a handful of density maxima detected
+  const auto bo = hop::bond_orientational_order(peaks, dx * N, dx * N, 1.3);
+  REQUIRE(bo.psi4.global > 0.8);
+  REQUIRE(bo.psi6.global < 0.3);
+}
+
+// ---------------------------------------------------------------------------
+// power_near tie-breaking (regression: an exact-boundary target must not
+// silently read the empty neighbouring shell)
+// ---------------------------------------------------------------------------
+
+TEST_CASE("power_near breaks an exact-distance tie towards the shell that "
+          "carries power",
+          "[higher_order_pfc][energy][analytical]") {
+  pfc::apps::StructureFactor sf;
+  // Two shells equidistant from k=1.0 (0.5 and 1.5), the lower-index one
+  // empty: exactly the situation a lattice_seed run produces on the shipped
+  // grid, where k=1 sits precisely on a shell boundary.
+  sf.k = {0.5, 1.5};
+  sf.S = {0.0, 42.0};
+  REQUIRE_THAT(hop::power_near(sf, 1.0), WithinAbs(42.0, 1e-15));
+
+  // And the reverse: empty neighbour on the high side.
+  sf.S = {42.0, 0.0};
+  REQUIRE_THAT(hop::power_near(sf, 1.0), WithinAbs(42.0, 1e-15));
+}
+
+// ---------------------------------------------------------------------------
+// FreeEnergySampler against an elementary case
+// ---------------------------------------------------------------------------
+
+TEST_CASE("Free-energy density on a constant field matches the elementary "
+          "k=0 formula",
+          "[higher_order_pfc][energy][analytical]") {
+  if (world_size() != 1) {
+    SKIP("single-rank spectral sampler");
+  }
+  constexpr int N = 16;
+  constexpr double dx = 2.0 * std::numbers::pi / 8.0;
+  constexpr double psi0 = -0.12;
+  const auto domain =
+      pfc::domain::create(pfc::GridSize({N, N, 1}), pfc::PhysicalOrigin({0.0, 0.0, 0.0}),
+                          pfc::GridSpacing({dx, dx, dx}));
+  pfc::sim::stacks::SpectralCPUStack stack(domain, 0, 1, MPI_COMM_WORLD);
+  auto &psi = stack.u();
+  psi.apply([&](double, double, double) { return psi0; });
+
+  const auto p = hop::HigherOrderPFCParams{}; // defaults: eps=0.25, two-mode, g=0
+  hop::FreeEnergySampler<pfc::HostSpace> sampler(domain, stack.fft(), MPI_COMM_WORLD);
+  const auto sample = sampler.sample(psi, p, 32);
+
+  REQUIRE_THAT(sample.mean_psi, WithinAbs(psi0, 1e-12));
+  // Constant field: all spectral weight at k=0, so the quadratic term is
+  // Lambda(0) * psi0^2 / 2 exactly.
+  const double lambda0 = p.kernel(0.0);
+  const double expected =
+      0.5 * lambda0 * psi0 * psi0 - (p.g / 3.0) * psi0 * psi0 * psi0 +
+      0.25 * psi0 * psi0 * psi0 * psi0;
+  REQUIRE_THAT(sample.free_energy_density, WithinAbs(expected, 1e-9));
+}
+
+TEST_CASE("Diagnostics mean_psi tracks exact mass conservation through ETD steps",
+          "[higher_order_pfc][energy][mass]") {
+  if (world_size() != 1) {
+    SKIP("single-rank spectral sampler");
+  }
+  constexpr int N = 32;
+  constexpr double dx = 2.0 * std::numbers::pi / 8.0;
+  constexpr double dt = 0.05;
+  const auto domain =
+      pfc::domain::create(pfc::GridSize({N, N, 1}), pfc::PhysicalOrigin({0.0, 0.0, 0.0}),
+                          pfc::GridSpacing({dx, dx, dx}));
+  pfc::sim::stacks::SpectralCPUStack stack(domain, 0, 1, MPI_COMM_WORLD);
+  auto phys = hop::HigherOrderPFCPhysics<>::from_json(json{{"g", 0.5}}, domain,
+                                                       stack.fft().get_inbox_bounds());
+  pfc::SimulationState state;
+  phys.declare_fields(state);
+  auto &psi = state.get_field<double>("psi");
+  hop::SeededNoise noise; // reuse the app's own decomposition-independent seed
+  noise.psi0 = -0.05;
+  noise.amplitude = 1.0e-2;
+  noise.seed = 5;
+  pfc::apply_field_modifier(noise, psi, 0.0);
+
+  pfc::sim::SpectralETDOptions opt;
+  opt.psi_name = "psi";
+  opt.dealias = true;
+  pfc::sim::SpectralETDSystem<hop::HigherOrderPFCPhysics<>> sys(phys, stack.fft(), state,
+                                                                dt, opt);
+  hop::FreeEnergySampler<pfc::HostSpace> sampler(domain, stack.fft(), MPI_COMM_WORLD);
+  const double mean0 = sampler.sample(psi, phys.params, 16).mean_psi;
+  REQUIRE_THAT(mean0, WithinAbs(-0.05, 1e-12));
+
+  double t = 0.0;
+  for (int step = 0; step < 20; ++step) t = sys.step(t);
+
+  const double mean1 = sampler.sample(psi, phys.params, 16).mean_psi;
+  REQUIRE_THAT(mean1, WithinAbs(mean0, 1e-12));
+}


### PR DESCRIPTION
## What changed

The `higher_order_pfc` app was a strong tenth-order numerical demonstration but,
per `#118`, its "square vs triangular" story was inferred mostly from the shape
of the kernel and from reciprocal-space ring power. This PR turns it into a
reproducible **crystal-selection experiment** with a real-space structural
metric, on top of the existing (unchanged) polynomial-kernel verification.

- **`order_parameter.hpp`** — bond-orientational order \(\psi_4\)/\(\psi_6\)
  from detected real-space density peaks (Nelson & Halperin's classic 2D
  melting-transition metric). Reports both a *global* (complex-averaged,
  orientation-sensitive — distinguishes single crystal from polycrystal) and
  a *local* (orientation-blind) average. Includes analytical ideal-lattice
  point-set generators used only by the tests.
- **`free_energy.hpp`** — free-energy density (same recipe
  `cahn_hilliard::Diagnostics` uses: apply the kernel to the transform,
  invert, dot with \(\psi\) in real space) and a reciprocal-space peak reader
  built on `pfc::apps::shell_average` (reused from `#114`, not reimplemented).
- **`lattice_seed.hpp`** — a new initial condition: an explicit sum of 2–3
  plane waves at a target lattice's reciprocal vectors, for a *controlled
  single-crystal seed*, alongside the existing `seeded_noise` polycrystalline
  IC.
- **`diagnostics.hpp`** — combines all of the above into one sample plus a
  never-overwriting CSV, wired into `HigherOrderPFCSession` the same way
  `cahn_hilliard`'s `DiagnosticSession` works (opt-in via a `diagnostics.csv`
  JSON block). Real-space order only runs single-rank (documented, honest
  limitation — see below).
- **Literature grounding**: cites Wu, Adland & Karma, *Phys. Rev. E* **81**,
  061601 (2010) (arXiv:1001.1349) as the primary two-mode-PFC source and maps
  OpenPFC's `Λ(∇²) = -eps + (1+∇²)²[r1+(q1²+∇²)²]` to their
  `f = (ψ/2)[-ε+(∇²+1)²((∇²+Q1²)²+R1)]ψ + ψ⁴/4` term by term. Their reported
  `Q1 = sqrt(2)` (2D square, ⟨10⟩+⟨11⟩) and `Q1 = 2/sqrt(3)` (3D fcc,
  ⟨111⟩+⟨200⟩) independently match the values already documented in this
  app's README, which is what gives the mapping confidence.
- Five 2D benchmark cases (JSON), three noise-seeded and two `lattice_seed`,
  on two differently-shaped but individually commensurate boxes (derivation
  in the README).
- New tests (`tests/test_order_parameter.cpp`): the key one the issue asks
  for — analytically constructed ideal square/triangular lattices give
  \((\psi_4,\psi_6)=(1,0)\)/\((0,1)\) to \(10^{-9}\) — plus orientation
  blindness, polycrystal-suppression, an end-to-end peak-detection pipeline
  check, free-energy-vs-elementary-formula, mass conservation through the new
  diagnostics path, and a regression test for a `power_near` tie-break bug
  found and fixed while running the benchmark (see "What I found and fixed"
  below).

## Honesty about the literature mapping

The functional form and the `Q1` ratios above were confirmed against the
arXiv preprint (an `ar5iv` HTML fetch, done in this session) — the published
APS-typeset version was not accessible from this machine, and the fetch of
the paper's 2D-square-appendix solid-phase free energy came back with
rendering artefacts in its sub/superscripts I could not cleanly resolve. So:
**verified** — the kernel's reciprocal-space structure and the `Q1` ratios.
**Not verified / not claimed** — the paper's quantitative phase diagram or
elastic-constant fits (their Ni/Fe parameter sets, their `R1`/`eps` stability
boundary). `eps`, `r1` and the mean density used in this benchmark demonstrate
the phase-selection *mechanism*, not a fit to the paper's numbers — calibration
is labelled **representative**, not **quantitative**, in the README's
"Model maturity" row and in the literature section. No citation or
coefficient is invented; where confidence is partial, the README says so
explicitly rather than rounding up.

## Measured phase-selection table

All runs: `higher_order_pfc` CPU build, single rank, LUMI login node,
\(128\times128\), `eps=0.25`, `g=0.5`, mean density \(\bar\psi=-0.15\).

| case | \(f\): initial → final | \(k_{\text{peak}}\) | \(S(\|k\|{=}1)\) final | \(S(\|k\|{=}q_1)\) final | \(\psi_4\) (global, local) | \(\psi_6\) (global, local) | mean neighbours | verdict |
|---|---|---|---|---|---|---|---|---|
| `single_mode_triangular` (noise, t: 0→400) | 0.00970 → 0.00585 | 1.031 | 160132 | 39.5 | (0.014, 0.094) | (0.335, **0.852**) | 5.87 | **triangular**, polycrystalline |
| `two_mode_square` (noise, t: 0→400) | 0.2051 → 0.0389 | 1.031 | 111849 | 27574 | (0.341, **0.806**) | (0.022, 0.247) | 4.04 | **square**, mostly one orientation |
| `two_mode_degenerate`, `r1=0` (noise, t: 0→400) | 0.2048 → 0.0398 | 1.406 ≈ √2 | 3947 | 156486 | (0.005, 0.122) | (0.792, **0.896**) | 5.70 | ring at √2 wins outright, but real space is **triangular** — confirms the README's "not a square lattice" claim directly, not by ring-power inference |
| `two_mode_seed_square` (`lattice_seed`, t: 0→100) | 0.0430 → 0.0377 | 1.031 (unchanged) | 41087 → 419780 | ≈0 → 66685 | (**1.000**, **1.000**) | (≈0, ≈0) | 4.00 | **square** preserved exactly; the √2 band grows in spontaneously |
| `single_mode_seed_triangular` (`lattice_seed`, t: 0→100) | 0.00891 → 0.00511 | 1.028 (unchanged) | 17207 → 322036 | ≈0 → ≈0 | (≈0, ≈0) | (**1.000**, **1.000**) | 6.00 | **triangular** preserved exactly |

The matched-conditions pair (`single_mode_triangular` vs `two_mode_square`,
same box/seed/quench) shows the real-space classifier doing the work the
issue asks for: single-mode → triangular (\(\psi_6\) dominant, ~5.9
neighbours), two-mode `q1=√2,r1=0.02` → square (\(\psi_4\) dominant, ~4.0
neighbours). The `r1=0` degenerate case is the most important honesty check:
it puts nearly all reciprocal power on the \(\sqrt2\) ring — a ring-power-only
report would likely read that as "square" — but the real-space metric shows
it is **triangular** (\(\psi_6\) dominant), exactly matching what the
existing README already said in words ("not a square lattice") but had never
verified structurally. Both `lattice_seed` runs hold their imposed symmetry
to 3 decimal places over 2000 ETD steps.

Free-energy density decreases monotonically in every run (conserved gradient
flow relaxing, as required) but is not comparable *across* rows — different
kernels have different \(\Lambda(0)\) — only \(\psi_4\)/\(\psi_6\) are.

## What I found and fixed while running this

`power_near` (nearest-shell lookup for "power at this wavenumber") had a
tie-breaking bug: `k=1` sits exactly on a shell-bin boundary for the shipped
grid's default 64 bins, so it is equidistant from two shells. The original
strict `<` comparison always picked the lower-index shell, which for a sharp
`lattice_seed` field (all its power in one shell, its neighbour empty) meant
"power near k=1" silently read ~0 instead of the actual signal. Fixed to
break ties towards the shell that actually carries power, added a regression
test, and reran all five cases (the ETD-integrated `SPECTRAL_CHECKSUM`s were
byte-identical before and after — this only affected the diagnostic
sampler, not the simulated physics).

## `#118` acceptance criteria

- [x] Exact primary-literature model/reference is cited (Wu, Adland & Karma,
      PRE 81, 061601 (2010)).
- [x] Implemented free energy and kernel mapped term-by-term to the reference.
- [x] Existing analytical polynomial/order tests remain green (unchanged,
      reran on this branch).
- [x] 2D square/triangular phase selection classified using a real structural
      metric (\(\psi_4\)/\(\psi_6\)), not ring power alone.
- [ ] One 3D phase-selection case — **deferred**, see below.
- [x] Single-mode and two-mode runs use controlled matched conditions
      (`single_mode_triangular` vs `two_mode_square`: same box, seed, quench).
- [x] Free-energy comparison accompanies structural classification.
- [x] Domain commensurability is checked and discussed (derivation for both
      box shapes in the README); the noise-seeded matched pair deliberately
      shares one box so the comparison isn't each kernel's favourite box.
- [x] README states domain, BCs, ICs, parameter provenance and model maturity
      (`Problem setup` table, three separate maturity axes).
- [ ] CPU/HIP observables agree within tolerance — **not re-verified this
      session** (see below); the existing HIP smoke test path is untouched.

## What is deferred / incomplete (said plainly)

- **3D crystal selection (BCC/FCC, `q1=2/sqrt(3)`)** is not implemented in
  this PR. 2D is solid and the acceptance criteria treat 3D as an "if the
  model supports it cleanly" stretch on top of a solid 2D case; extending
  `lattice_seed`'s commensurate-box logic and `order_parameter.hpp`'s
  neighbour search to 3D is real additional work I chose not to rush.
- **Explicit grain/orientation counting** (issue asks for a grain count on
  noise-seeded runs) is not implemented. The global-vs-local \(\psi_n\) gap
  is used and documented as a polycrystallinity proxy instead of a per-grain
  segmentation algorithm.
- **HIP/GPU**: not touched and not re-run this session. `HigherOrderPFCSession`
  (CPU) gained the diagnostics hook; `HigherOrderPFCHIPSession` did not, by
  design (the real-space order metric needs a whole-grid single-rank gather
  this PR does not attempt on GPU). The existing HIP smoke test / CPU-vs-HIP
  checksum table in the README is unchanged and was not rerun on LUMI-G in
  this session.
- **Stretch goal** (fitting the quadratic kernel to a documented liquid-state
  dataset) — not attempted.
- The literature mapping is verified for kernel structure and `Q1` ratios
  only, not the paper's quantitative phase diagram — see "Honesty about the
  literature mapping" above.

## Verification performed

- `./scripts/build.sh --machine=lumi --cpu --no-submit --no-test --cmake-arg=-DOpenPFC_BUILD_TESTS=ON` — clean build.
- `ctest -R higher-order-pfc` on the shared LUMI allocation — **2/2 passed**
  (`higher-order-pfc-all-tests`, `higher-order-pfc-mpi-tests`), including all
  new `[order]`/`[energy]` tagged tests (verified individually with
  `--success` output, 21 + 4 assertions).
- All five benchmark JSON cases actually run on the shared allocation
  (`srun --overlap -n 1`); `diagnostics.csv` inspected directly for the
  numbers in the table above.

Merge by **rebase**, not squash.
