### PR TITLE
feat(gradient_elasticity): stress fields and inclusion size-effect curve

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,30 @@ SPDX-License-Identifier: AGPL-3.0-or-later
   1100 h of simulated ageing). The reduced regular-solution verifier is the
   `L1 = 0` case of the same expression, not a second code path.
 
+- `gradient_elasticity`: derived stress/strain/energy fields and a
+  misfitting-inclusion size-effect study (`#117`). Every run now also
+  computes, spectrally from the displacement solution: strain (`exx`/`eyy`/
+  `exy`), Cauchy stress (`sxx`/`syy`/`sxy`), the hydrostatic/von-Mises
+  invariants (`stress_hydro`/`stress_vm`), and the elastic energy density
+  (`energy_density`) -- via the classical local constitutive law evaluated
+  on the (already `ell`-regularized) displacement field, documented as such.
+  New `circular_inclusion` field modifier (`tanh`-smoothed flat-top disk of
+  radius `R`) and a `line_profile` JSON block (single-rank line-cut CSV) feed
+  a new `scripts/size_sweep.py` size-effect sweep: peak hydrostatic/von-Mises
+  stress and total elastic energy vs. `R/ell`. For this smooth, finite
+  inclusion (no classical singularity), the measured, physical direction is
+  that peak stress *decreases* monotonically as `R/ell` grows, bounded above
+  by a new closed-form "clamped" limit (`R/ell -> 0`, no elastic relaxation)
+  and below by the classical "relaxed" limit (`R/ell -> infinity`,
+  Eshelby-type) -- both derived, checked by unit tests, and documented in the
+  app README, along with a documented and tested periodic-image control
+  (box doubling changes peak stress by <2% at `L/max(R,ell)=16`; ratio 8
+  measured ~4-5% contamination). The existing `#82` cosine/Gaussian
+  analytical verifiers are untouched and stay green. Deferred: the
+  dislocation/defect regularization benchmark (issue section B) and a
+  systematic 4th-vs-6th-order comparison (section C) beyond the existing
+  `alpha(k)` unit tests -- see the app README's "What `#117` does not
+  cover".
 
 - Cray/LUMI site profile for the runtime baker (`#13`): `--site cray`,
   `--host-lib` for stack libraries that share a directory with ordinary system

--- a/apps/gradient_elasticity/README.md
+++ b/apps/gradient_elasticity/README.md
@@ -6,7 +6,8 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 # Gradient elasticity (`apps/gradient_elasticity`)
 
 Isotropic **strain-gradient elasticity** (Aifantis / Helmholtz–Navier). This
-is the 0.2 application for GitHub issue `#82`.
+is the 0.2 application for GitHub issue `#82`, extended by `#117` with
+stress/energy diagnostics and a misfitting-inclusion size-effect study.
 
 Binaries: `gradient_elasticity` (CPU); `gradient_elasticity_hip` when
 `OpenPFC_ENABLE_HIP_SPECTRAL` is on. The HIP twin FFTs on the device and
@@ -15,6 +16,32 @@ inverts the \(2\times 2\) hats on the host.
 This is a **static** spectral solve, not ETD time-stepping. JSON still
 needs a `timestepping` block because the shared Time parser requires
 `t0 < t1` and `dt`; those values are unused.
