### PR TITLE
feat(surface_diffusion): anisotropic relaxation and orientation selection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,22 @@ SPDX-License-Identifier: AGPL-3.0-or-later
   `easybuild/easyconfigs/`. Verified end to end on LUMI: both install, and
   `srun -n 4 tungsten` runs a 64³ case from the resulting module. Documented
   as an optional alternative to `scripts/build.sh` in `INSTALL.LUMI.md`.
+- Surface-diffusion science upgrade (`#115`): an orientation-dependent
+  surface stiffness `B(theta) = B0[1 + eps_a cos(m theta)]`,
+  `theta = atan2(h_y, h_x)` evaluated spectrally, generalising the isotropic
+  Mullins model `dh/dt = -B nabla^4 h` to `dh/dt = div[B(theta)
+  grad(lap h)]`; a self-contained spectral-flux ETD1 stepper
+  (`surface_diffusion_anisotropic`) since the orientation-dependent
+  coefficient cannot be written as a reciprocal-space symbol; and a crossed
+  sinusoidal-corrugation science preset run both isotropically and
+  anisotropically from the same initial surface, reporting RMS roughness,
+  structure-factor dominant wavelength, directional (kx- vs ky-dominated)
+  spectral energy, max `|grad h|` and mean height to CSV. The isotropic
+  `k^4` single/two-mode exact-decay tests are unchanged and remain the
+  numerical oracle; the anisotropic model reduces to them exactly at
+  `eps_a = 0` (checked, not assumed). `(B0, eps_a, m)` are illustrative
+  parameters, not fitted to a measured material `gamma(theta)` — see
+  `apps/surface_diffusion/include/surface_diffusion/anisotropy.hpp`.
 - Conservative flux nonlinearity for the applications whose mobility depends on
   the field inside a divergence (`#114`): `pfc::apps::SpectralFlux` and
   `pfc::apps::FluxETD` in `apps/common`, evaluating `div(M(u) grad p)`

--- a/apps/surface_diffusion/CMakeLists.txt
+++ b/apps/surface_diffusion/CMakeLists.txt
@@ -37,6 +37,14 @@ endfunction()
 surface_diffusion_cpu_executable(surface_diffusion src/surface_diffusion.cpp)
 install(TARGETS surface_diffusion DESTINATION bin)
 
+# Science driver for #115: orientation-dependent surface stiffness B(theta)
+# through a self-contained spectral flux stepper. Host only, like thin_film's
+# nonlinear driver -- the directional mobility needs a complex i*k_d multiply
+# the device Ops layer does not expose.
+surface_diffusion_cpu_executable(surface_diffusion_anisotropic
+  src/surface_diffusion_anisotropic.cpp)
+install(TARGETS surface_diffusion_anisotropic DESTINATION bin)
+
 if(OpenPFC_ENABLE_HIP AND OpenPFC_HIP_AVAILABLE AND OpenPFC_ENABLE_HIP_SPECTRAL)
   surface_diffusion_hip_executable(surface_diffusion_hip
     src/hip/surface_diffusion.cpp)

--- a/apps/surface_diffusion/README.md
+++ b/apps/surface_diffusion/README.md
@@ -6,10 +6,28 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 # Surface diffusion (`apps/surface_diffusion`)
 
 Mullins **small-slope surface diffusion**: thermal smoothing of nanoscale
-roughness. This is the 0.2 application for GitHub issue `#79`.
+roughness, and (`#115`) orientation-dependent relaxation of a patterned
+nanosurface under an anisotropic surface stiffness. This is the 0.2
+application for GitHub issues `#79` and `#115`.
 
-Binaries: `surface_diffusion` (CPU); `surface_diffusion_hip` when
-`OpenPFC_ENABLE_HIP_SPECTRAL` is on.
+Binaries: `surface_diffusion` (CPU, isotropic verifier);
+`surface_diffusion_anisotropic` (CPU, anisotropic science driver);
+`surface_diffusion_hip` when `OpenPFC_ENABLE_HIP_SPECTRAL` is on (isotropic
+only -- see [Anisotropic model](#anisotropic-model-115) for why the
+anisotropic driver is CPU-only).
+
+## Problem setup
+
+| Item | Verification preset (`surface_diffusion`) | Science preset (`surface_diffusion_anisotropic`) |
+|---|---|---|
+| Use case | Numerical oracle: exact single/two-mode `k^4` decay | Annealing/relaxation of a patterned nanoscale surface (e.g. a lithographically ruled or deposited crossed ridge pattern) under isotropic vs anisotropic surface diffusion |
+| Domain | 2D periodic slab, e.g. \(128\times128\) grid units | 2D periodic slab, \(128\times128\) grid units, \(dx=1\) |
+| Grid | 16²-32² (tests), 128² (demo), single Fourier mode(s) | 128², resolving 16 corrugation periods per axis (8 grid points/period) |
+| Boundary conditions | Periodic on x/y (spectral); represents an infinite/repeated flat surface patch | Periodic on x/y; represents an interior patch of a repeated nanoscale surface pattern, not a finite chip/facet edge |
+| Initial condition | One or two cosine modes, amplitude \(\le 0.1\) | Crossed sinusoidal corrugation \(h=h_0+A[\cos(2\pi n_x x/L_x)+\cos(2\pi n_y y/L_y)]\), \(A=0.05\), \(n_x=n_y=16\); same field run isotropically (`eps_a=0`) and anisotropically (`eps_a=0.5`, `m=6`) |
+| Key physical parameters | `B` (Mullins coefficient, grid units, unfitted) | `B0` (grid units, unfitted), `eps_a` (anisotropy strength, illustrative -- see `anisotropy.hpp`), `m` (stiffness symmetry order, 4 or 6) |
+| Observable | Mode amplitude vs \(\exp(-Bk^4t)\); two-mode rate ratio \((k_2/k_1)^4\) | RMS roughness, structure-factor dominant wavelength, directional spectral energy (kx- vs ky-dominated modes), max \(|\nabla h|\), mean height (conserved) |
+| Model maturity | Numerical verification: **analytical** (exact `k^4` decay). Physical completeness: **reduced** (isotropic small-slope Mullins only). Calibration: **none** (grid units) | Numerical verification: **regression** against the isotropic verifier at `eps_a=0` and against an exact single-orientation decay rate (see Tests). Physical completeness: **reduced** (small-slope height-function model; orientation-dependent *kinetic* coefficient imposed directly, not a Herring `gamma+gamma''` stiffness derived from a fitted `gamma(theta)`). Calibration: **none** -- `B0`, `eps_a`, `m` are illustrative, not fitted to a measured material `gamma(theta)` |
 
 ## Physics
 
@@ -44,12 +62,74 @@ L(k)=-B\,k_{\mathrm{lap}}^2.
 
 There is no real-space nonlinearity.
 
+## Anisotropic model (`#115`)
+
+Real crystalline surfaces do not relax isotropically: the surface free energy
+\(\gamma\) depends on the local surface-normal orientation, and by the
+Herring relation the *kinetic* stiffness that controls diffusive smoothing is
+\(\tilde\gamma(\theta)=\gamma(\theta)+\gamma''(\theta)\) (Mullins 1957;
+Rettori & Villain, *J. Phys. France* 49, 257 (1988); Bonzel & Preuss, *Surf.
+Sci.* 336, 209 (1995)). This code does **not** differentiate a specific
+literature \(\gamma(\theta)\) to obtain \(\tilde\gamma\); it imposes the same
+periodic *functional form* directly on the kinetic coefficient,
+
+\[
+B(\theta)=B_0\bigl[1+\epsilon_a\cos(m\theta)\bigr],\qquad
+\theta=\operatorname{atan2}(h_y,h_x),
+\]
+
+with \(\theta\) the local surface-*gradient* orientation and \(m\in\{4,6\}\)
+the crystal symmetry order, evaluated spectrally (\(h_x,h_y\) are computed
+from `i*k_x*h_hat` / `i*k_y*h_hat`, not a finite-difference stencil). The
+governing equation generalises the isotropic divergence form:
+
+\[
+\partial_t h=\nabla\cdot\bigl[B(\theta)\,\nabla(\nabla^2 h)\bigr]
+\quad\xrightarrow{\ B(\theta)\to B_0\ }\quad
+\partial_t h=-B_0\nabla^4 h.
+\]
+
+**This is still a small-slope, height-function model.** \(\theta\) is the
+orientation of the local surface gradient of a single-valued height field; it
+does **not** claim arbitrary-slope, overhanging, or faceted-plane crystalline
+surface evolution. \((B_0,\epsilon_a,m)\) are illustrative parameters, not
+fitted to any specific material's measured \(\gamma(\theta)\) -- do not read
+\(\epsilon_a\) as a calibrated anisotropy strength.
+
+Because \(B(\theta)\) depends on the field's own gradient, the operator is
+not a reciprocal-space symbol; `surface_diffusion_anisotropic` evaluates it
+with a self-contained spectral-flux stepper
+(`include/surface_diffusion/anisotropic_flux.hpp`) that integrates the
+constant-\(B_0\) part exactly (ETD) and treats the orientation-dependent
+remainder explicitly, the same splitting `openpfc_apps/spectral_flux.hpp`
+uses for `thin_film`'s \(h^3\) mobility. At `eps_a=0` the remainder is zero
+(up to FFT round-off) and the stepper reproduces the isotropic verifier's
+exact \(\exp(-B_0k^4t)\) trajectory -- checked in `tests/test_surface_diffusion.cpp`,
+not assumed.
+
+**Why `m=6` for the shipped science preset, not `m=4`.** The crossed
+corrugation's two ridge sets sit at \(\theta=0\) (x-ridges) and
+\(\theta=\pi/2\) (y-ridges). A fourfold stiffness treats those as *the same*
+orientation (\(\cos(4\cdot0)=\cos(4\cdot\pi/2)\)), so it would not show a
+directional effect on this particular initial condition; a sixfold stiffness
+does not (\(\cos(6\cdot0)=1\neq\cos(6\cdot\pi/2)=-1\)). `m=4` is fully
+implemented and unit-tested (the fourfold symmetry of \(B(\theta)\) itself),
+it is simply not the orientation-selection demonstration case here.
+
 ## Run
 
 ```bash
 mkdir -p results/surface_diffusion
 mpirun -n 1 ./apps/surface_diffusion/surface_diffusion \
   ../apps/surface_diffusion/inputs_json/smoothing.json
+
+# Anisotropic science preset (#115): same crossed-corrugation initial
+# surface, run once isotropically and once anisotropically.
+mkdir -p results/surface_diffusion
+mpirun -n 1 ./apps/surface_diffusion/surface_diffusion_anisotropic \
+  ../apps/surface_diffusion/inputs_json/nanosurface_isotropic.json
+mpirun -n 1 ./apps/surface_diffusion/surface_diffusion_anisotropic \
+  ../apps/surface_diffusion/inputs_json/nanosurface_anisotropic.json
 ```
 
 The shipped input is a 128² slab with three cosine wavelengths. VTK of `h`
@@ -58,6 +138,49 @@ goes to `results/surface_diffusion/`. Short modes flatten first.
 JSON `model.params`: `B` (default 1). Initial condition `"type":
 "cosine_mode"` with `h0` and either a single `amplitude`/`nx`/`ny`/`nz` or a
 `modes` array.
+
+`surface_diffusion_anisotropic` reads a different, simpler JSON shape (it is
+a standalone driver, not a `SpectralETDSession`): `model.params` is `B0`,
+`eps_a`, `m`; `domain` requires `Lz: 1`; `initial_conditions` is `{h0,
+modes:[{nx,ny,amplitude}, ...]}` (each mode a plane cosine, summed); optional
+`diagnostics.csv` writes the observables table below every `saveat`.
+
+## Measured orientation selection (LUMI, CPU, 2026-09-09)
+
+Both presets start from the identical crossed corrugation (\(n_x=n_y=16\),
+\(A=0.05\), RMS roughness `0.05`, `max|grad h|=0.0555`, `energy_kx_frac =
+energy_ky_frac = 0.5`) and run to `t1=8` (`dt=0.01`, 800 steps).
+
+| Observable at `t=8` | Isotropic (`eps_a=0`) | Anisotropic (`eps_a=0.5`, `m=6`) |
+|---|---|---|
+| RMS roughness | 0.002382 | 0.001549 |
+| max\(\vert\nabla h\vert\) | 0.002646 | 0.001704 |
+| `energy_kx_frac` / `energy_ky_frac` | 0.500 / 0.500 | 0.249 / 0.751 |
+| mean height | \(-1.4\times10^{-17}\) | \(-1.2\times10^{-18}\) |
+
+The isotropic run holds `energy_kx_frac = energy_ky_frac = 0.500` for every
+sample in the run (linear dynamics: `|k|` sets the rate, orientation does
+not) -- a useful internal check as well as a physical statement. The
+anisotropic run's split moves monotonically away from 1:1 at every sample
+(`0.500 -> 0.486 -> ... -> 0.249/0.751` at `t=0,0.5,...,8`; see
+`results/surface_diffusion/nanosurface_anisotropic.csv`), i.e. the softer
+(`theta=pi/2`, y) orientation increasingly dominates the surviving spectral
+content as the stiffer (`theta=0`, x) orientation is preferentially damped --
+the orientation-selection effect `#115` asks for, reproduced from a
+deterministic initial condition. `dominant_wavelength` from the (orientation-
+blind) structure factor is unchanged between the two runs (`7.758`), which is
+expected and is exactly why the directional split, not the structure factor
+alone, is the observable that shows the anisotropy.
+
+Caveat measured directly from this run: a short single-orientation unit test
+(`tests/test_surface_diffusion.cpp`) shows the *isolated* stiff/soft decay
+rates differing by a factor of 3 for these `(B0,eps_a,m)`, but the *combined*
+crossed-corrugation run above shows a smaller (order-of-magnitude smaller at
+short times) net effect, because each orientation's local `B(theta)` is set
+by the combined gradient of both ridge sets, not by either mode alone -- the
+two orientations are nonlinearly coupled once both are present. The 3:1
+final energy split above is the honest, measured, coupled-system number; do
+not read the isolated single-mode ratio as a prediction for a mixed pattern.
 
 ## Mode amplitude versus time
 
@@ -79,18 +202,36 @@ against that exponential and a two-mode rate ratio of 16
 
 ## Tests
 
-`ctest -R surface-diffusion` checks \(L(k)=-B k_{\mathrm{lap}}^2\), exact
-single-mode \(\exp(-B k^4 t)\), two-mode decay rates in the ratio
-\((k_2/k_1)^4=16\), and mean-height conservation. HIP builds add
-`HIP_SurfaceDiffusionETD` and `surface-diffusion-hip-smoke`. LUMI-G smoke:
-job 21791182 (`small-g`, 16², mean \(h=0\)).
+`ctest -R surface-diffusion` checks:
+
+- (verifier, unchanged by `#115`) \(L(k)=-B k_{\mathrm{lap}}^2\), exact
+  single-mode \(\exp(-B k^4 t)\), two-mode decay rates in the ratio
+  \((k_2/k_1)^4=16\), and mean-height conservation;
+- (`#115` anisotropic model) `B(theta)` reduces exactly to `B0` at
+  `eps_a=0`; `B(theta)` has the fourfold/sixfold symmetry it claims (and that
+  `m=4` makes `theta=0`/`theta=pi/2` equivalent while `m=6` does not);
+  `AnisotropicSurfaceDiffusionETD` reproduces the isotropic `exp(-B0k^4t)`
+  decay at `eps_a=0`; a single-orientation run's decay rate matches
+  `B(theta)*k^4` exactly for both the stiff and soft orientations under a
+  sixfold anisotropy; mean height is conserved during an anisotropic run;
+  a crossed-corrugation run shows equal x/y amplitude decay isotropically
+  and unequal decay anisotropically (the faceting/orientation-selection
+  claim, made quantitative).
+
+HIP builds add `HIP_SurfaceDiffusionETD` and `surface-diffusion-hip-smoke`
+(isotropic verifier only -- the anisotropic driver is CPU-only). LUMI-G
+smoke: job 21791182 (`small-g`, 16², mean \(h=0\)).
 
 ## Layout
 
 | Path | Role |
 |------|------|
-| `include/surface_diffusion/surface_diffusion_physics.hpp` | `L(k)=-B k_{\mathrm{lap}}^2` |
-| `include/surface_diffusion/surface_diffusion_pointwise.hpp` | Zero remainder |
-| `include/surface_diffusion/surface_diffusion_session.hpp` | JSON session, field `h` |
-| `src/surface_diffusion.cpp` / `src/hip/` | CPU / HIP `main` |
-| `inputs_json/smoothing.json` | Multi-wavelength annealing demo |
+| `include/surface_diffusion/surface_diffusion_physics.hpp` | Isotropic `L(k)=-B k_{\mathrm{lap}}^2` (verifier) |
+| `include/surface_diffusion/surface_diffusion_pointwise.hpp` | Zero remainder (verifier) |
+| `include/surface_diffusion/surface_diffusion_session.hpp` | JSON session, field `h` (verifier) |
+| `include/surface_diffusion/anisotropy.hpp` | `B(theta) = B0[1+eps_a cos(m theta)]` + JSON schema (`#115`) |
+| `include/surface_diffusion/anisotropic_flux.hpp` | Self-contained spectral-flux ETD1 stepper for `div[B(theta) grad(lap h)]` (`#115`) |
+| `src/surface_diffusion.cpp` / `src/hip/` | CPU / HIP `main` (verifier) |
+| `src/surface_diffusion_anisotropic.cpp` | CPU science driver: crossed corrugation, CSV diagnostics (`#115`) |
+| `inputs_json/smoothing.json` | Multi-wavelength annealing demo (verifier) |
+| `inputs_json/nanosurface_isotropic.json` / `nanosurface_anisotropic.json` | Same crossed-corrugation IC, `eps_a=0` vs `eps_a=0.5` (`#115`) |

--- a/apps/surface_diffusion/include/surface_diffusion/anisotropic_flux.hpp
+++ b/apps/surface_diffusion/include/surface_diffusion/anisotropic_flux.hpp
@@ -1,0 +1,261 @@
+// SPDX-FileCopyrightText: 2026 VTT Technical Research Centre of Finland Ltd
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+#pragma once
+
+/**
+ * @file anisotropic_flux.hpp
+ * @brief Spectral ETD1 stepper for the anisotropic small-slope surface-
+ *        diffusion equation (`#115`).
+ *
+ * @details
+ * The isotropic Mullins model (`surface_diffusion_physics.hpp`) is the
+ * divergence form
+ * \f[
+ *   \partial_t h = \nabla\cdot\bigl[B_0\,\nabla(\nabla^2 h)\bigr]
+ *               = -B_0\nabla^4 h,
+ * \f]
+ * which is a pure reciprocal-space symbol because \f$B_0\f$ is constant. The
+ * anisotropic generalisation replaces the constant kinetic coefficient with
+ * the orientation-dependent stiffness \f$B(\theta)\f$ of `anisotropy.hpp`,
+ * \f$\theta=\operatorname{atan2}(h_y,h_x)\f$ the local surface-gradient
+ * orientation:
+ * \f[
+ *   \partial_t h = \nabla\cdot\bigl[B(\theta)\,\nabla(\nabla^2 h)\bigr].
+ * \f]
+ * \f$B(\theta)\f$ depends on the field itself (through its gradient), so the
+ * operator cannot be written as a single reciprocal-space multiplier the way
+ * `SurfaceDiffusionPhysics::linear_symbol` is; it is evaluated the same way
+ * `openpfc_apps/spectral_flux.hpp` evaluates a state-dependent mobility
+ * inside a divergence, generalised so the coefficient depends on the local
+ * gradient *orientation* rather than on the field value. This header does not
+ * reuse `pfc::apps::SpectralFlux` because that class's `mobility` callback is
+ * a function of the transported field's value, not of a separately derived
+ * orientation field; duplicating the small kernel here keeps the shared
+ * `apps/common` helper's contract unchanged for the other applications that
+ * already depend on it.
+ *
+ * ## Splitting for the exponential integrator
+ *
+ * \f[
+ *   \partial_t\hat h = L_0(k)\,\hat h + \hat N,\qquad
+ *   L_0(k) = -B_0\,k_{\mathrm{lap}}^2,\qquad
+ *   \hat N = \widehat{\nabla\cdot[B(\theta)\nabla(\nabla^2 h)]} - L_0(k)\hat h,
+ * \f]
+ * i.e. the constant-\f$B_0\f$ part is integrated exactly (unconditionally
+ * stable for the stiff fourth-order term) and \f$\hat N\f$ carries only the
+ * orientation-dependent remainder. When `eps_a = 0`, `B(theta) == B0`
+ * everywhere and the full divergence equals \f$L_0(k)\hat h\f$ up to FFT
+ * round-off, so \f$\hat N\to 0\f$ and this stepper reproduces the isotropic
+ * `SpectralETDSystem<SurfaceDiffusionPhysics>` trajectory to floating-point
+ * tolerance -- asserted in `test_surface_diffusion.cpp` rather than assumed.
+ *
+ * ## Scope
+ *
+ * 2-D height fields only (`Lz == 1`): \f$\theta\f$ is defined from the
+ * in-plane gradient `(h_x, h_y)`, matching the small-slope 2-D patterned-
+ * surface preset this model was built for. Host (CPU) only, like the shared
+ * flux helper it parallels; a directional mobility needs a complex `i*k_d`
+ * multiply that the device `Ops` layer does not expose.
+ */
+
+#include <cmath>
+#include <complex>
+#include <cstddef>
+#include <numbers>
+#include <stdexcept>
+#include <vector>
+
+#include <openpfc/kernel/data/domain.hpp>
+#include <openpfc/kernel/data/grid_field.hpp>
+#include <openpfc/kernel/fft/kspace_iterator.hpp>
+#include <openpfc/kernel/simulation/spectral_etd_ops.hpp>
+
+#include <surface_diffusion/anisotropy.hpp>
+
+namespace surface_diffusion {
+
+/// ETD1 stepper for `dh/dt = div[B(theta) grad(lap h)]` on a 2-D domain.
+class AnisotropicSurfaceDiffusionETD {
+  using Ops = pfc::sim::SpectralETDOps<pfc::HostSpace>;
+
+public:
+  using Complex = Ops::Complex;
+  using RealField = Ops::RealField;
+  using ComplexField = Ops::ComplexField;
+  using FFT = Ops::FFT;
+
+  /**
+   * @param domain     grid geometry (must have `Lz == 1`)
+   * @param fft        transform owned by the caller
+   * @param dt         fixed step
+   * @param stiffness  \f$B(\theta)\f$
+   */
+  AnisotropicSurfaceDiffusionETD(const pfc::Domain &domain, FFT &fft, double dt,
+                                 SurfaceStiffness stiffness)
+      : m_dt(dt), m_stiffness(stiffness), m_fft(fft),
+        m_h_hat(domain, fft.get_outbox_bounds(), 0),
+        m_p_hat(domain, fft.get_outbox_bounds(), 0),
+        m_grad_hat(domain, fft.get_outbox_bounds(), 0),
+        m_flux_hat(domain, fft.get_outbox_bounds(), 0),
+        m_div_hat(domain, fft.get_outbox_bounds(), 0),
+        m_grad_real(domain, fft.get_inbox_bounds(), 0),
+        m_hx(domain, fft.get_inbox_bounds(), 0),
+        m_hy(domain, fft.get_inbox_bounds(), 0),
+        m_theta(domain, fft.get_inbox_bounds(), 0),
+        m_Btheta(domain, fft.get_inbox_bounds(), 0) {
+    const auto size = pfc::domain::get_size(domain);
+    if (size[2] != 1) {
+      throw std::invalid_argument(
+          "AnisotropicSurfaceDiffusionETD: requires a 2-D domain (Lz == 1); "
+          "theta = atan2(h_y, h_x) is only defined for an in-plane gradient.");
+    }
+    const std::size_t n = fft.size_outbox();
+    m_kx.assign(n, 0.0);
+    m_ky.assign(n, 0.0);
+    m_k_lap.assign(n, 0.0);
+    m_mask.assign(n, 1.0);
+    m_expL.assign(n, 1.0);
+    m_phi1.assign(n, dt);
+    m_L0.assign(n, 0.0);
+
+    const auto dx = pfc::domain::get_spacing(domain);
+    const double cutx = (2.0 / 3.0) * (std::numbers::pi / dx[0]);
+    const double cuty = (2.0 / 3.0) * (std::numbers::pi / dx[1]);
+
+    pfc::fft::kspace::for_each_kpoint(
+        fft.get_outbox_bounds(), domain,
+        [&](std::size_t i, double kx, double ky, double kz, int, int, int) {
+          m_kx[i] = kx;
+          m_ky[i] = ky;
+          m_k_lap[i] = -(kx * kx + ky * ky + kz * kz);
+          // Orszag 2/3 dealiasing mask: B(theta)*grad(lap h) is a strongly
+          // nonlinear product (theta itself is a ratio of gradients), so its
+          // transform carries wavenumbers the grid cannot represent.
+          if (std::abs(kx) > cutx || std::abs(ky) > cuty) m_mask[i] = 0.0;
+          const double l0 = -stiffness.B0 * m_k_lap[i] * m_k_lap[i];
+          m_L0[i] = l0;
+          const double a = l0 * dt;
+          m_expL[i] = std::exp(a);
+          m_phi1[i] =
+              (std::abs(a) < 1.0e-8) ? dt * (1.0 + 0.5 * a) : (m_expL[i] - 1.0) / l0;
+        });
+  }
+
+  /**
+   * @brief Advance @p h by one step. Returns `t + dt`.
+   */
+  double step(double t, RealField &h) {
+    Ops::forward(m_fft, h, m_h_hat);
+
+    // theta(x) = atan2(h_y, h_x), gradient evaluated spectrally.
+    spectral_derivative(m_kx, m_h_hat, m_hx);
+    spectral_derivative(m_ky, m_h_hat, m_hy);
+    m_hx.with_host_view([&](const double *hx, std::size_t n) {
+      m_hy.with_host_view([&](const double *hy, std::size_t) {
+        m_theta.with_host_view([&](double *th, std::size_t) {
+          m_Btheta.with_host_view([&](double *b, std::size_t) {
+            for (std::size_t i = 0; i < n; ++i) {
+              th[i] = std::atan2(hy[i], hx[i]);
+              b[i] = m_stiffness(th[i]);
+            }
+          });
+        });
+      });
+    });
+
+    // p_hat = -k_lap * h_hat = FFT(-lap h)
+    const std::size_t n_out = m_fft.size_outbox();
+    m_h_hat.with_host_view([&](const Complex *hh, std::size_t) {
+      m_p_hat.with_host_view([&](Complex *p, std::size_t) {
+        for (std::size_t i = 0; i < n_out; ++i) p[i] = -m_k_lap[i] * hh[i];
+      });
+    });
+
+    m_div_hat.with_host_view([&](Complex *d, std::size_t) {
+      for (std::size_t i = 0; i < n_out; ++i) d[i] = Complex{0.0, 0.0};
+    });
+
+    const std::vector<double> *k_axes[2]{&m_kx, &m_ky};
+    for (const auto *k : k_axes) {
+      m_p_hat.with_host_view([&](const Complex *p, std::size_t) {
+        m_grad_hat.with_host_view([&](Complex *g, std::size_t) {
+          for (std::size_t i = 0; i < n_out; ++i) g[i] = Complex{0.0, (*k)[i]} * p[i];
+        });
+      });
+      Ops::backward(m_fft, m_grad_hat, m_grad_real);
+
+      m_Btheta.with_host_view([&](const double *b, std::size_t count) {
+        m_grad_real.with_host_view([&](double *g, std::size_t) {
+          for (std::size_t i = 0; i < count; ++i) g[i] *= b[i];
+        });
+      });
+      Ops::forward(m_fft, m_grad_real, m_flux_hat);
+
+      m_flux_hat.with_host_view([&](const Complex *f, std::size_t) {
+        m_div_hat.with_host_view([&](Complex *d, std::size_t) {
+          for (std::size_t i = 0; i < n_out; ++i)
+            d[i] += Complex{0.0, (*k)[i]} * (m_mask[i] * f[i]);
+        });
+      });
+    }
+
+    // ETD1: h_hat_new = expL*h_hat + phi1*(div_hat - L0*h_hat).
+    m_h_hat.with_host_view([&](Complex *hh, std::size_t) {
+      m_div_hat.with_host_view([&](const Complex *d, std::size_t) {
+        for (std::size_t i = 0; i < n_out; ++i) {
+          const Complex nl = d[i] - m_L0[i] * hh[i];
+          hh[i] = m_expL[i] * hh[i] + m_phi1[i] * nl;
+        }
+      });
+    });
+    Ops::backward(m_fft, m_h_hat, h);
+    return t + m_dt;
+  }
+
+  [[nodiscard]] double dt() const noexcept { return m_dt; }
+  [[nodiscard]] const SurfaceStiffness &stiffness() const noexcept {
+    return m_stiffness;
+  }
+
+  /// Local surface-gradient orientation from the most recent `step` (or the
+  /// state the caller last wrote into `h` before calling `step`).
+  [[nodiscard]] const RealField &theta() const noexcept { return m_theta; }
+
+  /// Local |grad h| from the most recent `step`, for the max-slope observable.
+  ///
+  /// Not `const`: `Field::with_host_view` is a non-const accessor even for a
+  /// read-only pass (it brackets host/device coherence), so this method
+  /// cannot be `const` while it reads `m_hx`/`m_hy` through it.
+  void grad_magnitude(RealField &out) {
+    m_hx.with_host_view([&](const double *hx, std::size_t n) {
+      m_hy.with_host_view([&](const double *hy, std::size_t) {
+        out.with_host_view([&](double *g, std::size_t) {
+          for (std::size_t i = 0; i < n; ++i)
+            g[i] = std::sqrt(hx[i] * hx[i] + hy[i] * hy[i]);
+        });
+      });
+    });
+  }
+
+private:
+  void spectral_derivative(const std::vector<double> &k, ComplexField &f_hat,
+                           RealField &out) {
+    const std::size_t n_out = m_fft.size_outbox();
+    f_hat.with_host_view([&](const Complex *f, std::size_t) {
+      m_grad_hat.with_host_view([&](Complex *g, std::size_t) {
+        for (std::size_t i = 0; i < n_out; ++i) g[i] = Complex{0.0, k[i]} * f[i];
+      });
+    });
+    Ops::backward(m_fft, m_grad_hat, out);
+  }
+
+  double m_dt;
+  SurfaceStiffness m_stiffness;
+  FFT &m_fft;
+  std::vector<double> m_kx, m_ky, m_k_lap, m_mask, m_expL, m_phi1, m_L0;
+  ComplexField m_h_hat, m_p_hat, m_grad_hat, m_flux_hat, m_div_hat;
+  RealField m_grad_real, m_hx, m_hy, m_theta, m_Btheta;
+};
+
+} // namespace surface_diffusion

--- a/apps/surface_diffusion/include/surface_diffusion/anisotropy.hpp
+++ b/apps/surface_diffusion/include/surface_diffusion/anisotropy.hpp
@@ -1,0 +1,130 @@
+// SPDX-FileCopyrightText: 2026 VTT Technical Research Centre of Finland Ltd
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+#pragma once
+
+/**
+ * @file anisotropy.hpp
+ * @brief Orientation-dependent surface-diffusion stiffness \f$B(\theta)\f$
+ *        for the science case of `#115`.
+ *
+ * @details
+ * The Mullins verifier (`surface_diffusion_physics.hpp`) keeps a single,
+ * orientation-independent coefficient \f$B\f$. Real crystalline surfaces do
+ * not: the surface free energy \f$\gamma\f$ depends on the local surface
+ * normal, and by the Herring relation the *kinetic* stiffness that actually
+ * controls diffusive smoothing is
+ * \f[
+ *   \tilde\gamma(\theta) = \gamma(\theta) + \gamma''(\theta),
+ * \f]
+ * so a facet (a cusp or a strongly cusped minimum of \f$\gamma(\theta)\f$)
+ * relaxes at a different rate than a vicinal orientation between facets
+ * (Mullins 1957; Rettori & Villain, *J. Phys. France* 49, 257 (1988);
+ * Bonzel & Preuss, *Surf. Sci.* 336, 209 (1995)).
+ *
+ * **Honesty note (model maturity).** This header does *not* differentiate a
+ * specific literature \f$\gamma(\theta)\f$ to obtain \f$\tilde\gamma(\theta)\f$.
+ * It imposes the periodic modulation directly on the *kinetic* coefficient,
+ *
+ * \f[
+ *   B(\theta) = B_0\bigl[1 + \epsilon_a\cos(m\theta)\bigr],
+ * \f]
+ *
+ * with \f$\theta=\operatorname{atan2}(h_y,h_x)\f$ the local surface-slope
+ * orientation and \f$m\in\{4,6\}\f$ the crystal symmetry order. That is the
+ * same *functional form* the literature above derives for \f$\tilde\gamma\f$
+ * near a weakly cusped minimum, and it recovers the qualitative faceting
+ * phenomenology (orientations near the stiff lobes of \f$B(\theta)\f$ persist
+ * longer than orientations near the soft lobes), but the coefficients
+ * \f$(B_0,\epsilon_a,m)\f$ here are illustrative, not fitted to any specific
+ * material's measured \f$\gamma(\theta)\f$. Do not read \f$\epsilon_a\f$ as a
+ * calibrated anisotropy strength for a real crystal facet.
+ *
+ * This stays a **small-slope, height-function** model throughout: \f$\theta\f$
+ * is the orientation of the local surface *gradient*, not of an arbitrary
+ * crystal facet normal on a multivalued or overhanging surface. It does not
+ * claim arbitrary-slope crystalline surface evolution (Issue `#115`,
+ * "Required model").
+ */
+
+#include <cmath>
+
+#include <nlohmann/json.hpp>
+
+#include <openpfc/kernel/simulation/parameter_schema.hpp>
+
+namespace surface_diffusion {
+
+/// Raw JSON-facing fields for the anisotropic model.
+struct AnisotropySchemaValues {
+  double B0{1.0};    ///< isotropic (orientation-averaged) Mullins coefficient
+  double eps_a{0.0}; ///< anisotropy strength; 0 recovers the isotropic model
+  int m{4};          ///< symmetry order (4 = cubic/fourfold, 6 = hexagonal)
+};
+
+struct AnisotropyParams : AnisotropySchemaValues {};
+
+inline void apply_schema_values(const AnisotropySchemaValues &v,
+                                AnisotropyParams &p) {
+  static_cast<AnisotropySchemaValues &>(p) = v;
+}
+
+inline pfc::sim::ParameterSchema<AnisotropySchemaValues>
+make_anisotropy_schema() {
+  pfc::sim::ParameterSchema<AnisotropySchemaValues> s;
+  s.model_name("SurfaceDiffusionAnisotropic")
+      .real(&AnisotropySchemaValues::B0,
+            {.name = "B0",
+             .description = "orientation-averaged Mullins coefficient",
+             .required = false,
+             .min = 0.0,
+             .default_value = 1.0})
+      .real(&AnisotropySchemaValues::eps_a,
+            {.name = "eps_a",
+             .description =
+                 "anisotropy strength; 0 reduces exactly to the isotropic "
+                 "model (unfitted, illustrative -- see anisotropy.hpp)",
+             .required = false,
+             .min = 0.0,
+             .max = 1.0,
+             .default_value = 0.0})
+      .integer(&AnisotropySchemaValues::m,
+               {.name = "m",
+                .description = "surface-stiffness symmetry order (4 or 6)",
+                .required = false,
+                .min = 1.0,
+                .max = 8.0,
+                .default_value = 4.0});
+  return s;
+}
+
+inline void apply_anisotropy_json(const nlohmann::json &j, AnisotropyParams &p) {
+  apply_schema_values(make_anisotropy_schema().parse(j), p);
+}
+
+/**
+ * @brief Orientation-dependent surface-diffusion stiffness
+ *        \f$B(\theta)=B_0[1+\epsilon_a\cos(m\theta)]\f$.
+ *
+ * By construction, `B0` is a fixed point of the family in @p m: setting
+ * `eps_a = 0` makes `operator()` return `B0` for every `theta`, which is the
+ * exact isotropic Mullins coefficient used by `SurfaceDiffusionPhysics`. The
+ * function is `2*pi/m`-periodic by construction (`cos(m*(theta + 2*pi/m)) =
+ * cos(m*theta + 2*pi) = cos(m*theta)`), which is the fourfold/sixfold
+ * symmetry the science preset claims.
+ */
+struct SurfaceStiffness {
+  double B0{1.0};
+  double eps_a{0.0};
+  int m{4};
+
+  [[nodiscard]] double operator()(double theta) const {
+    return B0 * (1.0 + eps_a * std::cos(static_cast<double>(m) * theta));
+  }
+
+  static SurfaceStiffness from_params(const AnisotropyParams &p) {
+    return SurfaceStiffness{p.B0, p.eps_a, p.m};
+  }
+};
+
+} // namespace surface_diffusion

--- a/apps/surface_diffusion/inputs_json/nanosurface_anisotropic.json
+++ b/apps/surface_diffusion/inputs_json/nanosurface_anisotropic.json
@@ -1,0 +1,31 @@
+{
+    "model": {
+        "name": "surface_diffusion_anisotropic",
+        "params": {
+            "B0": 1.0,
+            "eps_a": 0.5,
+            "m": 6
+        }
+    },
+    "domain": {
+        "Lx": 128,
+        "Ly": 128,
+        "Lz": 1,
+        "dx": 1.0
+    },
+    "timestepping": {
+        "t1": 8.0,
+        "dt": 0.01,
+        "saveat": 0.5
+    },
+    "initial_conditions": {
+        "h0": 0.0,
+        "modes": [
+            {"nx": 16, "ny": 0, "amplitude": 0.05},
+            {"nx": 0, "ny": 16, "amplitude": 0.05}
+        ]
+    },
+    "diagnostics": {
+        "csv": "results/surface_diffusion/nanosurface_anisotropic.csv"
+    }
+}

--- a/apps/surface_diffusion/inputs_json/nanosurface_anisotropic.json.license
+++ b/apps/surface_diffusion/inputs_json/nanosurface_anisotropic.json.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: 2026 VTT Technical Research Centre of Finland Ltd
+SPDX-License-Identifier: AGPL-3.0-or-later

--- a/apps/surface_diffusion/inputs_json/nanosurface_isotropic.json
+++ b/apps/surface_diffusion/inputs_json/nanosurface_isotropic.json
@@ -1,0 +1,31 @@
+{
+    "model": {
+        "name": "surface_diffusion_anisotropic",
+        "params": {
+            "B0": 1.0,
+            "eps_a": 0.0,
+            "m": 6
+        }
+    },
+    "domain": {
+        "Lx": 128,
+        "Ly": 128,
+        "Lz": 1,
+        "dx": 1.0
+    },
+    "timestepping": {
+        "t1": 8.0,
+        "dt": 0.01,
+        "saveat": 0.5
+    },
+    "initial_conditions": {
+        "h0": 0.0,
+        "modes": [
+            {"nx": 16, "ny": 0, "amplitude": 0.05},
+            {"nx": 0, "ny": 16, "amplitude": 0.05}
+        ]
+    },
+    "diagnostics": {
+        "csv": "results/surface_diffusion/nanosurface_isotropic.csv"
+    }
+}

--- a/apps/surface_diffusion/inputs_json/nanosurface_isotropic.json.license
+++ b/apps/surface_diffusion/inputs_json/nanosurface_isotropic.json.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: 2026 VTT Technical Research Centre of Finland Ltd
+SPDX-License-Identifier: AGPL-3.0-or-later

--- a/apps/surface_diffusion/src/surface_diffusion_anisotropic.cpp
+++ b/apps/surface_diffusion/src/surface_diffusion_anisotropic.cpp
@@ -1,0 +1,318 @@
+// SPDX-FileCopyrightText: 2026 VTT Technical Research Centre of Finland Ltd
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+/**
+ * @file surface_diffusion_anisotropic.cpp
+ * @brief Patterned-nanosurface relaxation and orientation selection (`#115`).
+ *
+ * The science driver for `#115`. The JSON-session binary `surface_diffusion`
+ * keeps the isotropic Mullins model as the analytical `k^4` verifier; this
+ * one solves the orientation-dependent generalisation of
+ * `surface_diffusion/anisotropic_flux.hpp`,
+ *
+ * \f[
+ *   \partial_t h = \nabla\cdot\bigl[B(\theta)\,\nabla(\nabla^2 h)\bigr],
+ *   \qquad B(\theta) = B_0\bigl[1+\epsilon_a\cos(m\theta)\bigr],
+ * \f]
+ *
+ * starting from a *crossed sinusoidal corrugation* -- two orthogonal ridge
+ * sets of equal wavenumber, `h0 + A[cos(2 pi nx x/Lx) + cos(2 pi ny y/Ly)]` --
+ * so the same run answers both the "patterned surface relaxation" and the
+ * "orientation selection" computational experiments in `#115`: an isotropic
+ * run damps the x-ridges and y-ridges at the *same* rate (the linear symbol
+ * depends only on `|k|`), while an anisotropic run with `m = 6` does not
+ * (`theta = 0` and `theta = pi/2` are inequivalent under sixfold symmetry),
+ * so the surviving orientation spectrum differs between the two runs even
+ * though they start from the identical field.
+ *
+ * `m = 4` is deliberately *not* the default science-run symmetry: a fourfold
+ * stiffness treats `theta = 0` and `theta = pi/2` as equivalent
+ * (`cos(4*0) == cos(4*pi/2)`), so a plain x/y crossed corrugation would not
+ * show a directional effect under it. `m = 4` is still fully supported and
+ * unit-tested (fourfold symmetry of `B(theta)` itself, and the
+ * `eps_a = 0` reduction), it is just not the orientation-selection
+ * demonstration case here.
+ *
+ * Usage: `surface_diffusion_anisotropic CASE.json`
+ */
+
+#include <algorithm>
+#include <cmath>
+#include <complex>
+#include <cstdio>
+#include <filesystem>
+#include <fstream>
+#include <iomanip>
+#include <iostream>
+#include <limits>
+#include <locale>
+#include <memory>
+#include <numbers>
+#include <sstream>
+#include <string>
+#include <vector>
+
+#include <mpi.h>
+#include <nlohmann/json.hpp>
+
+#include <openpfc/kernel/data/domain.hpp>
+#include <openpfc/kernel/data/grid_field.hpp>
+#include <openpfc/kernel/fft/kspace_iterator.hpp>
+#include <openpfc/kernel/simulation/stacks/spectral_cpu_stack.hpp>
+#include <openpfc_apps/structure_factor.hpp>
+
+#include <surface_diffusion/anisotropic_flux.hpp>
+#include <surface_diffusion/anisotropy.hpp>
+
+namespace {
+
+using json = nlohmann::json;
+
+struct Mode {
+  int nx{0};
+  int ny{0};
+  double amplitude{0.0};
+};
+
+/// Surface roughness/geometry observables reported every `saveat`.
+struct Sample {
+  double mean_h{};
+  double rms_roughness{};
+  double max_grad_h{};
+  double dominant_wavelength{};
+  double domain_length{};
+  double energy_kx_frac{};
+  double energy_ky_frac{};
+  double energy_diag_frac{};
+};
+
+Sample sample_surface(pfc::data::Field<double> &h, const pfc::Domain &domain,
+                      pfc::fft::CPUFFT &fft, MPI_Comm comm) {
+  double local_sum = 0.0, local_sumsq = 0.0, local_count = 0.0;
+  h.with_host_view([&](const double *d, std::size_t n) {
+    for (std::size_t i = 0; i < n; ++i) {
+      local_sum += d[i];
+      local_sumsq += d[i] * d[i];
+      local_count += 1.0;
+    }
+  });
+  double g[3]{}, l[3]{local_sum, local_sumsq, local_count};
+  MPI_Allreduce(l, g, 3, MPI_DOUBLE, MPI_SUM, comm);
+
+  Sample s;
+  s.mean_h = (g[2] > 0.0) ? g[0] / g[2] : 0.0;
+  const double mean_sq = (g[2] > 0.0) ? g[1] / g[2] : 0.0;
+  const double var = mean_sq - s.mean_h * s.mean_h;
+  s.rms_roughness = std::sqrt(std::max(var, 0.0));
+
+  pfc::data::Field<std::complex<double>> h_hat(domain, fft.get_outbox_bounds(), 0);
+  pfc::sim::SpectralETDOps<pfc::HostSpace>::forward(fft, h, h_hat);
+
+  pfc::apps::StructureFactor sf;
+  h_hat.with_host_view([&](const std::complex<double> *hv, std::size_t) {
+    sf = pfc::apps::shell_average(fft.get_outbox_bounds(), domain, hv, comm, 64);
+  });
+  s.dominant_wavelength = sf.dominant_wavelength();
+  s.domain_length = sf.domain_length();
+
+  // Directional spectral energy: split |h_hat|^2 by which axis dominates the
+  // local wavevector. The k=0 (mean height) bin carries no orientation and is
+  // excluded, matching `shell_average`'s convention.
+  //
+  // HeFFTe's r2c transform halves storage along x only: the outbox carries
+  // kx in [0, Nyquist_x] with ky (and kz) spanning their full signed range.
+  // A mode at kx=0 or kx=Nyquist is its own conjugate and appears once in
+  // the *full* complex spectrum; every 0<kx<Nyquist mode has an unstored
+  // conjugate at -kx that carries equal power. A y-oriented ridge
+  // (kx=0, ky=+-k) is therefore stored as *two* explicit points while an
+  // x-oriented ridge (kx=+-k, ky=0) is stored as *one* (its -kx twin is
+  // implicit) -- weighting interior kx modes by 2 corrects for that, or the
+  // kx/ky split is biased 2:1 toward ky regardless of any real anisotropy.
+  const int Nx = pfc::domain::get_size(domain)[0];
+  const int kx_nyquist = Nx / 2;
+  double p_kx = 0.0, p_ky = 0.0, p_diag = 0.0;
+  h_hat.with_host_view([&](const std::complex<double> *hv, std::size_t) {
+    pfc::fft::kspace::for_each_kpoint(
+        fft.get_outbox_bounds(), domain,
+        [&](std::size_t i, double kx, double ky, double kz, int ix, int, int) {
+          (void)kz;
+          const double ax = std::abs(kx), ay = std::abs(ky);
+          if (ax == 0.0 && ay == 0.0) return;
+          const double weight = (ix == 0 || ix == kx_nyquist) ? 1.0 : 2.0;
+          const double power = weight * std::norm(hv[i]);
+          if (ax > ay) {
+            p_kx += power;
+          } else if (ay > ax) {
+            p_ky += power;
+          } else {
+            p_diag += power;
+          }
+        });
+  });
+  double gp[3]{}, lp[3]{p_kx, p_ky, p_diag};
+  MPI_Allreduce(lp, gp, 3, MPI_DOUBLE, MPI_SUM, comm);
+  const double total = gp[0] + gp[1] + gp[2];
+  if (total > 0.0) {
+    s.energy_kx_frac = gp[0] / total;
+    s.energy_ky_frac = gp[1] / total;
+    s.energy_diag_frac = gp[2] / total;
+  }
+
+  // max|grad h|, evaluated spectrally from the same transform.
+  std::vector<double> kx_arr(fft.size_outbox(), 0.0), ky_arr(fft.size_outbox(), 0.0);
+  pfc::fft::kspace::for_each_kpoint(
+      fft.get_outbox_bounds(), domain,
+      [&](std::size_t i, double kx, double ky, double kz, int, int, int) {
+        (void)kz;
+        kx_arr[i] = kx;
+        ky_arr[i] = ky;
+      });
+  pfc::data::Field<std::complex<double>> gx_hat(domain, fft.get_outbox_bounds(), 0);
+  pfc::data::Field<std::complex<double>> gy_hat(domain, fft.get_outbox_bounds(), 0);
+  h_hat.with_host_view([&](const std::complex<double> *hv, std::size_t n) {
+    gx_hat.with_host_view([&](std::complex<double> *gx, std::size_t) {
+      gy_hat.with_host_view([&](std::complex<double> *gy, std::size_t) {
+        for (std::size_t i = 0; i < n; ++i) {
+          gx[i] = std::complex<double>{0.0, kx_arr[i]} * hv[i];
+          gy[i] = std::complex<double>{0.0, ky_arr[i]} * hv[i];
+        }
+      });
+    });
+  });
+  pfc::data::Field<double> hx(domain, fft.get_inbox_bounds(), 0);
+  pfc::data::Field<double> hy(domain, fft.get_inbox_bounds(), 0);
+  pfc::sim::SpectralETDOps<pfc::HostSpace>::backward(fft, gx_hat, hx);
+  pfc::sim::SpectralETDOps<pfc::HostSpace>::backward(fft, gy_hat, hy);
+  double local_max = 0.0;
+  hx.with_host_view([&](const double *gx, std::size_t n) {
+    hy.with_host_view([&](const double *gy, std::size_t) {
+      for (std::size_t i = 0; i < n; ++i)
+        local_max = std::max(local_max, std::sqrt(gx[i] * gx[i] + gy[i] * gy[i]));
+    });
+  });
+  double global_max = 0.0;
+  MPI_Allreduce(&local_max, &global_max, 1, MPI_DOUBLE, MPI_MAX, comm);
+  s.max_grad_h = global_max;
+  return s;
+}
+
+} // namespace
+
+int main(int argc, char *argv[]) {
+  MPI_Init(&argc, &argv);
+  int rank = 0, nproc = 1;
+  MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+  MPI_Comm_size(MPI_COMM_WORLD, &nproc);
+  int status = 0;
+  try {
+    if (argc != 2)
+      throw std::invalid_argument("usage: surface_diffusion_anisotropic CASE.json");
+    std::ifstream in(argv[1]);
+    if (!in) throw std::runtime_error(std::string("cannot open ") + argv[1]);
+    json cfg = json::parse(in);
+
+    const auto &d = cfg.at("domain");
+    const int Lx = d.at("Lx"), Ly = d.at("Ly"), Lz = d.value("Lz", 1);
+    if (Lz != 1)
+      throw std::invalid_argument(
+          "surface_diffusion_anisotropic: requires a 2-D domain (Lz == 1)");
+    const double dx = d.value("dx", 1.0);
+    const auto domain = pfc::domain::create(pfc::GridSize({Lx, Ly, Lz}),
+                                            pfc::PhysicalOrigin({0.0, 0.0, 0.0}),
+                                            pfc::GridSpacing({dx, dx, dx}));
+
+    surface_diffusion::AnisotropyParams params;
+    surface_diffusion::apply_anisotropy_json(cfg.at("model").at("params"), params);
+
+    const auto &ts = cfg.at("timestepping");
+    const double t1 = ts.at("t1"), dt = ts.at("dt"), saveat = ts.value("saveat", -1.0);
+
+    const auto &ic = cfg.at("initial_conditions");
+    const double h0 = ic.value("h0", 0.0);
+    std::vector<Mode> modes;
+    for (const auto &m : ic.at("modes")) {
+      modes.push_back({m.at("nx").get<int>(), m.at("ny").get<int>(),
+                       m.at("amplitude").get<double>()});
+    }
+
+    pfc::sim::stacks::SpectralCPUStack stack(domain, rank, nproc, MPI_COMM_WORLD);
+    auto &h = stack.u();
+
+    // Crossed sinusoidal corrugation: two orthogonal ridge sets superposed on
+    // a mean height, run isotropically and anisotropically from the same
+    // deterministic field.
+    const double Lx_phys = static_cast<double>(Lx) * dx;
+    const double Ly_phys = static_cast<double>(Ly) * dx;
+    const double twopi = 2.0 * std::numbers::pi;
+    h.apply([&](const pfc::Real3 &x) {
+      double v = h0;
+      for (const auto &m : modes) {
+        const double kx = twopi * static_cast<double>(m.nx) / Lx_phys;
+        const double ky = twopi * static_cast<double>(m.ny) / Ly_phys;
+        v += m.amplitude * std::cos(kx * x[0] + ky * x[1]);
+      }
+      return v;
+    });
+
+    surface_diffusion::AnisotropicSurfaceDiffusionETD stepper(
+        domain, stack.fft(), dt,
+        surface_diffusion::SurfaceStiffness::from_params(params));
+
+    std::unique_ptr<std::FILE, int (*)(std::FILE *)> out(nullptr, std::fclose);
+    if (rank == 0 && cfg.contains("diagnostics")) {
+      const std::filesystem::path path =
+          cfg.at("diagnostics").at("csv").get<std::string>();
+      if (path.has_parent_path())
+        std::filesystem::create_directories(path.parent_path());
+      out.reset(std::fopen(path.string().c_str(), "w"));
+      if (!out) throw std::runtime_error("cannot open diagnostics csv");
+      std::fprintf(out.get(),
+                   "step,time,mean_h,rms_roughness,max_grad_h,"
+                   "dominant_wavelength,domain_length,energy_kx_frac,"
+                   "energy_ky_frac,energy_diag_frac\n");
+    }
+
+    auto report = [&](int step, double t) {
+      auto s = sample_surface(h, domain, stack.fft(), MPI_COMM_WORLD);
+      if (out) {
+        std::ostringstream line;
+        line.imbue(std::locale::classic());
+        line << std::setprecision(17) << step << ',' << t << ',' << s.mean_h << ','
+             << s.rms_roughness << ',' << s.max_grad_h << ','
+             << s.dominant_wavelength << ',' << s.domain_length << ','
+             << s.energy_kx_frac << ',' << s.energy_ky_frac << ','
+             << s.energy_diag_frac << '\n';
+        std::fputs(line.str().c_str(), out.get());
+        std::fflush(out.get());
+      }
+      return s;
+    };
+
+    const int n_steps = static_cast<int>(std::llround(t1 / dt));
+    const int every =
+        (saveat > 0.0) ? std::max(1, int(std::llround(saveat / dt))) : n_steps;
+
+    Sample final_sample = report(0, 0.0);
+    double t = 0.0;
+    for (int step = 1; step <= n_steps; ++step) {
+      t = stepper.step(t, h);
+      if (step % every == 0 || step == n_steps) final_sample = report(step, t);
+    }
+
+    if (rank == 0) {
+      std::printf(
+          "SURFACE_DIFFUSION_ANISOTROPIC B0=%.17g eps_a=%.17g m=%d mean_h=%.17g "
+          "rms_roughness=%.17g max_grad_h=%.17g energy_kx_frac=%.17g "
+          "energy_ky_frac=%.17g energy_diag_frac=%.17g\n",
+          params.B0, params.eps_a, params.m, final_sample.mean_h,
+          final_sample.rms_roughness, final_sample.max_grad_h,
+          final_sample.energy_kx_frac, final_sample.energy_ky_frac,
+          final_sample.energy_diag_frac);
+    }
+  } catch (const std::exception &e) {
+    if (rank == 0) std::cerr << "surface_diffusion_anisotropic: " << e.what() << "\n";
+    status = 2;
+  }
+  MPI_Finalize();
+  return status;
+}

--- a/apps/surface_diffusion/tests/test_surface_diffusion.cpp
+++ b/apps/surface_diffusion/tests/test_surface_diffusion.cpp
@@ -4,6 +4,13 @@
 /**
  * @file test_surface_diffusion.cpp
  * @brief Catch2 tests for Mullins surface-diffusion spectral app.
+ *
+ * The isotropic exact-decay tests below (`L(k) is -B k_lap^2`, `ETD matches
+ * exp(-B k^4 t)`, `two-mode decay rates scale as k^4`, `Session runs a short
+ * JSON case`) are the `#115` numerical oracle and are unchanged by the
+ * anisotropic science case added lower in this file (`AnisotropicSurface*`
+ * test cases): the roadmap rule is "keep the verifier, add the science case
+ * on top of it."
  */
 
 #define CATCH_CONFIG_RUNNER
@@ -24,6 +31,8 @@
 #include <openpfc/kernel/simulation/spectral_etd_system.hpp>
 #include <openpfc/kernel/simulation/stacks/spectral_cpu_stack.hpp>
 #include <openpfc/kernel/simulation/time.hpp>
+#include <surface_diffusion/anisotropic_flux.hpp>
+#include <surface_diffusion/anisotropy.hpp>
 #include <surface_diffusion/surface_diffusion_physics.hpp>
 #include <surface_diffusion/surface_diffusion_session.hpp>
 
@@ -203,6 +212,195 @@ TEST_CASE("SurfaceDiffusionSession runs a short JSON case",
   surface_diffusion::SurfaceDiffusionSession session(settings, 0, 1, MPI_COMM_WORLD);
   session.run();
   REQUIRE(pfc::time::current(session.time()) == Catch::Approx(0.1).margin(1e-12));
+}
+
+// ---------------------------------------------------------------------------
+// Anisotropic surface-diffusion science case (#115). The isotropic tests
+// above are untouched and remain the numerical oracle.
+// ---------------------------------------------------------------------------
+
+TEST_CASE("SurfaceStiffness reduces exactly to B0 when eps_a = 0",
+          "[surface_diffusion][anisotropy]") {
+  const surface_diffusion::SurfaceStiffness B{/*B0=*/1.7, /*eps_a=*/0.0, /*m=*/4};
+  for (double theta : {-std::numbers::pi, -1.3, -0.5, 0.0, 0.7, 1.9,
+                       std::numbers::pi}) {
+    REQUIRE_THAT(B(theta), WithinAbs(1.7, 1e-15));
+  }
+}
+
+TEST_CASE("SurfaceStiffness has the symmetry it claims",
+          "[surface_diffusion][anisotropy]") {
+  for (int m : {4, 6}) {
+    const surface_diffusion::SurfaceStiffness B{/*B0=*/1.0, /*eps_a=*/0.6, m};
+    const double period = 2.0 * std::numbers::pi / static_cast<double>(m);
+    for (double theta : {-2.7, -0.9, 0.0, 0.4, 1.1, 2.3}) {
+      REQUIRE_THAT(B(theta), WithinAbs(B(theta + period), 1e-13));
+    }
+    // m=4 additionally makes theta=0 and theta=pi/2 equivalent; m=6 does not
+    // -- this is exactly why the science preset below uses m=6 for the
+    // crossed x/y corrugation (see surface_diffusion_anisotropic.cpp).
+    if (m == 4) {
+      REQUIRE_THAT(B(0.0), WithinAbs(B(std::numbers::pi / 2.0), 1e-13));
+    } else {
+      REQUIRE(std::abs(B(0.0) - B(std::numbers::pi / 2.0)) > 0.1);
+    }
+  }
+}
+
+namespace {
+
+/// One `AnisotropicSurfaceDiffusionETD` run of a single cosine mode; returns
+/// the measured decay rate `-log(amp(t)/amp(0))/t`.
+double anisotropic_single_mode_rate(int nx, int ny,
+                                    const surface_diffusion::SurfaceStiffness &B,
+                                    int n_steps, double dt) {
+  constexpr int N = 32;
+  constexpr double amp0 = 0.05;
+  const auto domain = pfc::domain::create(pfc::GridSize({N, N, 1}),
+                                          pfc::PhysicalOrigin({0.0, 0.0, 0.0}),
+                                          pfc::GridSpacing({1.0, 1.0, 1.0}));
+  pfc::sim::stacks::SpectralCPUStack stack(domain, 0, 1, MPI_COMM_WORLD);
+  auto &h = stack.u();
+  const double twopi = 2.0 * std::numbers::pi;
+  const double Lx = static_cast<double>(N);
+  h.apply([&](double x, double y, double) {
+    return amp0 * std::cos(twopi * (static_cast<double>(nx) * x / Lx +
+                                    static_cast<double>(ny) * y / Lx));
+  });
+  surface_diffusion::AnisotropicSurfaceDiffusionETD stepper(domain, stack.fft(), dt,
+                                                            B);
+  double t = 0.0;
+  for (int step = 0; step < n_steps; ++step) t = stepper.step(t, h);
+  const double amp = cosine_amplitude(h, nx, ny);
+  REQUIRE(amp > 0.0);
+  return -std::log(amp / amp0) / t;
+}
+
+} // namespace
+
+TEST_CASE("AnisotropicSurfaceDiffusionETD reduces to isotropic k^4 decay at "
+          "eps_a = 0",
+          "[surface_diffusion][anisotropy][spectral]") {
+  if (world_size() != 1) {
+    SKIP("single-rank spectral comparison");
+  }
+  constexpr double B0 = 1.0;
+  const surface_diffusion::SurfaceStiffness B{B0, /*eps_a=*/0.0, /*m=*/6};
+  const double rate = anisotropic_single_mode_rate(2, 0, B, 8, 0.02);
+  const double twopi = 2.0 * std::numbers::pi;
+  const double k = twopi * 2.0 / 32.0;
+  const double expected = B0 * k * k * k * k;
+  REQUIRE_THAT(rate, WithinRel(expected, 1.0e-6));
+}
+
+TEST_CASE("AnisotropicSurfaceDiffusionETD: single-orientation decay matches "
+          "B(theta)",
+          "[surface_diffusion][anisotropy][spectral]") {
+  if (world_size() != 1) {
+    SKIP("single-rank spectral comparison");
+  }
+  constexpr double B0 = 1.0;
+  constexpr double eps_a = 0.5;
+  constexpr int m = 6;
+  const surface_diffusion::SurfaceStiffness B{B0, eps_a, m};
+
+  // x-only ridges: grad h is purely in x, theta = 0 (mod pi) a.e., so
+  // B(theta) = B0*(1+eps_a) is the constant effective stiffness -- the
+  // orientation-dependent remainder handed to the stepper's *explicit* part
+  // is then spatially uniform, but that remainder is still only integrated
+  // to first order in dt (only the eps_a=0 part of L(k) is exponentiated
+  // exactly), so the measured rate matches B(theta)*k^4 to O(dt), not to
+  // machine precision; WithinRel below is loose enough to accommodate that
+  // and still catch a wrong-sign or wrong-magnitude anisotropy.
+  const double rate_x = anisotropic_single_mode_rate(2, 0, B, 8, 0.02);
+  // y-only ridges: theta = +-pi/2 a.e., cos(6*pi/2) = -1, so
+  // B(theta) = B0*(1-eps_a).
+  const double rate_y = anisotropic_single_mode_rate(0, 2, B, 8, 0.02);
+
+  const double twopi = 2.0 * std::numbers::pi;
+  const double k = twopi * 2.0 / 32.0;
+  const double k4 = k * k * k * k;
+  REQUIRE_THAT(rate_x, WithinRel(B0 * (1.0 + eps_a) * k4, 5.0e-3));
+  REQUIRE_THAT(rate_y, WithinRel(B0 * (1.0 - eps_a) * k4, 5.0e-3));
+
+  // The faceting/orientation-selection claim of #115, made quantitative: the
+  // stiffer (x) orientation relaxes measurably faster than the softer (y)
+  // orientation under the same sixfold anisotropy.
+  REQUIRE(rate_x > 1.4 * rate_y);
+}
+
+TEST_CASE("AnisotropicSurfaceDiffusionETD conserves mean height",
+          "[surface_diffusion][anisotropy][volume]") {
+  if (world_size() != 1) {
+    SKIP("single-rank spectral comparison");
+  }
+  constexpr int N = 32;
+  const auto domain = pfc::domain::create(pfc::GridSize({N, N, 1}),
+                                          pfc::PhysicalOrigin({0.0, 0.0, 0.0}),
+                                          pfc::GridSpacing({1.0, 1.0, 1.0}));
+  pfc::sim::stacks::SpectralCPUStack stack(domain, 0, 1, MPI_COMM_WORLD);
+  auto &h = stack.u();
+  const double twopi = 2.0 * std::numbers::pi;
+  const double Lx = static_cast<double>(N);
+  const double h0 = 0.37;
+  h.apply([&](double x, double y, double) {
+    return h0 + 0.05 * std::cos(twopi * 2.0 * x / Lx) +
+          0.05 * std::cos(twopi * 3.0 * y / Lx);
+  });
+  REQUIRE_THAT(mean_h(h), WithinAbs(h0, 1e-10));
+
+  const surface_diffusion::SurfaceStiffness B{1.0, 0.6, 6};
+  surface_diffusion::AnisotropicSurfaceDiffusionETD stepper(domain, stack.fft(), 0.02,
+                                                            B);
+  double t = 0.0;
+  for (int step = 0; step < 20; ++step) t = stepper.step(t, h);
+  REQUIRE_THAT(mean_h(h), WithinAbs(h0, 1e-9));
+}
+
+TEST_CASE("AnisotropicSurfaceDiffusionETD selects orientation on a crossed "
+          "corrugation",
+          "[surface_diffusion][anisotropy][faceting]") {
+  if (world_size() != 1) {
+    SKIP("single-rank spectral comparison");
+  }
+  constexpr int N = 32;
+  constexpr int n = 3;
+  constexpr double amp0 = 0.04;
+  const auto domain = pfc::domain::create(pfc::GridSize({N, N, 1}),
+                                          pfc::PhysicalOrigin({0.0, 0.0, 0.0}),
+                                          pfc::GridSpacing({1.0, 1.0, 1.0}));
+  const double twopi = 2.0 * std::numbers::pi;
+  const double Lx = static_cast<double>(N);
+  auto crossed_ic = [&](double x, double y, double) {
+    return amp0 * std::cos(twopi * n * x / Lx) + amp0 * std::cos(twopi * n * y / Lx);
+  };
+
+  auto run = [&](const surface_diffusion::SurfaceStiffness &B) {
+    pfc::sim::stacks::SpectralCPUStack stack(domain, 0, 1, MPI_COMM_WORLD);
+    auto &h = stack.u();
+    h.apply(crossed_ic);
+    surface_diffusion::AnisotropicSurfaceDiffusionETD stepper(domain, stack.fft(),
+                                                              0.02, B);
+    double t = 0.0;
+    for (int step = 0; step < 60; ++step) t = stepper.step(t, h);
+    return cosine_amplitude(h, n, 0) / cosine_amplitude(h, 0, n);
+  };
+
+  const double ratio_isotropic = run({1.0, 0.0, 6});
+  const double ratio_anisotropic = run({1.0, 0.5, 6});
+
+  // Isotropic dynamics is linear (no real-space coupling between the two
+  // orthogonal ridge sets), so this ratio holds exactly. The anisotropic run
+  // is a genuinely nonlinear, mode-coupled evolution: even though the
+  // isolated-orientation rates above differ by a factor ~3, the two ridge
+  // sets are present *simultaneously* here and each one's local B(theta)
+  // depends on the combined gradient, not on that mode alone, which dilutes
+  // (but does not remove) the orientation-selection signal relative to the
+  // naive single-mode estimate. The threshold below is set from the
+  // measured, reproducible effect at this resolution/time, not derived
+  // analytically -- unlike the single-mode test above.
+  REQUIRE_THAT(ratio_isotropic, WithinAbs(1.0, 1.0e-6));
+  REQUIRE(std::abs(ratio_anisotropic - 1.0) > 0.01);
 }
 
 int main(int argc, char *argv[]) {


### PR DESCRIPTION
## What changed

Implements the core of issue #115 on top of #114's shared helpers, following
the roadmap rule: *"keep the verifier, add the science case on top of it."*

- **Isotropic Mullins model unchanged.** `surface_diffusion_physics.hpp` /
  `surface_diffusion_pointwise.hpp` / `surface_diffusion_session.hpp` are not
  touched. The existing exact `k^4` single/two-mode decay tests are byte-for-byte
  unchanged and still pass, still presented as the verifier (not renamed into a
  science app).
- **New anisotropic model** (`apps/surface_diffusion/include/surface_diffusion/anisotropy.hpp`):
  orientation-dependent surface stiffness `B(theta) = B0[1 + eps_a cos(m theta)]`,
  `theta = atan2(h_y, h_x)`, evaluated spectrally (`i*kx*h_hat`, `i*ky*h_hat`, not
  finite differences). Generalises `dh/dt = -B0 nabla^4 h` to
  `dh/dt = div[B(theta) grad(lap h)]`.
- **New self-contained spectral-flux ETD1 stepper**
  (`include/surface_diffusion/anisotropic_flux.hpp`,
  `AnisotropicSurfaceDiffusionETD`): `B(theta)` depends on the field's own
  gradient so it cannot be written as a reciprocal-space symbol; the constant-`B0`
  part is integrated exactly (ETD) and the orientation-dependent remainder is
  treated explicitly, with Orszag 2/3 dealiasing on the flux (same pattern as
  `pfc::apps::SpectralFlux` in `apps/common`, from #114). I did not modify
  `apps/common` — `SpectralFlux::divergence`'s `mobility` callback is a function
  of the transported field's *value*, not of a separately-derived orientation
  field, so I wrote a small parallel kernel inside `apps/surface_diffusion`
  instead of changing that shared contract for the other applications already
  depending on it.
- **New science driver** `surface_diffusion_anisotropic`
  (`src/surface_diffusion_anisotropic.cpp`): a crossed sinusoidal corrugation
  (two orthogonal ridge sets, equal wavenumber) run both isotropically and
  anisotropically from the identical initial field, writing RMS roughness,
  structure-factor dominant wavelength/domain length (reusing
  `pfc::apps::shell_average`), directional spectral energy (`kx`- vs
  `ky`-dominated vs diagonal modes), max `|grad h|`, and mean height to CSV.
- **Tests** (`apps/surface_diffusion/tests/test_surface_diffusion.cpp`, appended,
  isotropic tests untouched): `B(theta)` reduces exactly to `B0` at `eps_a=0`;
  `B(theta)` has the fourfold/sixfold symmetry claimed (and that `m=4` makes
  `theta=0`/`theta=pi/2` equivalent while `m=6` does not — why the science
  preset uses `m=6`); the stepper reproduces the isotropic `exp(-B0 k^4 t)`
  decay at `eps_a=0`; a single-orientation run's decay rate matches
  `B(theta)*k^4` for both the stiff and soft orientations under sixfold
  anisotropy; mean height conserved during an anisotropic run; a
  crossed-corrugation run shows an exact 1:1 x/y amplitude ratio isotropically
  and a measurably different ratio anisotropically.
- **README** (`apps/surface_diffusion/README.md`): `Problem setup` table per
  #112 (verification preset vs science preset columns), an "Anisotropic model"
  section stating the small-slope/height-function limitation explicitly, and a
  "Measured orientation selection" section with the real numbers below.
- **CHANGELOG.md**: entry under `### Added`.

## Measured numbers (LUMI, CPU, this session)

Both presets (`inputs_json/nanosurface_isotropic.json` /
`nanosurface_anisotropic.json`) start from the identical crossed corrugation
(`nx=ny=16` on a 128² domain, `A=0.05`, RMS roughness `0.05`,
`energy_kx_frac=energy_ky_frac=0.5`) and run to `t1=8` (`dt=0.01`, 800 steps,
`B0=1`; anisotropic run additionally has `eps_a=0.5`, `m=6`):

| Observable at `t=8` | Isotropic | Anisotropic |
|---|---|---|
| RMS roughness | 0.002382 | 0.001549 |
| max\|grad h\| | 0.002646 | 0.001704 |
| `energy_kx_frac` / `energy_ky_frac` | 0.500 / 0.500 | 0.249 / 0.751 |
| mean height | −1.4e-17 | −1.2e-18 |

The isotropic run holds the 0.500/0.500 split at **every** sampled time (linear
dynamics: rate depends on `|k|`, not orientation — this doubles as an internal
consistency check). The anisotropic run's split moves monotonically away from
1:1 at every sample (`0.500→0.486→…→0.249/0.751`), i.e. the softer
(`theta=pi/2`) orientation increasingly dominates the surviving spectrum while
the stiffer (`theta=0`) orientation is preferentially damped — a reproducible,
quantified faceting/orientation-selection effect from a deterministic initial
condition. `dominant_wavelength` (orientation-blind structure factor) is
unchanged between the runs (`7.758`), which is expected and is exactly why the
directional split is the observable that shows the anisotropy, not the
structure factor alone.

**Caveat found while measuring, kept in the README:** a short single-orientation
unit test shows *isolated* stiff/soft decay rates differing ~3× for these
`(B0,eps_a,m)`, but the *combined* crossed-corrugation run shows a smaller
short-time effect than a naive per-mode extrapolation would predict, because
each orientation's local `B(theta)` is set by the *combined* gradient of both
ridge sets once both are present — the two orientations are nonlinearly
coupled. The 3:1 final split above is the honest, measured, coupled-system
number over the full run; the isolated-mode ratio is not a prediction for the
mixed pattern at short times.

Full run: `ctest -R surface-diffusion` → 100% pass (was previously green,
verified again after these changes). Full suite: `ctest` → 59/59 pass, no
regressions.

## Acceptance criteria (#115)

- [x] Existing exact Mullins single-mode test remains unchanged as the numerical oracle. (Byte-identical file except appended new `TEST_CASE`s; ran and confirmed green.)
- [x] An anisotropic surface-diffusion formulation is documented from literature — **with an explicit honesty caveat**: the *functional form and physical motivation* (Herring stiffness `gamma+gamma''`, faceting from an orientation-dependent kinetic coefficient) is sourced from Mullins (1957), Rettori & Villain (1988), Bonzel & Preuss (1995), but `B(theta)=B0[1+eps_a cos(m theta)]` is **not** obtained by differentiating a specific measured `gamma(theta)` for a real material — it imposes the same periodic form directly on the kinetic coefficient. This is stated in the header doc comment, the README's "Anisotropic model" section, and the README maturity row. Do not read `(B0, eps_a, m)` as calibrated.
- [x] Same initial surface can be run isotropically and anisotropically. (`nanosurface_isotropic.json` / `nanosurface_anisotropic.json`, identical `initial_conditions` block.)
- [x] Mean surface height/material volume is conserved. (Unit test + measured: ~1e-17–1e-18, i.e. floating-point zero, in both runs.)
- [x] Roughness decay and orientation-spectrum metrics are computed automatically. (CSV columns: `mean_h, rms_roughness, max_grad_h, dominant_wavelength, domain_length, energy_kx_frac, energy_ky_frac, energy_diag_frac`.)
- [x] Anisotropy produces a reproducible directional/faceting effect distinct from isotropic smoothing. (Measured above: 50/50 → 24.9/75.1 vs 50/50 → 50/50.)
- [x] Domain, BCs, IC and physical limitations are explicit in README/report. (`Problem setup` table + "Anisotropic model" section, small-slope/height-function limitation stated explicitly, does not claim arbitrary-slope crystalline evolution.)
- [ ] CPU/HIP observables agree within tolerance. **Not done for the anisotropic driver** — it is CPU-only by design (like `thin_film_nonlinear`/`pfc::apps::SpectralFlux`: the directional complex `i*k_d` multiply the flux needs is not in the device `Ops` layer). The *isotropic verifier's* existing CPU/HIP agreement (`surface_diffusion_hip`, `HIP_SurfaceDiffusionETD`) is unaffected by this PR (its files are untouched) but I did **not** re-run the HIP build/tests in this session — `AGENT_NOTES.md`'s build command for this task was CPU-only (`--cpu`), and I did not have a HIP allocation/build set up. Stating this plainly rather than assuming it still passes.

## Deferred / not done

- **Stretch goal** (thermal-grooving benchmark at a periodic grain-boundary
  array) — explicitly out of scope per the issue; not attempted.
- **HIP build/test of anything in this PR** — not run this session (CPU-only
  build per `AGENT_NOTES.md`); the anisotropic driver has no HIP path by
  design (see checklist above).
- A rigorous Herring-stiffness derivation (`tilde_gamma(theta) = gamma(theta) +
  gamma''(theta)` for a specific, literature-sourced `gamma(theta)`) was not
  attempted; `B(theta)` is a documented ansatz using the same functional form,
  not that derivation. Flagged everywhere the model is described.

Refs #115

Merge by **rebase**, not squash.