+
+## Problem setup
+
+Per the report/application contract (`#112`), two presets share this app.
+The **verification preset** is small and analytically checked (CI); the
+**science preset** is the `#117` inclusion size sweep (not run in CI, see
+[Size-effect sweep](#misfitting-inclusion-size-sweep-117)).
+
+| Item | Verification preset (`cosine_mode`) | Science preset (`circular_inclusion` size sweep) |
+|---|---|---|
+| Use case | Correctness check: single-Fourier-mode eigenstrain against the exact Fourier solution | How much does an internal length \(\ell\) change the peak stress/energy of a misfitting inclusion, as a function of inclusion size `R`? |
+| Domain | 2-D periodic square (`Lz=1`), homogeneous isotropic elastic medium, plane model (no explicit `zz` direction) | Same; box `L=16*max(R,ell)` so the periodic-image ratio stays fixed relative to both length scales (see [Periodic-image control](#periodic-image-control)) |
+| Grid | `32`–`64`² regular, `dx=dy=1` | `32`²–`1024`² regular, `dx=dy=1`, scaled with `R` |
+| Boundary conditions | Periodic on every axis (spectral method) | Periodic on every axis |
+| Initial condition | `cosine_mode`: \(g=g_0+A\cos(\mathbf{k}\cdot\mathbf{x})\), one Fourier mode | `circular_inclusion`: `tanh`-smoothed flat-top disk of radius `R`, dilatational eigenstrain `eps0*g` inside, ~0 outside |
+| Key physical parameters | `mu`, `lambda`, `ell`, `eps0` -- illustrative/nondimensional (no cited material), see caveat below | Same, plus inclusion radius `R` and internal length `ell` (both in grid-spacing units); `R/ell` is the controlling nondimensional group |
+| Observable | Exact match of `ux`/`uy` (and now `exx`/`eyy`/`exy`/stress/energy) to the closed-form Fourier displacement/strain/stress | Peak \(|\sigma_{h}|\), peak \(\sigma_{vm}\), total elastic energy, and a line profile of `u`/stress vs. distance from the inclusion centre, all vs. `R/ell` |
+| Model maturity | numerical verification: **analytical**; physical completeness: **reduced** (isotropic, homogeneous, 2-D planar eigenstrain, no dislocation/defect representation); calibration: **none** (nondimensional) | numerical verification: **analytical** at both `R/ell` extremes (classical Eshelby-type closed form as `R/ell -> infinity`, "clamped" closed form as `R/ell -> 0`, see below), **regression** (monotonicity + bounds) in between; physical completeness: **reduced**, same caveats; calibration: **none** |
+
+This app is a homogeneous, isotropic, plane (2-D), fully periodic elastic
+medium throughout: there is no free surface, no anisotropy, and no
+compositional/thermal coupling. "Periodic" means the inclusion (or Fourier
+mode) is one member of an infinite periodic array of identical inclusions;
+[Periodic-image control](#periodic-image-control) quantifies when that
+array does not measurably perturb the single-inclusion numbers reported
+here.
 
 ## Physics
 
@@ -46,7 +73,10 @@ and transverse parts:
 
 The \(k=0\) (rigid) mode is projected to \(\hat{\mathbf{u}}=0\). Optional
 sixth-order stretch: `order=6` uses \(\alpha=(1+\ell^2 k^2)^2\); `ell4>0`
-uses \(\alpha=1+\ell^2 k^2+\ell_4^4 k^4\).
+uses \(\alpha=1+\ell^2 k^2+\ell_4^4 k^4\). `#117` does not systematically
+compare the 4th- and 6th-order responses beyond the existing unit tests of
+`alpha(k)`; that comparison (issue section C) is deferred, see
+[What #117 does not cover](#what-117-does-not-cover).
 
 The shipped loading is a **periodic dilatational eigenstrain**
 \(\varepsilon^*=\varepsilon_0 g\,I\) in a 2-D slab (`ux`, `uy`). The
@@ -61,6 +91,43 @@ recovered. Finite \(\ell\) reduces high-\(k\) content.
 The \(2\times 2\) invert stays in the app (`invert` / `solve_displacement`).
 `SpectralDiagonalSolver` is scalar-only and is not used here.
 
+### Strain, stress, and energy (`#117`)
+
+Every run also derives, spectrally, from the displacement solution:
+
+- **strain** `exx`, `eyy`, `exy` (tensor components, not engineering):
+  \(\hat\varepsilon=\tfrac12(i\mathbf{k}\otimes\hat{\mathbf{u}}+\hat{\mathbf{u}}
+  \otimes i\mathbf{k})\), computed in the same \(\mathbf{k}\)-loop as the
+  displacement invert (no extra forward FFT);
+- **stress** `sxx`, `syy`, `sxy`, plus the invariants `stress_hydro`
+  (\(\sigma_h=\tfrac12(\sigma_{xx}+\sigma_{yy})\)) and `stress_vm`
+  (in-plane reduced von Mises,
+  \(\sigma_{vm}=\sqrt{\sigma_{xx}^2-\sigma_{xx}\sigma_{yy}+\sigma_{yy}^2+3\sigma_{xy}^2}\));
+- **elastic energy density** `energy_density`
+  (\(w=\tfrac12\sigma_{ij}\varepsilon^e_{ij}\)).
+
+Stress is the **classical, local** constitutive law
+\(\sigma=\lambda\,\mathrm{tr}(\varepsilon^e)I+2\mu\varepsilon^e\),
+\(\varepsilon^e=\varepsilon(\mathbf{u})-\varepsilon^*\), evaluated on the
+*already-regularized* displacement/strain field \(\mathbf{u}\). This is a
+deliberate simplification, not the higher-order Aifantis stress operator
+\(\sigma_{\mathrm{grad}}=(1-\ell^2\nabla^2)\sigma_{\mathrm{classical}}\):
+that operator is not uniquely defined for the `order=6`/`ell4` variants
+this app also supports, and using the simpler local law keeps one
+constitutive convention for every case. All of the size-dependent
+regularization reported here therefore comes from the smoothed
+*displacement/strain* field, not from an additional stress-smoothing
+operator. See `GradientElasticityPhysics::stress_state` (doxygen) for the
+same statement next to the code.
+
+The reduced (in-plane) von Mises invariant also ignores an out-of-plane
+\(\sigma_{zz}\): the eigenstrain here has no `zz` component (a genuinely
+2-D planar model, not a 3-D plane-strain elasticity problem with a
+non-trivial \(\sigma_{zz}\)), so `stress_vm` is not the full 3-D von Mises
+stress. For the equibiaxial state inside a classical circular inclusion
+(see below) this reduced invariant equals \(|\sigma_h|\), which is a useful
+sanity check but is *not* generally true off that special state.
+
 ## Run
 
 ```bash
@@ -69,34 +136,250 @@ mpirun -n 1 ./apps/gradient_elasticity/gradient_elasticity \
   ../apps/gradient_elasticity/inputs_json/inclusion.json
 mpirun -n 1 ./apps/gradient_elasticity/gradient_elasticity \
   ../apps/gradient_elasticity/inputs_json/gaussian.json
+mpirun -n 1 ./apps/gradient_elasticity/gradient_elasticity \
+  ../apps/gradient_elasticity/inputs_json/circular_inclusion.json
 ```
 
-VTK of `g`, `ux`, and `uy` goes to `results/gradient_elasticity/`.
+VTK of any declared field (`g`, `ux`, `uy`, `exx`, `eyy`, `exy`, `sxx`,
+`syy`, `sxy`, `stress_hydro`, `stress_vm`, `energy_density`) goes to
+`results/gradient_elasticity/` when listed in the JSON `fields` array.
+Every run also prints, on rank 0:
+
+```text
+SPECTRAL_CHECKSUM field=ux ...
+SPECTRAL_CHECKSUM field=uy ...
+GRADIENT_ELASTICITY_SUMMARY ell=... ell4=... order=... peak_abs_hydrostatic_stress=... peak_von_mises_stress=... total_elastic_energy=...
+```
 
 JSON `model.params`: `mu`, `lambda`, `ell`, `eps0`, optional `order`
 (4 or 6), optional `ell4`. `E` and `nu` may replace `mu`/`lambda`
 (plane-strain Lamé conversion). Initial conditions: `"type":
-"cosine_mode"` (`g0` / `amplitude` / `nx` / `ny` / `nz`) or
+"cosine_mode"` (`g0` / `amplitude` / `nx` / `ny` / `nz`),
 `"gaussian_inclusion"` (`amplitude` / `sigma`, optional `g0` / `x0` /
-`y0`).
+`y0`), or `"circular_inclusion"` (`amplitude` / `radius` / optional
+`interface_width` (default `1.0`) / `g0` / `x0` / `y0`) -- a
+`tanh`-smoothed flat-top disk,
+\(g=g_0+A\cdot\tfrac12(1-\tanh((r-R)/w))\), periodic (minimum-image)
+distance `r` from the centre.
+
+A top-level `"line_profile": {"path": "...", "x0": <opt>, "y0": <opt>}`
+JSON block writes a straight-line CSV cut through `(x0, y0)` along `+x`
+(`r,x,y,g,ux,uy,stress_hydro,stress_vm,energy_density`); single-rank only.
+`x0`/`y0` default to the domain midpoint.
+
+## Misfitting-inclusion size sweep (`#117`)
+
+Science case A of `#117`: a smoothed circular inclusion with dilatational
+eigenstrain, radius `R`, in a periodic cell, with internal length `ell`
+fixed. `apps/gradient_elasticity/scripts/size_sweep.py` runs the app once
+per `R`, parses the `GRADIENT_ELASTICITY_SUMMARY` line, and writes an
+aggregated CSV:
+
+```bash
+python3 apps/gradient_elasticity/scripts/size_sweep.py \
+  --binary build/apps/gradient_elasticity/gradient_elasticity \
+  --outdir results/gradient_elasticity/size_sweep \
+  --csv results/gradient_elasticity/size_sweep.csv \
+  --ell 8.0 --box-to-radius 16.0 --box-check-radius 32 \
+  --line-profile-radii 4 32 128 \
+  --launcher 'srun --overlap -n 1'
+```
+
+(Drop `--launcher` to run the binary directly; on LUMI, use the shared
+allocation per the environment notes, i.e. run with `SLURM_JOB_ID`/`TMPDIR`
+already set in the environment. `--launcher` takes one shell-quoted string,
+split with `shlex`, so it can hold its own `-n`/`--` flags without
+confusing this script's own argument parser.)
+
+### Which direction is the size effect?
+
+This loading is a **smooth, finite** inclusion -- classical elasticity
+already gives a finite, bounded field for it (no singularity at any length
+scale), unlike a dislocation or crack tip. So `ell` here does not
+"regularize a classical singularity" the way it does for the high-\(k\)
+cosine mode (existing `#82` test: finite `ell` damps a high mode's
+amplitude versus `ell=0`). Instead, `ell` acts as an increasing constraint
+on *elastic relaxation*: a large gradient penalty forbids the spatial
+variation the surrounding matrix would otherwise use to relax the misfit
+strain. The measured, physical result (see
+[Classical and clamped closed forms](#classical-and-clamped-closed-forms)
+below) is that **peak stress decreases monotonically as `R/ell` grows**,
+from a closed-form **clamped** bound (`R/ell -> 0`: essentially no
+relaxation, maximum internal stress) down to the closed-form classical
+**relaxed** bound (`R/ell -> infinity`: full elastic relaxation, the
+familiar Eshelby-type inclusion result). This is a genuine, textbook-
+consistent gradient-elasticity size effect (an "apparently stiffer small
+inclusion", the same family of effect as size-dependent strength in
+strain-gradient plasticity) -- just not the "peak-stress reduction" framing
+that applies to singular defects, which this app does not attempt (see
+[What `#117` does not cover](#what-117-does-not-cover)). **Total** elastic
+energy grows with `R` regardless (it is an integral over a growing area,
+roughly \(\propto R^2\) classically); the same size effect shows up in
+energy only after normalizing by the inclusion area, `energy/R^2`, which
+the table below also reports and which decreases with `R/ell` exactly like
+peak stress does.
+
+### Measured size-effect table
+
+`ell=8`, `mu=lambda=1`, `eps0=0.01`, `L=16*max(R,ell)`, `order=4`, measured
+on LUMI with `scripts/size_sweep.py` (exact command in the PR body).
+Closed-form bounds: clamped (`R/ell -> 0`)
+\(|\sigma_h^{\mathrm{clamped}}|=0.04\); classical (`R/ell -> infinity`)
+\(|\sigma_h^{\mathrm{classical}}|\approx 0.013333\),
+\(\sigma_{vm}^{\mathrm{classical}}(\mathrm{boundary})\approx 0.023094\).
+
+| R | R/ell | peak \|hydrostatic stress\| | peak von Mises stress | total elastic energy | energy / R² |
+|---:|---:|---:|---:|---:|---:|
+| 4 | 0.5 | 0.03547 | 0.03547 | 0.01292 | 0.000808 |
+| 8 | 1 | 0.03145 | 0.03147 | 0.04682 | 0.000731 |
+| 16 | 2 | 0.02544 | 0.02555 | 0.13677 | 0.000534 |
+| 32 | 4 | 0.02033 | 0.02065 | 0.43863 | 0.000428 |
+| 64 | 8 | 0.01659 | 0.01692 | 1.60974 | 0.000393 |
+| 128 | 16 | 0.01426 | 0.01438 | 6.29299 | 0.000384 |
+
+Peak stress (and `energy/R^2`) decreases monotonically with `R/ell`,
+bounded above by the clamped value (`0.04`) and below by the classical
+value (`0.013333`); the `R/ell=16` row is within 7% of the classical bound
+and still visibly approaching it. See the PR body for the full run output.
+`apps/gradient_elasticity/tests/test_gradient_elasticity.cpp` checks the
+same monotonicity and both bounds on a small grid as an automated
+regression (not this exact sweep, which is a science preset and
+intentionally not run in CI, per the roadmap `#120` "keep science presets
+out of CI" rule).
+
+### Classical and clamped closed forms
+
+**Classical** (`ell=0`, infinite matrix, sharp boundary): the solution for
+a 2-D circular inclusion of radius `R` with dilatational eigenstrain
+\(\varepsilon^*=\varepsilon_0 I\), from axisymmetric elasticity with
+eigenstrain (a standard "inclusion problem", e.g. Mura, *Micromechanics of
+Defects in Solids*): with
+\(A=\varepsilon_0(\lambda+\mu)/(\lambda+2\mu)\), stress is **spatially
+uniform inside** and independent of `R`,
+
+\[
+\sigma_h^{\mathrm{in}}=\sigma_{rr}^{\mathrm{in}}=\sigma_{\theta\theta}^{\mathrm{in}}
+=2(\lambda+\mu)(A-\varepsilon_0)=-\frac{2\mu(\lambda+\mu)}{\lambda+2\mu}\varepsilon_0,
+\]
+
+and decays as \(1/r^2\) outside, with a jump in the von Mises invariant at
+the boundary,
+
+\[
+\sigma_{vm}(R^+)=\sqrt{3}\cdot 2\mu A.
+\]
+
+**Clamped** (`ell -> infinity`, equivalently `R/ell -> 0`): every Fourier
+mode with \(k>0\) is annihilated as \(\alpha=1+\ell^2k^2\to\infty\), so
+\(\mathbf{u}\to 0\) identically (the gradient penalty forbids *any* spatial
+variation of the displacement). With \(\mathbf{u}=0\), the elastic strain
+is just the negative eigenstrain, so deep inside the inclusion (\(g=1\))
+the material cannot relax the misfit at all:
+
+\[
+\sigma_h^{\mathrm{clamped}}=\sigma_{vm}^{\mathrm{clamped}}=-2(\lambda+\mu)\varepsilon_0,
+\]
+
+a pure equibiaxial state (so hydrostatic and reduced-von-Mises coincide),
+independent of `R` and `ell`. This is the *maximum possible* internal
+stress for this eigenstrain.
+
+Both bounds have **no dependence on `R`** -- exactly the fact that a
+finite internal length `ell` breaks by introducing the nondimensional group
+`R/ell`, which is the size effect this app measures. The classical form is
+used directly in the `ell=0` unit test (`"ell=0 recovers the classical
+analytical circular-inclusion stress"`); the clamped form bounds the
+`"Peak inclusion stress decreases monotonically..."` unit test from above.
+
+## Periodic-image control
+
+Every case in the sweep keeps a fixed ratio of box size `L` to
+`max(R, ell)` (default 16, not just `R`: ell can exceed R at the small-R
+end of the sweep) so neither the inclusion nor the ell-scale smoothing
+fills a large fraction of the periodic cell.
+`apps/gradient_elasticity/tests/test_gradient_elasticity.cpp` ("Doubling
+the periodic box leaves the inclusion peak stress essentially unchanged")
+measured, at `R=12`, `ell=3`: going from `L/max(R,ell)=8` to `16` changed
+the peak hydrostatic stress by **~4.3%**; going from `16` to `32` changed
+it by only **~1.1%** (printed via `WARN` in the test output every run, so
+this number is checked, not just quoted) -- a converging trend, and the
+reason `16` (not `8`) is the sweep's default ratio. The test requires that
+`16 -> 32` change to stay under 2%. `--box-check-radius` on `size_sweep.py`
+reproduces the same check at full sweep resolution and prints the measured
+relative change (see PR body for the run).
 
 ## Tests
 
-`ctest -R gradient-elasticity` checks the Helmholtz factor, the
-longitudinal invert, \(k=0\) projection, \(\ell\to 0\) recovery of
-classical elasticity, analytical Fourier displacement for a cosine
-inclusion, high-\(k\) reduction at finite \(\ell\), and mean
-\(\mathbf{u}=0\). HIP builds add `HIP_GradientElasticity` and
+`ctest -R gradient-elasticity` checks (all still pass, `#82` verifiers
+untouched): the Helmholtz factor, the longitudinal invert, \(k=0\)
+projection, \(\ell\to 0\) recovery of classical elasticity, analytical
+Fourier displacement for a cosine inclusion, high-\(k\) reduction at finite
+\(\ell\), mean \(\mathbf{u}=0\); and, for `#117`: strain/stress
+post-processing against the analytical cosine-mode field, the `ell=0`
+classical circular-inclusion closed form above, monotonicity of peak
+inclusion stress in `R/ell`, and the box-doubling periodic-image check.
+HIP builds add `HIP_GradientElasticity` and
 `gradient-elasticity-hip-smoke`. LUMI-G smoke: job 21820023 (`small-g`,
-16², mean \(\mathbf{u}=0\)).
+16², mean \(\mathbf{u}=0\)); the HIP session-parity test
+(`HIP_GradientElasticity`) still only compares `ux`/`uy` between the CPU
+and HIP sessions -- the new derived fields are computed identically on both
+(same real-space post-processing code, `with_host_view`-generic) but are
+not separately diff-checked CPU vs. HIP, see below.
+
+## What `#117` does not cover
+
+Honestly, what was implemented and what was deferred:
+
+- **Implemented**: derived strain/stress/energy fields; the
+  `circular_inclusion` smoothed flat-top eigenstrain; the size-effect sweep
+  script and a measured size-effect table (see PR body); a documented,
+  tested periodic-image control; Catch2 coverage of the analytical
+  cosine-mode stress check, the `ell=0` classical circular-inclusion
+  closed form, size-effect monotonicity, and box-doubling.
+- **Deferred: section B, the dislocation/defect regularization benchmark.**
+  The issue's preferred target (an edge-dislocation-like eigenstrain
+  representation) needs a distinct loading (a displacement-jump/Burgers-
+  vector construction) compatible with the periodic spectral formulation,
+  which is a materially different piece of physics from the inclusion
+  study above. It is not implemented here; the inclusion size-effect study
+  already demonstrates the qualitative regularization lesson (finite,
+  size-dependent peak stress instead of a classical, size-independent
+  peak) with a case that has an exact classical closed form to check
+  against, which the dislocation case would not have as cheaply.
+- **Deferred/partial: section C, systematic 4th- vs 6th-order comparison.**
+  `order=6` and `ell4` were already implemented before `#117` and are unit
+  tested at the level of `alpha(k)`; `#117` did not add a dedicated
+  controlled-setup comparison (e.g. one inclusion run at `order=4` vs.
+  `order=6`) beyond that. Anyone extending this can add it cheaply: the
+  `run_circular_case` test helper already takes an `order` argument.
+- **Not separately verified**: CPU vs. HIP agreement for the *new* derived
+  fields specifically (issue acceptance criterion "CPU/HIP observables
+  agree within tolerance"). The post-processing code path is
+  memory-space-generic (`with_host_view`, used identically for `HostSpace`
+  and `HIPSpace`) and reuses the same displacement solve the existing
+  `HIP_GradientElasticity` test already diff-checks, so there is no new
+  numerical code specific to HIP, but a direct CPU-vs-HIP diff of e.g.
+  `stress_vm` was not run as part of this change (no HIP device was
+  available in this environment's build; only `--cpu` was built/tested).
+- **Stretch goals** from the issue (anisotropic cubic elasticity, a 3-D
+  precipitate benchmark, coupling into another physics model) were not
+  attempted, as scoped.
+- Physical constants (`mu`, `lambda`, `eps0`, `ell`, `R`) throughout this
+  app remain **illustrative/nondimensional**, not calibrated to a named
+  material; the `Problem setup` table above labels calibration as "none"
+  for both presets, honestly.
 
 ## Layout
 
 | Path | Role |
 |------|------|
-| `include/gradient_elasticity/gradient_elasticity_physics.hpp` | \(\alpha(k)\), \(2\times 2\) invert, eigenstrain force |
-| `include/gradient_elasticity/gradient_elasticity_solve.hpp` | FFT → host invert → IFFT |
-| `include/gradient_elasticity/gradient_elasticity_session.hpp` | JSON session, fields `g`/`ux`/`uy` |
+| `include/gradient_elasticity/gradient_elasticity_physics.hpp` | \(\alpha(k)\), \(2\times 2\) invert, eigenstrain force, strain-from-displacement, local stress/energy state |
+| `include/gradient_elasticity/gradient_elasticity_solve.hpp` | FFT → host invert → IFFT (displacement, and displacement+strain) |
+| `include/gradient_elasticity/gradient_elasticity_diagnostics.hpp` | Stress/energy fields from strain+eigenstrain, peak/energy reduction, line-profile CSV |
+| `include/gradient_elasticity/gradient_elasticity_session.hpp` | JSON session, fields `g`/`ux`/`uy`/strain/stress/energy |
+| `include/gradient_elasticity/circular_inclusion.hpp` | `circular_inclusion` smoothed flat-top eigenstrain field modifier |
 | `src/gradient_elasticity.cpp` / `src/hip/` | CPU / HIP `main` |
-| `inputs_json/inclusion.json` | Cosine eigenstrain |
+| `scripts/size_sweep.py` | `#117` size-effect sweep driver (science preset, not run in CI) |
+| `inputs_json/inclusion.json` | Cosine eigenstrain (verification) |
 | `inputs_json/gaussian.json` | Localized Gaussian inclusion |
+| `inputs_json/circular_inclusion.json` | One flat-top circular inclusion with all derived fields written out |

--- a/apps/gradient_elasticity/include/gradient_elasticity/circular_inclusion.hpp
+++ b/apps/gradient_elasticity/include/gradient_elasticity/circular_inclusion.hpp
@@ -1,0 +1,147 @@
+// SPDX-FileCopyrightText: 2026 VTT Technical Research Centre of Finland Ltd
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+#pragma once
+
+/**
+ * @file circular_inclusion.hpp
+ * @brief Smoothed flat-top circular inclusion:
+ * \(g=g_0+A\cdot\tfrac12\bigl(1-\tanh\bigl(\tfrac{r-R}{w}\bigr)\bigr)\).
+ *
+ * @details
+ * `g` is \(\approx A\) for \(r\ll R\), \(\approx 0\) for \(r\gg R\), and
+ * transitions over an interface half-width \(w\) around \(r=R\) (a
+ * `tanh`-smoothed indicator, not a sharp disk): a sharp disk has infinite
+ * Fourier content and rings on a periodic grid; the smoothing keeps the
+ * eigenstrain field well resolved at finite grid spacing while still
+ * defining a clean radius `R` for the `#117` inclusion size sweep. Distance
+ * `r` from the centre is measured with periodic (minimum-image) wrapping, so
+ * this is well-defined even when `R` is a sizeable fraction of the box.
+ *
+ * This is the *dilatational eigenstrain amplitude* field `g`; the physics
+ * eigenstrain is \(\varepsilon^*=\varepsilon_0 g I\) (`eps0` in
+ * `model.params`), matching `cosine_mode`/`gaussian_inclusion`.
+ *
+ * JSON `"type": "circular_inclusion"`.
+ */
+
+#include <cmath>
+#include <limits>
+#include <stdexcept>
+#include <string>
+
+#include <nlohmann/json.hpp>
+
+#include <openpfc/frontend/ui/from_json_field_modifiers.hpp>
+#include <openpfc/kernel/data/box3i.hpp>
+#include <openpfc/kernel/data/domain.hpp>
+#include <openpfc/kernel/field/operations.hpp>
+#include <openpfc/kernel/field/state_access.hpp>
+#include <openpfc/kernel/simulation/field_modifier.hpp>
+
+namespace gradient_elasticity {
+
+class CircularInclusion : public pfc::FieldModifier {
+public:
+  void set_g0(double g0) { m_g0 = g0; }
+  void set_amplitude(double amplitude) { m_amplitude = amplitude; }
+  void set_radius(double radius) { m_radius = radius; }
+  void set_interface_width(double w) { m_interface_width = w; }
+  void set_x0(double x0) { m_x0 = x0; }
+  void set_y0(double y0) { m_y0 = y0; }
+
+  [[nodiscard]] double g0() const { return m_g0; }
+  [[nodiscard]] double amplitude() const { return m_amplitude; }
+  [[nodiscard]] double radius() const { return m_radius; }
+  [[nodiscard]] double interface_width() const { return m_interface_width; }
+  [[nodiscard]] double x0() const { return m_x0; }
+  [[nodiscard]] double y0() const { return m_y0; }
+
+  const std::string &get_modifier_name() const override {
+    static const std::string k{"CircularInclusion"};
+    return k;
+  }
+
+  void apply(pfc::field::FieldOutput<double> field, const pfc::Domain &domain,
+             const pfc::Box3i &box, double /*time*/) override {
+    const auto size = pfc::domain::get_size(domain);
+    const auto spacing = pfc::domain::get_spacing(domain);
+    const double Lx = spacing[0] * static_cast<double>(size[0]);
+    const double Ly = spacing[1] * static_cast<double>(size[1]);
+    const double x0 = std::isfinite(m_x0) ? m_x0 : 0.5 * Lx;
+    const double y0 = std::isfinite(m_y0) ? m_y0 : 0.5 * Ly;
+    const double g0 = m_g0;
+    const double amp = m_amplitude;
+    const double R = m_radius;
+    const double w = m_interface_width;
+    if (!(R > 0.0)) {
+      throw std::invalid_argument("circular_inclusion: radius must be > 0.");
+    }
+    if (!(w > 0.0)) {
+      throw std::invalid_argument("circular_inclusion: interface_width must be > 0.");
+    }
+    auto wrap = [](double d, double L) {
+      if (!(L > 0.0)) {
+        return d;
+      }
+      return d - L * std::nearbyint(d / L);
+    };
+    pfc::field::apply(field, domain, box, [=](const pfc::Real3 &x) {
+      const double dx = wrap(x[0] - x0, Lx);
+      const double dy = wrap(x[1] - y0, Ly);
+      const double r = std::sqrt(dx * dx + dy * dy);
+      return g0 + amp * 0.5 * (1.0 - std::tanh((r - R) / w));
+    });
+  }
+
+private:
+  double m_g0{0.0};
+  double m_amplitude{1.0};
+  double m_radius{8.0};
+  double m_interface_width{1.0};
+  double m_x0{std::numeric_limits<double>::quiet_NaN()};
+  double m_y0{std::numeric_limits<double>::quiet_NaN()};
+};
+
+inline void from_json(const nlohmann::json &j, CircularInclusion &ic) {
+  pfc::ui::detail::throw_unless_json_modifier_type(
+      j, "circular_inclusion",
+      "Invalid JSON input: missing or incorrect 'type' field.");
+  if (j.contains("g0")) {
+    if (!j["g0"].is_number()) {
+      throw std::invalid_argument("circular_inclusion: 'g0' must be numeric.");
+    }
+    ic.set_g0(j["g0"].get<double>());
+  }
+  if (!j.contains("amplitude") || !j["amplitude"].is_number()) {
+    throw std::invalid_argument(
+        "circular_inclusion: missing or invalid 'amplitude' field.");
+  }
+  ic.set_amplitude(j["amplitude"].get<double>());
+  if (!j.contains("radius") || !j["radius"].is_number()) {
+    throw std::invalid_argument(
+        "circular_inclusion: missing or invalid 'radius' field.");
+  }
+  ic.set_radius(j["radius"].get<double>());
+  if (j.contains("interface_width")) {
+    if (!j["interface_width"].is_number()) {
+      throw std::invalid_argument(
+          "circular_inclusion: 'interface_width' must be numeric.");
+    }
+    ic.set_interface_width(j["interface_width"].get<double>());
+  }
+  if (j.contains("x0")) {
+    if (!j["x0"].is_number()) {
+      throw std::invalid_argument("circular_inclusion: 'x0' must be numeric.");
+    }
+    ic.set_x0(j["x0"].get<double>());
+  }
+  if (j.contains("y0")) {
+    if (!j["y0"].is_number()) {
+      throw std::invalid_argument("circular_inclusion: 'y0' must be numeric.");
+    }
+    ic.set_y0(j["y0"].get<double>());
+  }
+}
+
+} // namespace gradient_elasticity

--- a/apps/gradient_elasticity/include/gradient_elasticity/gradient_elasticity_diagnostics.hpp
+++ b/apps/gradient_elasticity/include/gradient_elasticity/gradient_elasticity_diagnostics.hpp
@@ -1,0 +1,197 @@
+// SPDX-FileCopyrightText: 2026 VTT Technical Research Centre of Finland Ltd
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+#pragma once
+
+/**
+ * @file gradient_elasticity_diagnostics.hpp
+ * @brief Real-space stress/energy post-processing and reduced diagnostics
+ * for the gradient-elasticity size-effect study (`#117`).
+ *
+ * @details
+ * `compute_stress_fields` turns the compatible strain (`exx`/`eyy`/`exy`,
+ * from `solve_displacement_and_strain`) and the eigenstrain field `g` into
+ * the Cauchy stress components, hydrostatic/von-Mises invariants, and the
+ * elastic energy density, via `GradientElasticityPhysics::stress_state` at
+ * every owned grid point. `summarize_stress` then reduces those fields to
+ * the three scalar science-case observables: peak \(|\sigma_h|\), peak
+ * \(\sigma_{vm}\), and total elastic energy \(\int w\,dA\) (MPI-collective).
+ *
+ * `write_line_profile` dumps a straight line cut through a chosen centre
+ * (displacement, stress, energy density vs. distance) to CSV -- the "radial
+ * line profile" required by the issue. A straight cut through the inclusion
+ * centre is used instead of a polar/angular average: the circular inclusion
+ * is not exactly axisymmetric on a periodic square grid, but a cut is
+ * simple, exact (no interpolation), and sufficient to see the near-field
+ * decay and any high-\(k\) ringing at the interface.
+ */
+
+#include <algorithm>
+#include <cmath>
+#include <cstddef>
+#include <filesystem>
+#include <fstream>
+#include <iomanip>
+#include <limits>
+#include <sstream>
+#include <stdexcept>
+#include <string>
+
+#include <mpi.h>
+
+#include <gradient_elasticity/gradient_elasticity_physics.hpp>
+#include <openpfc/kernel/data/domain.hpp>
+#include <openpfc/kernel/data/grid_field.hpp>
+
+namespace gradient_elasticity {
+
+/// Reduced size-effect observables (`#117` science case A): peak stresses
+/// and total stored elastic energy over the whole periodic cell.
+struct StressSummary {
+  double peak_abs_hydrostatic{}; ///< \(\max|\sigma_h|\) over the domain.
+  double peak_von_mises{};       ///< \(\max\sigma_{vm}\) over the domain.
+  double total_elastic_energy{}; ///< \(\int w\,dA\) (2-D; per unit thickness).
+};
+
+/// Fill `sxx`/`syy`/`sxy`/`stress_hydro`/`stress_vm`/`energy_density` from
+/// the strain fields `exx`/`eyy`/`exy` and the eigenstrain field `g`, using
+/// `phys.stress_state` pointwise. Works uniformly for a host or a
+/// device-backed field via `with_host_view` (identity for `HostSpace`).
+template <class Physics, class MemorySpace>
+void compute_stress_fields(const Physics &phys,
+                           pfc::data::Field<double, MemorySpace> &g,
+                           pfc::data::Field<double, MemorySpace> &exx,
+                           pfc::data::Field<double, MemorySpace> &eyy,
+                           pfc::data::Field<double, MemorySpace> &exy,
+                           pfc::data::Field<double, MemorySpace> &sxx,
+                           pfc::data::Field<double, MemorySpace> &syy,
+                           pfc::data::Field<double, MemorySpace> &sxy,
+                           pfc::data::Field<double, MemorySpace> &stress_hydro,
+                           pfc::data::Field<double, MemorySpace> &stress_vm,
+                           pfc::data::Field<double, MemorySpace> &energy_density) {
+  g.with_host_view([&](double *gp, std::size_t n) {
+    exx.with_host_view([&](double *exxp, std::size_t) {
+      eyy.with_host_view([&](double *eyyp, std::size_t) {
+        exy.with_host_view([&](double *exyp, std::size_t) {
+          sxx.with_host_view([&](double *sxxp, std::size_t) {
+            syy.with_host_view([&](double *syyp, std::size_t) {
+              sxy.with_host_view([&](double *sxyp, std::size_t) {
+                stress_hydro.with_host_view([&](double *pp, std::size_t) {
+                  stress_vm.with_host_view([&](double *vmp, std::size_t) {
+                    energy_density.with_host_view([&](double *wp, std::size_t) {
+                      for (std::size_t idx = 0; idx < n; ++idx) {
+                        const auto s =
+                            phys.stress_state(exxp[idx], eyyp[idx], exyp[idx], gp[idx]);
+                        sxxp[idx] = s.sxx;
+                        syyp[idx] = s.syy;
+                        sxyp[idx] = s.sxy;
+                        pp[idx] = s.hydrostatic;
+                        vmp[idx] = s.von_mises;
+                        wp[idx] = s.energy_density;
+                      }
+                    });
+                  });
+                });
+              });
+            });
+          });
+        });
+      });
+    });
+  });
+}
+
+/// MPI-collective reduction of the derived stress/energy fields to the
+/// scalar size-effect observables (peak stresses, total energy).
+template <class MemorySpace>
+StressSummary summarize_stress(pfc::data::Field<double, MemorySpace> &stress_hydro,
+                               pfc::data::Field<double, MemorySpace> &stress_vm,
+                               pfc::data::Field<double, MemorySpace> &energy_density,
+                               const pfc::Domain &domain, MPI_Comm comm) {
+  double local_hydro = 0.0;
+  double local_vm = 0.0;
+  double local_energy = 0.0;
+  stress_hydro.with_host_view([&](double *p, std::size_t n) {
+    for (std::size_t i = 0; i < n; ++i) {
+      local_hydro = std::max(local_hydro, std::abs(p[i]));
+    }
+  });
+  stress_vm.with_host_view([&](double *p, std::size_t n) {
+    for (std::size_t i = 0; i < n; ++i) {
+      local_vm = std::max(local_vm, p[i]);
+    }
+  });
+  energy_density.with_host_view([&](double *p, std::size_t n) {
+    for (std::size_t i = 0; i < n; ++i) {
+      local_energy += p[i];
+    }
+  });
+  const auto dx = pfc::domain::get_spacing(domain);
+  const double cell_volume = dx[0] * dx[1] * dx[2];
+  StressSummary global{};
+  MPI_Allreduce(&local_hydro, &global.peak_abs_hydrostatic, 1, MPI_DOUBLE, MPI_MAX,
+               comm);
+  MPI_Allreduce(&local_vm, &global.peak_von_mises, 1, MPI_DOUBLE, MPI_MAX, comm);
+  double global_energy_sum = 0.0;
+  MPI_Allreduce(&local_energy, &global_energy_sum, 1, MPI_DOUBLE, MPI_SUM, comm);
+  global.total_elastic_energy = global_energy_sum * cell_volume;
+  return global;
+}
+
+/**
+ * @brief Write a straight-line CSV cut through `(x0, y0)` along `+x`
+ * (`r, g, ux, uy, stress_hydro, stress_vm, energy_density`).
+ *
+ * Single-rank only (the science sweeps that use this run on one rank); throws
+ * if `nproc > 1` so a multi-rank misuse fails loudly instead of writing a
+ * partial line.
+ */
+template <class MemorySpace>
+void write_line_profile(const std::filesystem::path &path,
+                        pfc::data::Field<double, MemorySpace> &g,
+                        pfc::data::Field<double, MemorySpace> &ux,
+                        pfc::data::Field<double, MemorySpace> &uy,
+                        pfc::data::Field<double, MemorySpace> &stress_hydro,
+                        pfc::data::Field<double, MemorySpace> &stress_vm,
+                        pfc::data::Field<double, MemorySpace> &energy_density,
+                        double x0, double y0, int nproc) {
+  if (nproc != 1) {
+    throw std::runtime_error(
+        "gradient_elasticity: write_line_profile requires a single rank");
+  }
+  if (path.has_parent_path()) {
+    std::filesystem::create_directories(path.parent_path());
+  }
+  std::ofstream out(path);
+  if (!out) {
+    throw std::runtime_error("gradient_elasticity: cannot open line profile CSV: " +
+                             path.string());
+  }
+  out << std::setprecision(17);
+  out << "r,x,y,g,ux,uy,stress_hydro,stress_vm,energy_density\n";
+  const auto size = g.local_size();
+  const int j0 = std::clamp(
+      static_cast<int>(std::lround((y0 - g.origin()[1]) / g.spacing()[1])), 0,
+      size[1] - 1);
+  g.with_host_view([&](double *gp, std::size_t) {
+    ux.with_host_view([&](double *uxp, std::size_t) {
+      uy.with_host_view([&](double *uyp, std::size_t) {
+        stress_hydro.with_host_view([&](double *pp, std::size_t) {
+          stress_vm.with_host_view([&](double *vmp, std::size_t) {
+            energy_density.with_host_view([&](double *wp, std::size_t) {
+              for (int i = 0; i < size[0]; ++i) {
+                const auto c = g.coords(i, j0, 0);
+                const std::size_t idx = g.idx(i, j0, 0);
+                out << (c[0] - x0) << ',' << c[0] << ',' << c[1] << ',' << gp[idx]
+                    << ',' << uxp[idx] << ',' << uyp[idx] << ',' << pp[idx] << ','
+                    << vmp[idx] << ',' << wp[idx] << '\n';
+              }
+            });
+          });
+        });
+      });
+    });
+  });
+}
+
+} // namespace gradient_elasticity

--- a/apps/gradient_elasticity/include/gradient_elasticity/gradient_elasticity_physics.hpp
+++ b/apps/gradient_elasticity/include/gradient_elasticity/gradient_elasticity_physics.hpp
@@ -85,6 +85,27 @@ struct ModeDisplacement {
   std::complex<double> uy{};
 };
 
+/// Spectral strain-tensor components at one wavevector (tensor, not
+/// engineering, shear: \(\hat\varepsilon_{xy}=\tfrac12(ik_y\hat u_x+ik_x\hat
+/// u_y)\)).
+struct ModeStrain {
+  std::complex<double> exx{};
+  std::complex<double> eyy{};
+  std::complex<double> exy{};
+};
+
+/// Real-space local elastic state derived from the classical constitutive
+/// law evaluated on the (regularized) displacement field -- see
+/// `GradientElasticityPhysics::stress_state`.
+struct LocalStressState {
+  double sxx{};
+  double syy{};
+  double sxy{};
+  double hydrostatic{};   ///< \((\sigma_{xx}+\sigma_{yy})/2\), 2-D mean normal stress.
+  double von_mises{};     ///< in-plane reduced von Mises, see `stress_state`.
+  double energy_density{}; ///< \(\tfrac12\sigma_{ij}\varepsilon^e_{ij}\).
+};
+
 inline pfc::sim::ParameterSchema<GradientElasticitySchemaValues>
 make_gradient_elasticity_schema() {
   pfc::sim::ParameterSchema<GradientElasticitySchemaValues> s;
@@ -200,10 +221,16 @@ struct GradientElasticityPhysics {
     return p;
   }
 
+  /// Displacement fields plus the derived strain/stress/energy diagnostics
+  /// (`#117`): `exx`/`eyy`/`exy` (compatible strain of `u`), `sxx`/`syy`/`sxy`
+  /// (Cauchy stress), `stress_hydro`/`stress_vm` (invariants), and
+  /// `energy_density`. See `stress_state()` for the constitutive convention.
   void declare_fields(pfc::SimulationState &state) const {
-    pfc::sim::add_declared_field<RealType, MemorySpace>(state, "g", domain, box, 0);
-    pfc::sim::add_declared_field<RealType, MemorySpace>(state, "ux", domain, box, 0);
-    pfc::sim::add_declared_field<RealType, MemorySpace>(state, "uy", domain, box, 0);
+    for (const char *name : {"g", "ux", "uy", "exx", "eyy", "exy", "sxx", "syy",
+                             "sxy", "stress_hydro", "stress_vm", "energy_density"}) {
+      pfc::sim::add_declared_field<RealType, MemorySpace>(state, name, domain, box,
+                                                           0);
+    }
   }
 
   /// Helmholtz factor \(\alpha(k^2)\).
@@ -253,6 +280,63 @@ struct GradientElasticityPhysics {
     const double alpha = helmholtz_alpha(k2);
     return 2.0 * (params.lambda + params.mu) * params.eps0 /
            (alpha * (params.lambda + 2.0 * params.mu) * k2);
+  }
+
+  /// Spectral strain \(\hat\varepsilon=\tfrac12(i\mathbf{k}\otimes\hat{\mathbf{u}}
+  /// +\hat{\mathbf{u}}\otimes i\mathbf{k})\) from the mode displacement.
+  [[nodiscard]] ModeStrain strain_from_displacement(double kx, double ky,
+                                                     ModeDisplacement u) const {
+    const std::complex<double> ik{0.0, 1.0};
+    return {ik * kx * u.ux, ik * ky * u.uy,
+            0.5 * (ik * ky * u.ux + ik * kx * u.uy)};
+  }
+
+  /**
+   * @brief Local Cauchy stress, hydrostatic/von-Mises invariants, and
+   * elastic energy density at one grid point, from the compatible strain
+   * \(\varepsilon(\mathbf{u})\) and the local eigenstrain field value \(g\).
+   *
+   * @details
+   * The displacement \(\mathbf{u}\) already solves the regularized
+   * Helmholtz--Navier equilibrium equation, so the strain
+   * \(\varepsilon(\mathbf{u})\) it produces is itself smoothed relative to
+   * the classical (\(\ell=0\)) solution near sharp features. This function
+   * then applies the **classical, local** isotropic constitutive law to
+   * that (already regularized) strain:
+   * \(\sigma=\lambda\,\mathrm{tr}(\varepsilon^e)I+2\mu\varepsilon^e\), with
+   * elastic strain \(\varepsilon^e=\varepsilon(\mathbf{u})-\varepsilon^*\),
+   * \(\varepsilon^*=\varepsilon_0 g I\).
+   *
+   * This is a deliberate, simpler modeling choice: it is **not** the
+   * higher-order Aifantis stress operator
+   * \(\sigma_{\mathrm{grad}}=(1-\ell^2\nabla^2)\sigma_{\mathrm{classical}}\),
+   * which would need its own (order-dependent) regularizing operator and is
+   * not uniquely defined for the `order=6`/`ell4` variants used here.
+   * Regularization enters this report only through the smoothed
+   * displacement/strain field. See the app README for the caveat.
+   *
+   * Von Mises is the **in-plane reduced** invariant
+   * \(\sigma_{vm}=\sqrt{\sigma_{xx}^2-\sigma_{xx}\sigma_{yy}+\sigma_{yy}^2
+   * +3\sigma_{xy}^2}\); it ignores an out-of-plane \(\sigma_{zz}\) because
+   * the eigenstrain here is purely planar (no `zz` component), so this is
+   * not the full 3-D plane-strain von Mises stress.
+   */
+  [[nodiscard]] LocalStressState stress_state(double exx, double eyy, double exy,
+                                              double g) const {
+    const double eps_star = params.eps0 * g;
+    const double eexx = exx - eps_star;
+    const double eeyy = eyy - eps_star;
+    const double eexy = exy; // eigenstrain here has no shear component
+    const double trace = eexx + eeyy;
+    LocalStressState s{};
+    s.sxx = params.lambda * trace + 2.0 * params.mu * eexx;
+    s.syy = params.lambda * trace + 2.0 * params.mu * eeyy;
+    s.sxy = 2.0 * params.mu * eexy;
+    s.hydrostatic = 0.5 * (s.sxx + s.syy);
+    s.von_mises = std::sqrt(s.sxx * s.sxx - s.sxx * s.syy + s.syy * s.syy +
+                            3.0 * s.sxy * s.sxy);
+    s.energy_density = 0.5 * (s.sxx * eexx + s.syy * eeyy + 2.0 * s.sxy * eexy);
+    return s;
   }
 };
 

--- a/apps/gradient_elasticity/include/gradient_elasticity/gradient_elasticity_session.hpp
+++ b/apps/gradient_elasticity/include/gradient_elasticity/gradient_elasticity_session.hpp
@@ -17,6 +17,7 @@
 #include <filesystem>
 #include <iomanip>
 #include <iostream>
+#include <limits>
 #include <memory>
 #include <stdexcept>
 #include <string>
@@ -27,8 +28,10 @@
 #include <mpi.h>
 #include <nlohmann/json.hpp>
 
+#include <gradient_elasticity/circular_inclusion.hpp>
 #include <gradient_elasticity/cosine_mode.hpp>
 #include <gradient_elasticity/gaussian_inclusion.hpp>
+#include <gradient_elasticity/gradient_elasticity_diagnostics.hpp>
 #include <gradient_elasticity/gradient_elasticity_physics.hpp>
 #include <gradient_elasticity/gradient_elasticity_solve.hpp>
 #include <openpfc/frontend/ui/field_modifier_registry.hpp>
@@ -62,6 +65,7 @@ namespace gradient_elasticity {
 inline void register_catalog() {
   pfc::ui::register_field_modifier<CosineMode>("cosine_mode");
   pfc::ui::register_field_modifier<GaussianInclusion>("gaussian_inclusion");
+  pfc::ui::register_field_modifier<CircularInclusion>("circular_inclusion");
 }
 
 template <class Stack> struct stack_memory_space {
@@ -72,6 +76,37 @@ template <> struct stack_memory_space<pfc::sim::stacks::SpectralCPUStack> {
 };
 template <class Stack>
 using stack_memory_space_t = typename stack_memory_space<Stack>::type;
+
+/// Optional straight-line CSV cut through the field, JSON `"line_profile"`:
+/// `{"path": "...", "x0": <opt>, "y0": <opt>}`. `x0`/`y0` default to the
+/// domain midpoint. Single-rank only, see `write_line_profile`.
+struct LineProfileConfig {
+  bool enabled{false};
+  std::string path;
+  double x0{std::numeric_limits<double>::quiet_NaN()};
+  double y0{std::numeric_limits<double>::quiet_NaN()};
+};
+
+inline LineProfileConfig parse_line_profile(const nlohmann::json &settings) {
+  LineProfileConfig cfg;
+  if (!settings.contains("line_profile")) {
+    return cfg;
+  }
+  const auto &j = settings["line_profile"];
+  if (!j.contains("path") || !j["path"].is_string()) {
+    throw std::invalid_argument(
+        "GradientElasticitySession: 'line_profile.path' must be a string.");
+  }
+  cfg.enabled = true;
+  cfg.path = j["path"].get<std::string>();
+  if (j.contains("x0")) {
+    cfg.x0 = j["x0"].get<double>();
+  }
+  if (j.contains("y0")) {
+    cfg.y0 = j["y0"].get<double>();
+  }
+  return cfg;
+}
 
 template <class Stack = pfc::sim::stacks::SpectralCPUStack>
 class GradientElasticitySession {
@@ -90,6 +125,7 @@ public:
                             MPI_Comm comm = MPI_COMM_WORLD)
       : m_settings(with_backend_default(settings_in)),
         m_ctx{.comm = comm, .mpi_rank = rank, .rank0 = (rank == 0)},
+        m_nproc(nproc),
         m_domain(pfc::ui::from_json<pfc::Domain>(m_settings)),
         m_session(
             pfc::ui::make_simulation_session<Stack>(m_settings, rank, nproc, comm)) {
@@ -100,6 +136,7 @@ public:
             : nlohmann::json::object();
     m_physics = Physics::from_json(params, m_domain, inbox);
     m_physics.declare_fields(m_state);
+    m_line_profile = parse_line_profile(m_settings);
 
     auto &modifiers = pfc::ui::default_field_modifier_catalog();
     for (auto &ic :
@@ -154,11 +191,22 @@ public:
     return global;
   }
 
+  /// Solve displacement, derive strain/stress/energy fields (`#117`), write
+  /// requested outputs, and print `SPECTRAL_CHECKSUM` and
+  /// `GRADIENT_ELASTICITY_SUMMARY` lines on rank 0. The summary line carries
+  /// the size-effect observables (peak stresses, total elastic energy) that
+  /// `scripts/gradient_elasticity_size_sweep.py` parses for the size sweep.
   void run() {
-    solve_displacement(fft(), m_physics, g(), ux(), uy());
+    solve_displacement_and_strain(fft(), m_physics, g(), ux(), uy(), exx(), eyy(),
+                                  exy());
+    compute_stress_fields(m_physics, g(), exx(), eyy(), exy(), sxx(), syy(), sxy(),
+                          stress_hydro(), stress_vm(), energy_density());
     write_results();
     const FieldChecksum cs_x = field_checksum("ux");
     const FieldChecksum cs_y = field_checksum("uy");
+    const StressSummary summary = summarize_stress(stress_hydro(), stress_vm(),
+                                                    energy_density(), m_domain,
+                                                    m_ctx.comm);
     if (m_ctx.rank0) {
       std::cout << std::setprecision(17)
                 << "SPECTRAL_CHECKSUM field=ux sum=" << cs_x.sum
@@ -170,13 +218,45 @@ public:
                 << '\n';
       std::cout << "SPECTRAL_CHECKSUM_HEX sum=" << std::hexfloat << cs_x.sum
                 << std::defaultfloat << " sumsq=" << std::hexfloat << cs_x.sumsq
-                << '\n';
+                << std::defaultfloat << '\n';
+      // std::hexfloat leaves the stream in hex-float mode until explicitly
+      // reset (it is not a one-shot manipulator): without the
+      // std::defaultfloat above, GRADIENT_ELASTICITY_SUMMARY below would
+      // print every value as "0x1p+3" instead of decimal, which
+      // scripts/size_sweep.py cannot parse as a plain float.
+      std::cout << std::setprecision(17) << "GRADIENT_ELASTICITY_SUMMARY ell="
+                << m_physics.params.ell << " ell4=" << m_physics.params.ell4
+                << " order=" << m_physics.params.order
+                << " peak_abs_hydrostatic_stress=" << summary.peak_abs_hydrostatic
+                << " peak_von_mises_stress=" << summary.peak_von_mises
+                << " total_elastic_energy=" << summary.total_elastic_energy << '\n';
+    }
+    if (m_line_profile.enabled) {
+      const auto size = pfc::domain::get_size(m_domain);
+      const auto spacing = pfc::domain::get_spacing(m_domain);
+      const double Lx = spacing[0] * static_cast<double>(size[0]);
+      const double Ly = spacing[1] * static_cast<double>(size[1]);
+      const double x0 = std::isfinite(m_line_profile.x0) ? m_line_profile.x0
+                                                          : 0.5 * Lx;
+      const double y0 = std::isfinite(m_line_profile.y0) ? m_line_profile.y0
+                                                          : 0.5 * Ly;
+      write_line_profile(m_line_profile.path, g(), ux(), uy(), stress_hydro(),
+                         stress_vm(), energy_density(), x0, y0, m_nproc);
     }
   }
 
   [[nodiscard]] RealField &g() { return real_field("g"); }
   [[nodiscard]] RealField &ux() { return real_field("ux"); }
   [[nodiscard]] RealField &uy() { return real_field("uy"); }
+  [[nodiscard]] RealField &exx() { return real_field("exx"); }
+  [[nodiscard]] RealField &eyy() { return real_field("eyy"); }
+  [[nodiscard]] RealField &exy() { return real_field("exy"); }
+  [[nodiscard]] RealField &sxx() { return real_field("sxx"); }
+  [[nodiscard]] RealField &syy() { return real_field("syy"); }
+  [[nodiscard]] RealField &sxy() { return real_field("sxy"); }
+  [[nodiscard]] RealField &stress_hydro() { return real_field("stress_hydro"); }
+  [[nodiscard]] RealField &stress_vm() { return real_field("stress_vm"); }
+  [[nodiscard]] RealField &energy_density() { return real_field("energy_density"); }
   [[nodiscard]] pfc::Time &time() noexcept { return m_session.time(); }
   [[nodiscard]] const pfc::Time &time() const noexcept { return m_session.time(); }
   [[nodiscard]] pfc::SimulationState &state() noexcept { return m_state; }
@@ -252,11 +332,13 @@ private:
 
   nlohmann::json m_settings;
   pfc::ui::JsonWiringContext m_ctx{};
+  int m_nproc{1};
   pfc::Domain m_domain{};
   pfc::sim::SimulationSession<Stack> m_session;
   pfc::SimulationState m_state;
   Physics m_physics{};
   std::vector<pfc::ui::NamedResultsWriter> m_writers;
+  LineProfileConfig m_line_profile{};
 };
 
 using GradientElasticityCPUSession =

--- a/apps/gradient_elasticity/include/gradient_elasticity/gradient_elasticity_solve.hpp
+++ b/apps/gradient_elasticity/include/gradient_elasticity/gradient_elasticity_solve.hpp
@@ -65,4 +65,86 @@ void solve_displacement(FFT &fft, const Physics &phys,
   Ops::backward(fft, uy_hat, uy);
 }
 
+/**
+ * @brief Same one-shot invert as `invert_hats`, but also emits the spectral
+ * strain of the resulting displacement (`#117` derived diagnostics).
+ *
+ * Computed in the same \(\mathbf{k}\)-loop as the displacement invert (no
+ * extra forward FFT of \(u_x,u_y\) is needed): \(\hat\varepsilon\) follows
+ * directly from \(\hat{\mathbf{u}}(\mathbf{k})\) and
+ * `Physics::strain_from_displacement`.
+ */
+template <class Physics, class ComplexField>
+void invert_hats_with_strain(const Physics &phys, const pfc::fft::IFFTQueries &fft,
+                             const pfc::Domain &domain, ComplexField &g_hat,
+                             ComplexField &ux_hat, ComplexField &uy_hat,
+                             ComplexField &exx_hat, ComplexField &eyy_hat,
+                             ComplexField &exy_hat) {
+  const auto outbox = fft.get_outbox_bounds();
+  g_hat.with_host_view([&](auto *gh, std::size_t) {
+    ux_hat.with_host_view([&](auto *uxh, std::size_t) {
+      uy_hat.with_host_view([&](auto *uyh, std::size_t) {
+        exx_hat.with_host_view([&](auto *exxh, std::size_t) {
+          eyy_hat.with_host_view([&](auto *eyyh, std::size_t) {
+            exy_hat.with_host_view([&](auto *exyh, std::size_t) {
+              pfc::fft::kspace::for_each_kpoint(
+                  outbox, domain,
+                  [&](std::size_t idx, double kx, double ky, double kz, int, int,
+                      int) {
+                    const auto f = phys.eigenstrain_force(kx, ky, kz, gh[idx]);
+                    const auto u = phys.invert(kx, ky, kz, f);
+                    const auto e = phys.strain_from_displacement(kx, ky, u);
+                    uxh[idx] = u.ux;
+                    uyh[idx] = u.uy;
+                    exxh[idx] = e.exx;
+                    eyyh[idx] = e.eyy;
+                    exyh[idx] = e.exy;
+                  });
+            });
+          });
+        });
+      });
+    });
+  });
+}
+
+/**
+ * @brief Solve for displacement and its compatible strain in one pass:
+ * forward FFT of \(g\), a single \(\mathbf{k}\)-loop invert (displacement +
+ * strain hats), five inverse FFTs.
+ */
+template <class MemorySpace, class FFT, class Physics>
+void solve_displacement_and_strain(FFT &fft, const Physics &phys,
+                                   pfc::data::Field<double, MemorySpace> &g,
+                                   pfc::data::Field<double, MemorySpace> &ux,
+                                   pfc::data::Field<double, MemorySpace> &uy,
+                                   pfc::data::Field<double, MemorySpace> &exx,
+                                   pfc::data::Field<double, MemorySpace> &eyy,
+                                   pfc::data::Field<double, MemorySpace> &exy) {
+  using Ops = pfc::sim::SpectralETDOps<MemorySpace>;
+  using Complex = std::complex<double>;
+  using ComplexField = pfc::data::Field<Complex, MemorySpace>;
+  ComplexField g_hat(g.domain(), fft.get_outbox_bounds(), 0);
+  ComplexField ux_hat(g.domain(), fft.get_outbox_bounds(), 0);
+  ComplexField uy_hat(g.domain(), fft.get_outbox_bounds(), 0);
+  ComplexField exx_hat(g.domain(), fft.get_outbox_bounds(), 0);
+  ComplexField eyy_hat(g.domain(), fft.get_outbox_bounds(), 0);
+  ComplexField exy_hat(g.domain(), fft.get_outbox_bounds(), 0);
+  Ops::forward(fft, g, g_hat);
+  invert_hats_with_strain(phys, fft, g.domain(), g_hat, ux_hat, uy_hat, exx_hat,
+                          eyy_hat, exy_hat);
+  if constexpr (!std::is_same_v<MemorySpace, pfc::HostSpace>) {
+    ux_hat.sync_to_device();
+    uy_hat.sync_to_device();
+    exx_hat.sync_to_device();
+    eyy_hat.sync_to_device();
+    exy_hat.sync_to_device();
+  }
+  Ops::backward(fft, ux_hat, ux);
+  Ops::backward(fft, uy_hat, uy);
+  Ops::backward(fft, exx_hat, exx);
+  Ops::backward(fft, eyy_hat, eyy);
+  Ops::backward(fft, exy_hat, exy);
+}
+
 } // namespace gradient_elasticity

--- a/apps/gradient_elasticity/inputs_json/circular_inclusion.json
+++ b/apps/gradient_elasticity/inputs_json/circular_inclusion.json
@@ -1,0 +1,66 @@
+{
+    "model": {
+        "name": "gradient_elasticity",
+        "params": {
+            "mu": 1.0,
+            "lambda": 1.0,
+            "ell": 8.0,
+            "eps0": 0.01,
+            "order": 4
+        }
+    },
+    "domain": {
+        "Lx": 256,
+        "Ly": 256,
+        "Lz": 1,
+        "dx": 1.0,
+        "dy": 1.0,
+        "dz": 1.0,
+        "origin": "corner"
+    },
+    "timestepping": {
+        "t0": 0.0,
+        "t1": 1.0,
+        "dt": 1.0,
+        "saveat": 1.0
+    },
+    "fields": [
+        {
+            "name": "g",
+            "data": "results/gradient_elasticity/inclusion_g_%04d.vti"
+        },
+        {
+            "name": "ux",
+            "data": "results/gradient_elasticity/inclusion_ux_%04d.vti"
+        },
+        {
+            "name": "uy",
+            "data": "results/gradient_elasticity/inclusion_uy_%04d.vti"
+        },
+        {
+            "name": "stress_hydro",
+            "data": "results/gradient_elasticity/inclusion_stress_hydro_%04d.vti"
+        },
+        {
+            "name": "stress_vm",
+            "data": "results/gradient_elasticity/inclusion_stress_vm_%04d.vti"
+        },
+        {
+            "name": "energy_density",
+            "data": "results/gradient_elasticity/inclusion_energy_density_%04d.vti"
+        }
+    ],
+    "initial_conditions": [
+        {
+            "target": "g",
+            "type": "circular_inclusion",
+            "g0": 0.0,
+            "amplitude": 1.0,
+            "radius": 32.0,
+            "interface_width": 4.0
+        }
+    ],
+    "line_profile": {
+        "path": "results/gradient_elasticity/inclusion_line_profile.csv"
+    }
+}

--- a/apps/gradient_elasticity/inputs_json/circular_inclusion.json.license
+++ b/apps/gradient_elasticity/inputs_json/circular_inclusion.json.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: 2026 VTT Technical Research Centre of Finland Ltd
+SPDX-License-Identifier: AGPL-3.0-or-later

--- a/apps/gradient_elasticity/scripts/size_sweep.py
+++ b/apps/gradient_elasticity/scripts/size_sweep.py
@@ -1,0 +1,186 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: 2026 VTT Technical Research Centre of Finland Ltd
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+"""Gradient-elasticity misfitting-inclusion size sweep (issue #117, science case A).
+
+Runs the `gradient_elasticity` binary once per inclusion radius `R` (fixed
+internal length `ell`, fixed Lame parameters and eigenstrain amplitude, box
+size L = box_to_radius * max(R, ell) so the periodic-image ratio stays fixed
+relative to *both* controlling length scales, not just R -- ell can be
+larger than R at the small-R end of the sweep), parses the
+`GRADIENT_ELASTICITY_SUMMARY` line each run prints on rank 0, and writes one
+aggregated CSV: R, ell, R/ell, box L, peak |hydrostatic stress|, peak von
+Mises stress, total elastic energy.
+
+Physical direction (see the app README "Classical and clamped closed forms"
+section): for this loading (a smooth, *finite* inclusion, no classical
+singularity), peak stress *decreases* as R/ell grows, from a closed-form
+"clamped" bound (R/ell -> 0, the gradient penalty suppresses essentially all
+elastic relaxation) down to the closed-form classical "relaxed" bound
+(R/ell -> infinity). This is the opposite direction from the familiar
+"gradient elasticity regularizes a classical singularity" story, which
+applies to sharp/singular defect loadings, not this smooth inclusion.
+
+This is a *science preset* (roadmap #120): it is meant to be run by hand on
+real allocations to produce the size-effect table for the report/PR, not to
+run inside CI. `apps/gradient_elasticity/tests/test_gradient_elasticity.cpp`
+carries the fast, CI-safe analytical/monotonicity/box-size regression tests
+that check the same physics on tiny grids.
+
+Example (see apps/gradient_elasticity/README.md for the full recipe):
+
+    python3 size_sweep.py --binary build/apps/gradient_elasticity/gradient_elasticity \\
+        --outdir results/gradient_elasticity/size_sweep --csv size_sweep.csv \\
+        --launcher 'srun --overlap -n 1'
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+import re
+import shlex
+import subprocess
+from pathlib import Path
+
+SUMMARY_RE = re.compile(
+    r"GRADIENT_ELASTICITY_SUMMARY ell=(?P<ell>\S+) ell4=(?P<ell4>\S+) "
+    r"order=(?P<order>\S+) peak_abs_hydrostatic_stress=(?P<peak_hydro>\S+) "
+    r"peak_von_mises_stress=(?P<peak_vm>\S+) total_elastic_energy=(?P<energy>\S+)"
+)
+
+
+def make_settings(*, N, R, w, ell, mu, lam, eps0, order, x0=None, y0=None,
+                   line_profile=None):
+    x0 = N / 2.0 if x0 is None else x0
+    y0 = N / 2.0 if y0 is None else y0
+    settings = {
+        "model": {
+            "name": "gradient_elasticity",
+            "params": {"mu": mu, "lambda": lam, "ell": ell, "eps0": eps0,
+                       "order": order},
+        },
+        "domain": {"Lx": N, "Ly": N, "Lz": 1, "dx": 1.0, "dy": 1.0, "dz": 1.0,
+                  "origin": "corner"},
+        "timestepping": {"t0": 0.0, "t1": 1.0, "dt": 1.0, "saveat": -1.0},
+        "initial_conditions": [
+            {"target": "g", "type": "circular_inclusion", "g0": 0.0,
+             "amplitude": 1.0, "radius": R, "interface_width": w, "x0": x0,
+             "y0": y0}
+        ],
+    }
+    if line_profile is not None:
+        settings["line_profile"] = {"path": line_profile, "x0": x0, "y0": y0}
+    return settings
+
+
+def run_case(binary, launcher, workdir, settings):
+    workdir.mkdir(parents=True, exist_ok=True)
+    input_path = workdir / "case.json"
+    input_path.write_text(json.dumps(settings, indent=2))
+    cmd = [*launcher, str(binary), str(input_path)]
+    result = subprocess.run(cmd, cwd=workdir, capture_output=True, text=True,
+                            timeout=300, check=False)
+    if result.returncode != 0:
+        raise RuntimeError(f"{' '.join(cmd)} failed (rc={result.returncode}):\n"
+                           f"{result.stdout}\n{result.stderr}")
+    match = SUMMARY_RE.search(result.stdout)
+    if not match:
+        raise RuntimeError(f"no GRADIENT_ELASTICITY_SUMMARY line in output of "
+                           f"{' '.join(cmd)}:\n{result.stdout}")
+    return {k: float(v) for k, v in match.groupdict().items()}
+
+
+def interface_width(R, dx=1.0):
+    """Smoothed-inclusion interface half-width: max(1 grid spacing, R/8)."""
+    return max(dx, R / 8.0)
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__,
+                                     formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("--binary", required=True, type=Path)
+    parser.add_argument("--outdir", required=True, type=Path)
+    parser.add_argument("--csv", required=True, type=Path)
+    parser.add_argument("--ell", type=float, default=8.0,
+                        help="Fixed Helmholtz internal length (default: 8.0).")
+    parser.add_argument("--mu", type=float, default=1.0)
+    parser.add_argument("--lam", type=float, default=1.0)
+    parser.add_argument("--eps0", type=float, default=0.01)
+    parser.add_argument("--box-to-radius", type=float, default=16.0,
+                        help="L = box_to_radius * max(R, ell) (default: 16; "
+                             "the box_size unit test measured ~4-5%% image "
+                             "contamination at ratio 8 and <2%% doubling from "
+                             "16 to 32, so 16 is the default here). Scaling "
+                             "by max(R, ell), not just R, matters once ell "
+                             "is comparable to or larger than R.")
+    parser.add_argument("--radii", type=float, nargs="+",
+                        default=[4.0, 8.0, 16.0, 32.0, 64.0, 128.0],
+                        help="Inclusion radii to sweep (default spans "
+                             "R/ell = 0.5 .. 16 at ell=8).")
+    parser.add_argument("--launcher", type=str, default="",
+                        help="Command prefix as one shell-quoted string, e.g. "
+                             "--launcher 'srun --overlap -n 1' (argparse cannot "
+                             "collect a prefix containing its own -n/--flags as "
+                             "nargs='*', so this takes a single string, split "
+                             "with shlex).")
+    parser.add_argument("--line-profile-radii", type=float, nargs="*", default=[],
+                        help="Also write a line-profile CSV for these radii.")
+    parser.add_argument("--box-check-radius", type=float, default=None,
+                        help="If set, also runs this radius at the sweep's "
+                             "box-to-radius ratio and at double that ratio, "
+                             "and reports the relative peak-stress change "
+                             "(periodic-image control evidence).")
+    args = parser.parse_args()
+    launcher = shlex.split(args.launcher)
+
+    args.outdir.mkdir(parents=True, exist_ok=True)
+    rows = []
+    for R in args.radii:
+        N = int(round(args.box_to_radius * max(R, args.ell)))
+        w = interface_width(R)
+        line_profile = None
+        if R in args.line_profile_radii:
+            line_profile = str((args.outdir / f"line_profile_R{R:g}.csv").resolve())
+        settings = make_settings(N=N, R=R, w=w, ell=args.ell, mu=args.mu,
+                                 lam=args.lam, eps0=args.eps0, order=4,
+                                 line_profile=line_profile)
+        summary = run_case(args.binary, launcher, args.outdir / f"R{R:g}",
+                           settings)
+        rows.append({"R": R, "ell": args.ell, "R_over_ell": R / args.ell, "N": N,
+                    "box_L": N, "box_L_over_R": N / R,
+                    "interface_width": w, **summary})
+        print(f"R={R:g} R/ell={R/args.ell:.3g} peak_hydro={summary['peak_hydro']:.6g} "
+             f"peak_vm={summary['peak_vm']:.6g} energy={summary['energy']:.6g}")
+
+    with args.csv.open("w", newline="") as stream:
+        fieldnames = list(rows[0].keys())
+        writer = csv.DictWriter(stream, fieldnames=fieldnames)
+        writer.writeheader()
+        writer.writerows(rows)
+    print(f"wrote {args.csv} ({len(rows)} rows)")
+
+    if args.box_check_radius is not None:
+        R = args.box_check_radius
+        w = interface_width(R)
+        base = max(R, args.ell)
+        small_N = int(round(args.box_to_radius * base))
+        large_N = int(round(2.0 * args.box_to_radius * base))
+        small = run_case(args.binary, launcher, args.outdir / "box_check_small",
+                         make_settings(N=small_N, R=R, w=w, ell=args.ell, mu=args.mu,
+                                      lam=args.lam, eps0=args.eps0, order=4))
+        large = run_case(args.binary, launcher, args.outdir / "box_check_large",
+                         make_settings(N=large_N, R=R, w=w, ell=args.ell, mu=args.mu,
+                                      lam=args.lam, eps0=args.eps0, order=4))
+        rel_hydro = abs(large["peak_hydro"] - small["peak_hydro"]) / small["peak_hydro"]
+        rel_vm = abs(large["peak_vm"] - small["peak_vm"]) / small["peak_vm"]
+        print(f"box check R={R:g} ell={args.ell:g}: L/max(R,ell) "
+             f"{args.box_to_radius:g} -> {2*args.box_to_radius:g} (N={small_N} -> "
+             f"{large_N}): peak_hydro rel. change={rel_hydro:.3%}, peak_vm rel. "
+             f"change={rel_vm:.3%}")
+
+
+if __name__ == "__main__":
+    main()

--- a/apps/gradient_elasticity/tests/test_gradient_elasticity.cpp
+++ b/apps/gradient_elasticity/tests/test_gradient_elasticity.cpp
@@ -17,9 +17,11 @@
 #include <complex>
 #include <mpi.h>
 #include <numbers>
+#include <vector>
 
 #include <nlohmann/json.hpp>
 
+#include <gradient_elasticity/gradient_elasticity_diagnostics.hpp>
 #include <gradient_elasticity/gradient_elasticity_physics.hpp>
 #include <gradient_elasticity/gradient_elasticity_session.hpp>
 #include <gradient_elasticity/gradient_elasticity_solve.hpp>
@@ -65,6 +67,100 @@ double max_abs_err_sine(const pfc::data::Field<double> &ux, double amp, double k
     }
   }
   return m;
+}
+
+/// Fill `g` with a `tanh`-smoothed circular inclusion (same formula as
+/// `CircularInclusion::apply`, inlined here so the low-level physics tests
+/// don't need the JSON field-modifier plumbing).
+void fill_circular_inclusion(pfc::data::Field<double> &g, double x0, double y0,
+                             double R, double w) {
+  g.apply([&](double x, double y, double) {
+    const double dx = x - x0;
+    const double dy = y - y0;
+    const double r = std::sqrt(dx * dx + dy * dy);
+    return 0.5 * (1.0 - std::tanh((r - R) / w));
+  });
+}
+
+/// One-shot circular-inclusion solve (displacement, strain, stress, energy)
+/// on an `N x N` periodic square, inclusion centred at the box midpoint.
+/// Single-rank, direct physics/solve calls (no JSON session) so the size
+/// sweep used by the tests below stays fast and self-contained.
+gradient_elasticity::StressSummary run_circular_case(int N, double R, double w,
+                                                      double ell, double mu,
+                                                      double lambda, double eps0,
+                                                      int order = 4) {
+  const auto domain = pfc::domain::create(pfc::GridSize({N, N, 1}),
+                                          pfc::PhysicalOrigin({0.0, 0.0, 0.0}),
+                                          pfc::GridSpacing({1.0, 1.0, 1.0}));
+  pfc::sim::stacks::SpectralCPUStack stack(domain, 0, 1, MPI_COMM_WORLD);
+  auto phys = gradient_elasticity::GradientElasticityPhysics<>::from_json(
+      json{{"ell", ell}, {"eps0", eps0}, {"mu", mu}, {"lambda", lambda},
+          {"order", order}},
+      domain, stack.fft().get_inbox_bounds());
+  pfc::SimulationState state;
+  phys.declare_fields(state);
+  auto &g = state.get_field<double>("g");
+  auto &ux = state.get_field<double>("ux");
+  auto &uy = state.get_field<double>("uy");
+  auto &exx = state.get_field<double>("exx");
+  auto &eyy = state.get_field<double>("eyy");
+  auto &exy = state.get_field<double>("exy");
+  auto &sxx = state.get_field<double>("sxx");
+  auto &syy = state.get_field<double>("syy");
+  auto &sxy = state.get_field<double>("sxy");
+  auto &stress_hydro = state.get_field<double>("stress_hydro");
+  auto &stress_vm = state.get_field<double>("stress_vm");
+  auto &energy_density = state.get_field<double>("energy_density");
+  const double x0 = 0.5 * static_cast<double>(N);
+  const double y0 = 0.5 * static_cast<double>(N);
+  fill_circular_inclusion(g, x0, y0, R, w);
+  gradient_elasticity::solve_displacement_and_strain(stack.fft(), phys, g, ux, uy,
+                                                     exx, eyy, exy);
+  gradient_elasticity::compute_stress_fields(phys, g, exx, eyy, exy, sxx, syy, sxy,
+                                             stress_hydro, stress_vm,
+                                             energy_density);
+  return gradient_elasticity::summarize_stress(stress_hydro, stress_vm,
+                                               energy_density, domain,
+                                               MPI_COMM_WORLD);
+}
+
+/// Classical (infinite-domain, sharp-boundary) closed form for a 2-D
+/// circular inclusion of radius `R` with dilatational eigenstrain
+/// `eps*=eps0*I`, from axisymmetric elasticity with eigenstrain (derived in
+/// the PR description / app README): stress is spatially uniform inside and
+/// decays as \(1/r^2\) outside; both are independent of `R` -- the classical
+/// theory has no length scale, which is exactly the size effect gradient
+/// elasticity is meant to introduce.
+double classical_inclusion_inside_hydrostatic(double mu, double lambda,
+                                              double eps0) {
+  const double A = eps0 * (lambda + mu) / (lambda + 2.0 * mu);
+  return 2.0 * (lambda + mu) * (A - eps0);
+}
+
+double classical_inclusion_boundary_von_mises(double mu, double lambda,
+                                              double eps0) {
+  const double A = eps0 * (lambda + mu) / (lambda + 2.0 * mu);
+  return std::sqrt(3.0) * 2.0 * mu * A;
+}
+
+/// The *other* closed-form bound of the size-effect curve: the fully
+/// unrelaxed ("clamped") limit `ell -> infinity` (equivalently `R/ell -> 0`).
+/// Every Fourier mode with `k>0` is annihilated as `alpha=1+ell^2 k^2 ->
+/// infinity`, so `u -> 0` identically (the gradient penalty forbids *any*
+/// spatial variation of the displacement). With `u=0`, the elastic strain is
+/// just the negative eigenstrain, `eps^e=-eps0*g*I`, so deep inside the
+/// inclusion (`g=1`) the material cannot relax the misfit at all:
+/// `sigma=-2(lambda+mu)*eps0*I`, a pure equibiaxial (hydrostatic) state, so
+/// the reduced von Mises invariant equals the same magnitude. This is the
+/// *maximum possible* internal stress for this eigenstrain -- gradient
+/// elasticity increases peak stress above the classical value for small
+/// inclusions (`R/ell` small) here, the opposite of the familiar
+/// "regularizes a classical singularity" story: this loading (a smooth,
+/// finite inclusion) has no classical singularity to begin with, so `ell`
+/// instead acts as an increasing constraint on elastic relaxation.
+double clamped_inclusion_hydrostatic(double mu, double lambda, double eps0) {
+  return -2.0 * (lambda + mu) * eps0;
 }
 
 } // namespace
@@ -305,6 +401,217 @@ TEST_CASE("GradientElasticitySession runs a short JSON case",
   session.run();
   REQUIRE_THAT(mean_field(session.ux()), WithinAbs(0.0, 1e-12));
   REQUIRE_THAT(mean_field(session.uy()), WithinAbs(0.0, 1e-12));
+}
+
+TEST_CASE("Spectral strain/stress post-processing matches the analytical "
+          "cosine-mode field",
+          "[gradient_elasticity][spectral][stress][analytical]") {
+  if (world_size() != 1) {
+    SKIP("single-rank spectral comparison");
+  }
+  constexpr int N = 32;
+  constexpr int nx = 2;
+  constexpr int ny = 1;
+  constexpr double amp_g = 1.0;
+  constexpr double mu = 1.3;
+  constexpr double lambda = 0.7;
+  constexpr double eps0 = 0.03;
+  constexpr double ell = 2.0;
+
+  const auto domain = pfc::domain::create(pfc::GridSize({N, N, 1}),
+                                          pfc::PhysicalOrigin({0.0, 0.0, 0.0}),
+                                          pfc::GridSpacing({1.0, 1.0, 1.0}));
+  pfc::sim::stacks::SpectralCPUStack stack(domain, 0, 1, MPI_COMM_WORLD);
+  auto phys = gradient_elasticity::GradientElasticityPhysics<>::from_json(
+      json{{"ell", ell}, {"eps0", eps0}, {"mu", mu}, {"lambda", lambda}}, domain,
+      stack.fft().get_inbox_bounds());
+  pfc::SimulationState state;
+  phys.declare_fields(state);
+  auto &g = state.get_field<double>("g");
+  auto &ux = state.get_field<double>("ux");
+  auto &uy = state.get_field<double>("uy");
+  auto &exx = state.get_field<double>("exx");
+  auto &eyy = state.get_field<double>("eyy");
+  auto &exy = state.get_field<double>("exy");
+  auto &sxx = state.get_field<double>("sxx");
+  auto &syy = state.get_field<double>("syy");
+  auto &sxy = state.get_field<double>("sxy");
+  auto &stress_hydro = state.get_field<double>("stress_hydro");
+  auto &stress_vm = state.get_field<double>("stress_vm");
+  auto &energy_density = state.get_field<double>("energy_density");
+  const double twopi = 2.0 * std::numbers::pi;
+  const double L = static_cast<double>(N);
+  const double kx = twopi * static_cast<double>(nx) / L;
+  const double ky = twopi * static_cast<double>(ny) / L;
+  g.apply(
+      [&](double x, double y, double) { return amp_g * std::cos(kx * x + ky * y); });
+
+  gradient_elasticity::solve_displacement_and_strain(stack.fft(), phys, g, ux, uy,
+                                                     exx, eyy, exy);
+  gradient_elasticity::compute_stress_fields(phys, g, exx, eyy, exy, sxx, syy, sxy,
+                                             stress_hydro, stress_vm,
+                                             energy_density);
+
+  const double k2 = kx * kx + ky * ky;
+  const double B = phys.cosine_displacement_prefactor(k2) * amp_g;
+  double max_err_exx = 0.0, max_err_eyy = 0.0, max_err_exy = 0.0;
+  double max_err_hydro = 0.0, max_err_vm = 0.0, max_err_w = 0.0;
+  const auto n = g.local_size();
+  for (int k = 0; k < n[2]; ++k) {
+    for (int j = 0; j < n[1]; ++j) {
+      for (int i = 0; i < n[0]; ++i) {
+        const auto x = g.coords(i, j, k);
+        const double phi = kx * x[0] + ky * x[1];
+        const double gv = amp_g * std::cos(phi);
+        // Analytical strain from u = B*(kx,ky)*sin(phi):
+        const double exx_a = B * kx * kx * std::cos(phi);
+        const double eyy_a = B * ky * ky * std::cos(phi);
+        const double exy_a = B * kx * ky * std::cos(phi);
+        const auto s = phys.stress_state(exx_a, eyy_a, exy_a, gv);
+        max_err_exx = std::max(max_err_exx, std::abs(exx(i, j, k) - exx_a));
+        max_err_eyy = std::max(max_err_eyy, std::abs(eyy(i, j, k) - eyy_a));
+        max_err_exy = std::max(max_err_exy, std::abs(exy(i, j, k) - exy_a));
+        max_err_hydro =
+            std::max(max_err_hydro, std::abs(stress_hydro(i, j, k) - s.hydrostatic));
+        max_err_vm = std::max(max_err_vm, std::abs(stress_vm(i, j, k) - s.von_mises));
+        max_err_w = std::max(max_err_w,
+                             std::abs(energy_density(i, j, k) - s.energy_density));
+      }
+    }
+  }
+  REQUIRE_THAT(max_err_exx, WithinAbs(0.0, 1e-9));
+  REQUIRE_THAT(max_err_eyy, WithinAbs(0.0, 1e-9));
+  REQUIRE_THAT(max_err_exy, WithinAbs(0.0, 1e-9));
+  REQUIRE_THAT(max_err_hydro, WithinAbs(0.0, 1e-9));
+  REQUIRE_THAT(max_err_vm, WithinAbs(0.0, 1e-9));
+  REQUIRE_THAT(max_err_w, WithinAbs(0.0, 1e-9));
+}
+
+TEST_CASE("ell=0 recovers the classical analytical circular-inclusion stress",
+          "[gradient_elasticity][spectral][classical][inclusion]") {
+  if (world_size() != 1) {
+    SKIP("single-rank spectral comparison");
+  }
+  // Sharp-inclusion Eshelby-type closed form assumes an infinite matrix and
+  // an infinitely sharp boundary; the numerical case has a periodic box and
+  // a finite tanh interface width, so allow a stated few-percent tolerance
+  // rather than machine precision.
+  constexpr int N = 320;
+  constexpr double R = 40.0;
+  constexpr double w = 1.0; // interface half-width, w/R = 0.025
+  constexpr double mu = 1.0;
+  constexpr double lambda = 1.0;
+  constexpr double eps0 = 0.01;
+
+  const auto summary = run_circular_case(N, R, w, /*ell=*/0.0, mu, lambda, eps0);
+  const double p_classical = std::abs(classical_inclusion_inside_hydrostatic(
+      mu, lambda, eps0));
+  const double vm_classical =
+      classical_inclusion_boundary_von_mises(mu, lambda, eps0);
+
+  // The finite tanh interface width makes the smoothed problem's actual
+  // peak (the field near r=R, where the eigenstrain itself has a gradient)
+  // measurably higher than the idealized-sharp-boundary uniform interior
+  // value: the classical hydrostatic stress is discontinuous across a sharp
+  // boundary (p_in far from 0, p_out=0 immediately outside), so smoothing
+  // that step introduces a boundary-layer effect on top of discretization
+  // error. 10% at w/R=0.025 is the measured, stated tolerance.
+  REQUIRE_THAT(summary.peak_abs_hydrostatic, WithinRel(p_classical, 0.12));
+  REQUIRE_THAT(summary.peak_von_mises, WithinRel(vm_classical, 0.12));
+}
+
+TEST_CASE("Peak inclusion stress decreases monotonically with R/ell, from the "
+          "clamped bound to the classical bound (size-effect curve)",
+          "[gradient_elasticity][spectral][size_effect]") {
+  if (world_size() != 1) {
+    SKIP("single-rank spectral comparison");
+  }
+  // Fixed inclusion radius R, varying ell so R/ell spans well below 1 to
+  // well above 1. This loading (a smooth, *finite* inclusion) has no
+  // classical singularity, so ell does not "regularize a singular peak"
+  // here the way it does for the high-k cosine mode above. Instead ell acts
+  // as an increasing constraint on elastic relaxation: for R/ell -> 0 the
+  // gradient penalty suppresses essentially all spatial variation of u
+  // (every k>0 mode is annihilated as alpha=1+ell^2 k^2 -> infinity), so the
+  // material cannot relax the eigenstrain misfit at all and the internal
+  // stress approaches the *clamped* bound `clamped_inclusion_hydrostatic`
+  // (measured empirically first, then matched to this closed form -- see PR
+  // description). For R/ell -> infinity, ell is negligible and the classical
+  // *relaxed* bound `classical_inclusion_inside_hydrostatic` is recovered
+  // (already checked by the `ell=0` test above). Both bounds are
+  // R-independent closed forms; peak stress should decrease monotonically
+  // from one to the other as R/ell grows. The box is scaled with
+  // max(R, ell), not just R, so periodic images stay controlled at every
+  // ell in the sweep.
+  constexpr double R = 40.0;
+  constexpr double w = 1.0;
+  constexpr double mu = 1.0;
+  constexpr double lambda = 1.0;
+  constexpr double eps0 = 0.01;
+  const std::vector<double> ells = {80.0, 40.0, 10.0, 2.5}; // R/ell: 0.5,1,4,16
+
+  std::vector<double> peak_hydro;
+  for (double ell : ells) {
+    const int N = static_cast<int>(std::lround(8.0 * std::max(R, ell)));
+    peak_hydro.push_back(
+        run_circular_case(N, R, w, ell, mu, lambda, eps0).peak_abs_hydrostatic);
+  }
+  for (std::size_t i = 1; i < peak_hydro.size(); ++i) {
+    REQUIRE(peak_hydro[i] < peak_hydro[i - 1]);
+  }
+  const double p_classical =
+      std::abs(classical_inclusion_inside_hydrostatic(mu, lambda, eps0));
+  const double p_clamped = std::abs(clamped_inclusion_hydrostatic(mu, lambda, eps0));
+  // Smallest R/ell in the sweep: closer to (but not yet at) the clamped
+  // bound; largest R/ell: closer to (but not yet at) the classical bound.
+  // Every measured value must lie strictly between the two closed forms.
+  for (double p : peak_hydro) {
+    REQUIRE(p > p_classical);
+    REQUIRE(p < p_clamped);
+  }
+}
+
+TEST_CASE("Doubling the periodic box leaves the inclusion peak stress "
+          "essentially unchanged",
+          "[gradient_elasticity][spectral][box_size]") {
+  if (world_size() != 1) {
+    SKIP("single-rank spectral comparison");
+  }
+  // #117 requires documented/controlled inclusion-image interaction: repeat
+  // one radius in a larger box (same R, ell, dx; doubled L) and show the
+  // peak stress barely moves.
+  constexpr double R = 12.0;
+  constexpr double w = 1.0;
+  constexpr double ell = 3.0;
+  constexpr double mu = 1.0;
+  constexpr double lambda = 1.0;
+  constexpr double eps0 = 0.01;
+
+  // L/R=8 (as first tried) measurably contaminates the peak stress with
+  // periodic images; L/R=16 -> 32 is the regime where doubling the box
+  // changes the peak by less than the tolerance below. `size_sweep.py
+  // --box-to-radius` defaults to the safer ratio (16). Report all three
+  // ratios (8, 16, 32) via WARN so the convergence trend is visible, not
+  // just asserted.
+  const auto box8 =
+      run_circular_case(8 * static_cast<int>(R), R, w, ell, mu, lambda, eps0);
+  const auto small_box = run_circular_case(16 * static_cast<int>(R), R, w, ell, mu,
+                                           lambda, eps0);
+  const auto large_box = run_circular_case(32 * static_cast<int>(R), R, w, ell, mu,
+                                           lambda, eps0);
+  const auto rel_change = [](double a, double b) { return std::abs(b - a) / a; };
+  WARN("L/R 8->16 relative change: peak_hydro="
+       << rel_change(box8.peak_abs_hydrostatic, small_box.peak_abs_hydrostatic)
+       << " peak_vm="
+       << rel_change(box8.peak_von_mises, small_box.peak_von_mises));
+  WARN("L/R 16->32 relative change: peak_hydro="
+       << rel_change(small_box.peak_abs_hydrostatic, large_box.peak_abs_hydrostatic)
+       << " peak_vm="
+       << rel_change(small_box.peak_von_mises, large_box.peak_von_mises));
+  REQUIRE_THAT(large_box.peak_abs_hydrostatic,
+              WithinRel(small_box.peak_abs_hydrostatic, 0.02));
+  REQUIRE_THAT(large_box.peak_von_mises,
+              WithinRel(small_box.peak_von_mises, 0.02));
 }
 
 int main(int argc, char *argv[]) {


### PR DESCRIPTION
## What changed

Extends `apps/gradient_elasticity` (issue #82's periodic Helmholtz–Navier
gradient-elasticity app) per issue #117, on top of the existing verifier
without touching it:

- **Derived fields** (`apps/gradient_elasticity/include/gradient_elasticity/gradient_elasticity_physics.hpp`,
  `gradient_elasticity_solve.hpp`, new `gradient_elasticity_diagnostics.hpp`):
  strain (`exx`/`eyy`/`exy`), Cauchy stress (`sxx`/`syy`/`sxy`), hydrostatic
  and (in-plane reduced) von Mises invariants (`stress_hydro`/`stress_vm`),
  and elastic energy density (`energy_density`), all computed **spectrally**
  from the displacement solution in the same k-space loop as the existing
  2x2 invert (no extra forward FFT). Stress is the classical local
  constitutive law evaluated on the already-`ell`-regularized
  displacement/strain field — documented in code and README as a deliberate
  simplification, not the higher-order Aifantis `(1-ell^2 lap)*sigma`
  operator (which is not uniquely defined for the existing `order=6`/`ell4`
  variants).
- **New `circular_inclusion` field modifier** (new
  `include/gradient_elasticity/circular_inclusion.hpp`): a `tanh`-smoothed
  flat-top disk of radius `R`, periodic minimum-image distance, dilatational
  eigenstrain inside, ~0 outside.
- **New `line_profile` JSON block**: single-rank straight-line CSV cut
  through the inclusion centre (`g`, `ux`, `uy`, stress, energy vs.
  distance).
- **Size-effect sweep** (`apps/gradient_elasticity/scripts/size_sweep.py`,
  a science preset, not run in CI): runs the app once per radius `R` at
  fixed `ell`, box scaled to `L=16*max(R,ell)` (periodic-image control
  scaled to *both* length scales, not just `R`), parses the new
  `GRADIENT_ELASTICITY_SUMMARY` stdout line, writes an aggregated CSV.
- **New closed forms** derived for this PR (axisymmetric elasticity with
  eigenstrain, standard "inclusion problem"): the classical (`ell=0`,
  `R/ell -> infinity`) uniform interior stress, **and** a new "clamped"
  bound (`ell -> infinity`, `R/ell -> 0`) — every Fourier mode is
  annihilated, so the material cannot relax the eigenstrain at all. Both
  are `R`-independent; the measured size effect is the transition between
  them as `R/ell` varies.
- **Tests** (`apps/gradient_elasticity/tests/test_gradient_elasticity.cpp`,
  all via `ctest -R gradient-elasticity`, all passing): existing #82
  verifiers untouched; strain/stress post-processing checked against an
  exact analytical cosine-mode closed form (1e-9 tolerance); the classical
  `ell=0` limit checked against the new closed form (12% tolerance, driven
  by finite interface width + periodic box, stated honestly); peak stress
  monotonicity in `R/ell`, bounded by the classical and clamped closed
  forms; periodic-image control (box doubling `L/max(R,ell)`: 16→32 must
  change peak stress <2%, actual measured value printed via `WARN`).
- **README**: `Problem setup` table (issue #112 contract, verification vs.
  science preset, three separate model-maturity axes), full physics writeup
  including *why* the size effect goes the direction it does, the two
  closed forms, and an honest "What #117 does not cover" section.
- **CHANGELOG.md**: `### Added` entry.

## Physical direction — read this before the table

This loading is a **smooth, finite** inclusion, so classical elasticity
already gives it a bounded field (no singularity at any length scale),
unlike a dislocation or crack tip. So `ell` here does not "regularize a
classical singularity" the way it does for a fixed high-`k` cosine mode
(existing #82 test). Instead `ell` acts as an increasing constraint on
**elastic relaxation**: the gradient penalty increasingly forbids the
spatial variation the matrix would use to relax the misfit strain. Peak
stress therefore **decreases monotonically as `R/ell` grows**, from a
closed-form "clamped" bound (`R/ell -> 0`, no relaxation) down to the
classical Eshelby-type "relaxed" bound (`R/ell -> infinity`) — the opposite
direction from my first assumption while writing this (an earlier draft of
the size-effect unit test asserted the wrong direction and caught this
during development; see the test file's comments for the debugging trail).

## Measured size-effect table (real run on LUMI)

`ell=8`, `mu=lambda=1`, `eps0=0.01`, `L=16*max(R,ell)`, `order=4`:

```
python3 apps/gradient_elasticity/scripts/size_sweep.py \
  --binary build/apps/gradient_elasticity/gradient_elasticity \
  --outdir results/gradient_elasticity/size_sweep \
  --csv results/gradient_elasticity/size_sweep.csv \
  --ell 8.0 --box-to-radius 16.0 --box-check-radius 32 \
  --line-profile-radii 4 32 128 \
  --launcher 'srun --overlap -n 1'
```

```
R=4   R/ell=0.5  peak_hydro=0.0354724 peak_vm=0.0354725 energy=0.0129218
R=8   R/ell=1    peak_hydro=0.0314536 peak_vm=0.0314666 energy=0.0468152
R=16  R/ell=2    peak_hydro=0.0254438 peak_vm=0.0255543 energy=0.1367690
R=32  R/ell=4    peak_hydro=0.0203329 peak_vm=0.0206502 energy=0.4386250
R=64  R/ell=8    peak_hydro=0.0165884 peak_vm=0.0169242 energy=1.6097400
R=128 R/ell=16   peak_hydro=0.0142603 peak_vm=0.0143828 energy=6.2929900
box check R=32 ell=8: L/max(R,ell) 16 -> 32 (N=512 -> 1024):
  peak_hydro rel. change=1.223%, peak_vm rel. change=1.186%
```

Closed-form bounds: clamped `|sigma_h|=0.04` (`R/ell -> 0`); classical
`|sigma_h| ≈ 0.013333`, `sigma_vm(boundary) ≈ 0.023094` (`R/ell -> infinity`).
Peak hydrostatic stress decreases monotonically 0.0355 → 0.0143 as `R/ell`
goes 0.5 → 16, strictly between the two closed-form bounds at every point,
and within 7% of the classical bound by `R/ell=16`. (Total elastic energy
grows with `R` regardless, since it's an area integral; `energy/R^2`
— 0.000808 → 0.000384 — shows the same decreasing-with-`R/ell` trend the
peak stresses do; see the README table.)

Periodic-image control, separately, on the app's Catch2 test (`R=12`,
`ell=3`): `L/max(R,ell)` 8→16 changed peak hydrostatic stress by **4.30%**;
16→32 changed it by only **1.12%** — the reason the sweep defaults to
ratio 16, not 8.

## #117 acceptance criteria

- [x] Current cosine analytical verification remains green (unchanged, all
      passing).
- [x] Stress and strain fields are available as outputs/diagnostics, not
      displacement only.
- [x] Inclusion-size sweep spans at least one decade in `R/ell` (0.5 to 16,
      more than a decade).
- [x] A measurable size-effect curve is reported (table above; monotone,
      bounded by two closed forms).
- [x] Classical `ell -> 0` recovery is demonstrated (unit test + sweep's
      `R/ell=16` row within 7% of the closed form).
- [ ] One localized defect/regularization case shows finite-width/finite-peak
      behaviour relative to the classical case. **Deferred** — issue section
      B (dislocation/defect benchmark), see below.
- [ ] Fourth- vs sixth-order response compared on one controlled setup.
      **Deferred/partial** — `order=6`/`ell4` already existed and are unit
      tested at the `alpha(k)` level; no new controlled inclusion-level
      comparison was added in this PR.
- [x] Domain, BC/gauge, geometry and constitutive assumptions explicit in
      README (`Problem setup` table + physics section).
- [ ] CPU/HIP observables agree within tolerance. **Not separately
      verified** for the new fields — no HIP device was available in this
      build environment (`--cpu` only); the post-processing code is
      memory-space-generic (`with_host_view`, identical code path for
      `HostSpace`/`HIPSpace`) and reuses the displacement solve the
      existing `HIP_GradientElasticity` test already diff-checks, but a
      direct CPU-vs-HIP diff of e.g. `stress_vm` was not run.

## What is deferred

- **Section B (dislocation/defect regularization benchmark)**: not
  implemented. It needs a materially different loading (a displacement-
  jump/Burgers-vector construction) compatible with the periodic spectral
  formulation. The inclusion size-effect study here demonstrates a related
  but different lesson — size-dependent, bounded peak stress with an exact
  classical closed form to check against — which was judged the higher-
  value use of the available time.
- **Section C (systematic 4th- vs 6th-order comparison)**: not added beyond
  the pre-existing `alpha(k)` unit tests. `run_circular_case` in the test
  file already takes an `order` argument, so this is cheap to add later.
- **Stretch goals** (anisotropic cubic elasticity, 3-D precipitate
  benchmark, coupling into another physics model): not attempted, as
  scoped.
- **CPU vs. HIP diff of the new fields specifically**: not run (see
  acceptance-criteria checklist above).
- All physical constants (`mu`, `lambda`, `eps0`, `ell`, `R`) remain
  **illustrative/nondimensional**, not calibrated to a named material —
  labelled as such in the README's `Problem setup` table (calibration:
  none) and throughout.

## Verification performed

- Full CPU build: `./scripts/build.sh --machine=lumi --cpu --no-submit
  --no-test --jobs=16 --cmake-arg=-DOpenPFC_BUILD_TESTS=ON` — clean, zero
  compiler errors.
- `ctest -R gradient-elasticity` on the shared LUMI allocation: **all 15
  test cases / 40 assertions pass** (existing #82 verifiers + new #117
  tests).
- `ctest -R "openpfc-cli-gradient_elasticity-smoke|openpfc-cli-smoke"`:
  pass (CLI catalog unaffected — `circular_inclusion.json` is a new example
  file, not wired into `scripts/openpfc`'s preset dict).
- Ran the actual `gradient_elasticity` binary against
  `inputs_json/circular_inclusion.json` (all 6 derived fields as VTK + line
  profile) and the full size sweep above via `srun` on the shared
  allocation — real, not simulated, output.
- Did not run HIP tests (no HIP device in this build environment).

Refs #117

Merge by **rebase**, not squash.
