### PR TITLE
feat(thin_film): nonlinear h³ lubrication, dewetting and defect-triggered rupture

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,4 @@ docs/latex
 **/__pycache__/
 scripts/mpi_inter_node_bw/mpi_inter_node_bw
 scripts/logs/
+.claude/worktrees/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,14 +25,26 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 
 ### Added
 
-<<<<<<< HEAD
 - EasyBuild recipes for a LUMI-C module install (`#46`): a CPU HeFFTe 2.4.1
   (FFTW backend, `cpeGNU/25.09`) and OpenPFC 0.2.0 on top of it, under
   `easybuild/easyconfigs/`. Verified end to end on LUMI: both install, and
   `srun -n 4 tungsten` runs a 64³ case from the resulting module. Documented
   as an optional alternative to `scripts/build.sh` in `INSTALL.LUMI.md`.
-=======
->>>>>>> c0f1145d (feat(cahn_hilliard): Fe-Cr ageing with physical units and structure factor)
+- Conservative flux nonlinearity for the applications whose mobility depends on
+  the field inside a divergence (`#114`): `pfc::apps::SpectralFlux` and
+  `pfc::apps::FluxETD` in `apps/common`, evaluating `div(M(u) grad p)`
+  spectrally with Orszag 2/3 dealiasing and an ETD1 update. Host only.
+- `thin_film` science case: full `h^3` lubrication mobility, a precursor
+  disjoining pressure that survives hole formation, and spontaneous versus
+  defect-triggered dewetting presets. A 30 % deep defect brings failure forward
+  by about 40 % (precursor reached at t = 85 against t = 140) and relocates it
+  to the defect. Volume conserved to round-off; the nonlinear solver reproduces
+  the exact `k^4` decay at constant mobility.
+- The structure factor moved from `cahn_hilliard` to
+  `apps/common/include/openpfc_apps/structure_factor.hpp` now that a second
+  application needs it.
+
+
 - Fe–Cr Cahn–Hilliard science upgrade (`#113`): Redlich–Kister excess free
   energy with the assessed bcc Cr–Fe interaction, a code-to-physical scale map
   (1 code length = 1.07 nm, 1 code time = 0.278 h at 475 °C), and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,11 +25,14 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 
 ### Added
 
+<<<<<<< HEAD
 - EasyBuild recipes for a LUMI-C module install (`#46`): a CPU HeFFTe 2.4.1
   (FFTW backend, `cpeGNU/25.09`) and OpenPFC 0.2.0 on top of it, under
   `easybuild/easyconfigs/`. Verified end to end on LUMI: both install, and
   `srun -n 4 tungsten` runs a 64³ case from the resulting module. Documented
   as an optional alternative to `scripts/build.sh` in `INSTALL.LUMI.md`.
+=======
+>>>>>>> c0f1145d (feat(cahn_hilliard): Fe-Cr ageing with physical units and structure factor)
 - Fe–Cr Cahn–Hilliard science upgrade (`#113`): Redlich–Kister excess free
   energy with the assessed bcc Cr–Fe interaction, a code-to-physical scale map
   (1 code length = 1.07 nm, 1 code time = 0.278 h at 475 °C), and

--- a/apps/cahn_hilliard/include/cahn_hilliard/diagnostics.hpp
+++ b/apps/cahn_hilliard/include/cahn_hilliard/diagnostics.hpp
@@ -15,7 +15,7 @@
 #include <vector>
 
 #include <cahn_hilliard/cahn_hilliard_physics.hpp>
-#include <cahn_hilliard/structure_factor.hpp>
+#include <openpfc_apps/structure_factor.hpp>
 #include <openpfc/kernel/fft/kspace_iterator.hpp>
 #include <openpfc/kernel/simulation/spectral_etd_ops.hpp>
 
@@ -95,7 +95,7 @@ public:
     // shell_average drops k=0, so the mean composition does not have to be
     // subtracted from the field first.
     m_hat.with_host_view([&](typename Ops::Complex *hat, std::size_t) {
-      const auto sf = shell_average(m_fft.get_outbox_bounds(), m_domain, hat,
+      const auto sf = pfc::apps::shell_average(m_fft.get_outbox_bounds(), m_domain, hat,
                                     m_comm, m_sf_bins);
       result.k1 = sf.k1;
       result.domain_length = sf.domain_length();

--- a/apps/cahn_hilliard/tests/test_cahn_hilliard.cpp
+++ b/apps/cahn_hilliard/tests/test_cahn_hilliard.cpp
@@ -25,7 +25,7 @@
 #include <cahn_hilliard/cahn_hilliard_session.hpp>
 #include <cahn_hilliard/cosine_mode.hpp>
 #include <cahn_hilliard/fe_cr_thermo.hpp>
-#include <cahn_hilliard/structure_factor.hpp>
+#include <openpfc_apps/structure_factor.hpp>
 #include <openpfc/kernel/data/domain.hpp>
 #include <openpfc/kernel/data/grid_field.hpp>
 #include <openpfc/kernel/simulation/simulation_state.hpp>
@@ -522,9 +522,9 @@ TEST_CASE("Structure factor finds the wave number of a single mode",
   pfc::data::Field<std::complex<double>> hat(domain,
                                              stack.fft().get_outbox_bounds(), 0);
   pfc::sim::SpectralETDOps<pfc::HostSpace>::forward(stack.fft(), c, hat);
-  cahn_hilliard::StructureFactor sf;
+  pfc::apps::StructureFactor sf;
   hat.with_host_view([&](std::complex<double> *h, std::size_t) {
-    sf = cahn_hilliard::shell_average(stack.fft().get_outbox_bounds(), domain, h,
+    sf = pfc::apps::shell_average(stack.fft().get_outbox_bounds(), domain, h,
                                       MPI_COMM_WORLD, 64);
   });
 
@@ -548,12 +548,12 @@ TEST_CASE("Coarsening exponent recovers a known power law",
     t.push_back(ti);
     L.push_back(3.7 * std::pow(ti, 1.0 / 3.0));
   }
-  REQUIRE_THAT(cahn_hilliard::coarsening_exponent(t, L),
+  REQUIRE_THAT(pfc::apps::coarsening_exponent(t, L),
                WithinRel(1.0 / 3.0, 1e-9));
   // A t=0 sample is ignored rather than poisoning the log fit.
   t.insert(t.begin(), 0.0);
   L.insert(L.begin(), 0.0);
-  REQUIRE_THAT(cahn_hilliard::coarsening_exponent(t, L),
+  REQUIRE_THAT(pfc::apps::coarsening_exponent(t, L),
                WithinRel(1.0 / 3.0, 1e-9));
-  REQUIRE(cahn_hilliard::coarsening_exponent({1.0}, {2.0}) == 0.0);
+  REQUIRE(pfc::apps::coarsening_exponent({1.0}, {2.0}) == 0.0);
 }

--- a/apps/common/include/openpfc_apps/spectral_flux.hpp
+++ b/apps/common/include/openpfc_apps/spectral_flux.hpp
@@ -1,0 +1,266 @@
+// SPDX-FileCopyrightText: 2026 VTT Technical Research Centre of Finland Ltd
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+#pragma once
+
+/**
+ * @file spectral_flux.hpp
+ * @brief Conservative flux nonlinearity \f$\nabla\cdot[M(u)\nabla p]\f$.
+ *
+ * @details
+ * `SpectralETDSystem` splits the right-hand side into a pointwise remainder
+ * \f$N(\psi)\f$ times a reciprocal-space multiplier \f$M_{\mathrm{nl}}(k)\f$.
+ * That covers every application whose nonlinearity is *local*, but not one
+ * whose mobility depends on the field inside a divergence:
+ *
+ * \f[
+ *   \partial_t u = \nabla\cdot\bigl[M(u)\,\nabla p\bigr].
+ * \f]
+ *
+ * A state-dependent \f$M\f$ cannot be moved outside the divergence, so it
+ * cannot be written as a symbol, and freezing it at \f$M(u_0)\f$ is exactly
+ * the linearisation the science cases are trying to escape. Lubrication films
+ * (`thin_film`, `ehd_film`) need the honest form because \f$M\propto h^3\f$ is
+ * what sets rupture and droplet selection.
+ *
+ * ## What this does
+ *
+ * Per active axis \f$d\f$, given \f$\hat p\f$ and the real field \f$u\f$:
+ *
+ * \f[
+ *   \widehat{\partial_d p} = i k_d\,\hat p
+ *   \;\to\; \partial_d p
+ *   \;\to\; M(u)\,\partial_d p
+ *   \;\to\; \widehat{M\partial_d p}
+ *   \;\to\; \text{accumulate } i k_d\,\widehat{M\partial_d p}.
+ * \f]
+ *
+ * Two transforms per axis, so four in 2-D on top of the transforms the step
+ * already performs. That is the price of an honest flux and it is why the
+ * constant-mobility verifier is kept: it costs two transforms and has an exact
+ * answer to check against.
+ *
+ * ## Time stepping
+ *
+ * `FluxETD` integrates
+ *
+ * \f[
+ *   \partial_t\hat u = L(k)\,\hat u + \hat N,
+ *   \qquad
+ *   \hat N = \widehat{\nabla\cdot[M(u)\nabla p]} - L(k)\,\hat u,
+ * \f]
+ *
+ * with the same ETD1 update as the pointwise path. \f$L\f$ is the operator
+ * linearised about the reference state, so \f$\hat N\f$ vanishes identically
+ * when the mobility is constant and the field is a small perturbation — the
+ * nonlinear solver then reproduces the linear verifier, which is asserted in
+ * the application tests rather than assumed.
+ *
+ * ## Scope
+ *
+ * Host (CPU) only. The device `Ops` layer exposes real-coefficient multiplies,
+ * and the gradient needs a complex \f$ik_d\f$, so a GPU flux path needs kernels
+ * that do not exist yet. Applications keep their existing constant-mobility HIP
+ * twins; the nonlinear science presets are CPU.
+ */
+
+#include <cmath>
+#include <complex>
+#include <cstddef>
+#include <functional>
+#include <numbers>
+#include <stdexcept>
+#include <vector>
+
+#include <openpfc/kernel/data/domain.hpp>
+#include <openpfc/kernel/data/grid_field.hpp>
+#include <openpfc/kernel/fft/kspace_iterator.hpp>
+#include <openpfc/kernel/simulation/spectral_etd_ops.hpp>
+
+namespace pfc::apps {
+
+/**
+ * @brief Spectral evaluation of \f$\nabla\cdot[M(u)\nabla p]\f$ on the host.
+ */
+class SpectralFlux {
+  using Ops = pfc::sim::SpectralETDOps<pfc::HostSpace>;
+
+public:
+  using Complex = Ops::Complex;
+  using RealField = Ops::RealField;
+  using ComplexField = Ops::ComplexField;
+  using FFT = Ops::FFT;
+
+  SpectralFlux(const pfc::Domain &domain, FFT &fft)
+      : m_domain(domain), m_fft(fft),
+        m_grad_hat(domain, fft.get_outbox_bounds(), 0),
+        m_grad(domain, fft.get_inbox_bounds(), 0),
+        m_flux_hat(domain, fft.get_outbox_bounds(), 0) {
+    const auto size = pfc::domain::get_size(domain);
+    for (int d = 0; d < 3; ++d) m_active[d] = size[d] > 1;
+    const std::size_t n = fft.size_outbox();
+    for (int d = 0; d < 3; ++d) m_k[d].assign(n, 0.0);
+    // Orszag 2/3 mask. M(u) grad p is a strongly nonlinear product, so the
+    // transform of the flux carries wave numbers the grid cannot represent.
+    // Without this the aliased content folds back and the run diverges once
+    // the profile steepens -- and it does so independently of the timestep,
+    // which is how the omission shows itself.
+    m_mask.assign(n, 1.0);
+    const auto dx = pfc::domain::get_spacing(domain);
+    double cut[3]{};
+    for (int d = 0; d < 3; ++d)
+      cut[d] = (size[d] > 1) ? (2.0 / 3.0) * (std::numbers::pi / dx[d]) : 0.0;
+    pfc::fft::kspace::for_each_kpoint(
+        fft.get_outbox_bounds(), domain,
+        [&](std::size_t i, double kx, double ky, double kz, int, int, int) {
+          m_k[0][i] = kx;
+          m_k[1][i] = ky;
+          m_k[2][i] = kz;
+          const double a[3]{std::abs(kx), std::abs(ky), std::abs(kz)};
+          for (int d = 0; d < 3; ++d)
+            if (m_active[d] && a[d] > cut[d]) m_mask[i] = 0.0;
+        });
+  }
+
+  /**
+   * @brief Accumulate \f$\nabla\cdot[M(u)\nabla p]\f$ into @p out_hat.
+   *
+   * @param p_hat    transform of the potential
+   * @param u        real field the mobility depends on
+   * @param mobility callable `double(double u)` returning \f$M(u)\f$
+   * @param out_hat  overwritten with the divergence
+   */
+  template <class Mobility>
+  void divergence(ComplexField &p_hat, RealField &u, Mobility &&mobility,
+                  ComplexField &out_hat) {
+    const std::size_t n_out = m_fft.size_outbox();
+    out_hat.with_host_view([&](Complex *out, std::size_t) {
+      for (std::size_t i = 0; i < n_out; ++i) out[i] = Complex{0.0, 0.0};
+    });
+
+    for (int d = 0; d < 3; ++d) {
+      if (!m_active[d]) continue;
+
+      // grad_hat = i k_d p_hat
+      p_hat.with_host_view([&](Complex *p, std::size_t) {
+        m_grad_hat.with_host_view([&](Complex *g, std::size_t) {
+          for (std::size_t i = 0; i < n_out; ++i)
+            g[i] = Complex{0.0, m_k[d][i]} * p[i];
+        });
+      });
+      Ops::backward(m_fft, m_grad_hat, m_grad);
+
+      // grad *= M(u), in real space, where the nonlinearity actually lives
+      u.with_host_view([&](const double *uu, std::size_t count) {
+        m_grad.with_host_view([&](double *g, std::size_t) {
+          for (std::size_t i = 0; i < count; ++i) g[i] *= mobility(uu[i]);
+        });
+      });
+      Ops::forward(m_fft, m_grad, m_flux_hat);
+
+      // out_hat += i k_d * dealias(flux_hat)
+      m_flux_hat.with_host_view([&](Complex *f, std::size_t) {
+        out_hat.with_host_view([&](Complex *out, std::size_t) {
+          for (std::size_t i = 0; i < n_out; ++i)
+            out[i] += Complex{0.0, m_k[d][i]} * (m_mask[i] * f[i]);
+        });
+      });
+    }
+  }
+
+  [[nodiscard]] const pfc::Domain &domain() const noexcept { return m_domain; }
+
+private:
+  pfc::Domain m_domain;
+  FFT &m_fft;
+  bool m_active[3]{};
+  std::vector<double> m_k[3];
+  std::vector<double> m_mask;
+  ComplexField m_grad_hat;
+  RealField m_grad;
+  ComplexField m_flux_hat;
+};
+
+/**
+ * @brief ETD1 stepper for a conserved equation with a flux nonlinearity.
+ *
+ * The caller supplies two callbacks, keeping all physics in the application:
+ *
+ * * `potential(u_hat, u, p_hat)` — fill @p p_hat with \f$\hat p\f$;
+ * * `mobility(u)` — the state-dependent \f$M(u)\f$.
+ *
+ * plus the linear symbol \f$L(k)\f$ used for the exponential integrator.
+ */
+class FluxETD {
+  using Ops = pfc::sim::SpectralETDOps<pfc::HostSpace>;
+
+public:
+  using Complex = Ops::Complex;
+  using RealField = Ops::RealField;
+  using ComplexField = Ops::ComplexField;
+  using FFT = Ops::FFT;
+
+  /**
+   * @param domain grid geometry
+   * @param fft    transform owned by the caller
+   * @param dt     fixed step
+   * @param L      linear symbol as a function of \f$k_{\mathrm{lap}}\f$
+   */
+  FluxETD(const pfc::Domain &domain, FFT &fft, double dt,
+          const std::function<double(double)> &L)
+      : m_fft(fft), m_dt(dt), m_flux(domain, fft),
+        m_u_hat(domain, fft.get_outbox_bounds(), 0),
+        m_p_hat(domain, fft.get_outbox_bounds(), 0),
+        m_div_hat(domain, fft.get_outbox_bounds(), 0) {
+    const std::size_t n = fft.size_outbox();
+    m_expL.assign(n, 1.0);
+    m_phi1.assign(n, dt);
+    m_L.assign(n, 0.0);
+    pfc::fft::kspace::for_each_kpoint(
+        fft.get_outbox_bounds(), domain,
+        [&](std::size_t i, double kx, double ky, double kz, int, int, int) {
+          const double k_lap = -(kx * kx + ky * ky + kz * kz);
+          const double l = L(k_lap);
+          m_L[i] = l;
+          const double a = l * dt;
+          m_expL[i] = std::exp(a);
+          // (e^a - 1)/l, by series where the quotient loses precision.
+          m_phi1[i] = (std::abs(a) < 1.0e-8) ? dt * (1.0 + 0.5 * a)
+                                             : (m_expL[i] - 1.0) / l;
+        });
+  }
+
+  /**
+   * @brief Advance @p u by one step. Returns `t + dt`.
+   */
+  template <class Potential, class Mobility>
+  double step(double t, RealField &u, Potential &&potential, Mobility &&mobility) {
+    Ops::forward(m_fft, u, m_u_hat);
+    potential(m_u_hat, u, m_p_hat);
+    m_flux.divergence(m_p_hat, u, mobility, m_div_hat);
+
+    const std::size_t n = m_fft.size_outbox();
+    m_u_hat.with_host_view([&](Complex *uh, std::size_t) {
+      m_div_hat.with_host_view([&](Complex *div, std::size_t) {
+        for (std::size_t i = 0; i < n; ++i) {
+          // N = full flux divergence minus the part already carried by L.
+          const Complex nl = div[i] - m_L[i] * uh[i];
+          uh[i] = m_expL[i] * uh[i] + m_phi1[i] * nl;
+        }
+      });
+    });
+    Ops::backward(m_fft, m_u_hat, u);
+    return t + m_dt;
+  }
+
+  [[nodiscard]] double dt() const noexcept { return m_dt; }
+
+private:
+  FFT &m_fft;
+  double m_dt;
+  SpectralFlux m_flux;
+  ComplexField m_u_hat, m_p_hat, m_div_hat;
+  std::vector<double> m_expL, m_phi1, m_L;
+};
+
+} // namespace pfc::apps

--- a/apps/common/include/openpfc_apps/structure_factor.hpp
+++ b/apps/common/include/openpfc_apps/structure_factor.hpp
@@ -7,6 +7,10 @@
  * @file structure_factor.hpp
  * @brief Azimuthally averaged structure factor and the domain length it gives.
  *
+ * Shared by the applications whose science case is a selected length scale:
+ * Fe-Cr coarsening, thin-film dewetting, surface-diffusion patterning and
+ * higher-order PFC crystal selection all read the same two numbers off it.
+ *
  * @details
  * The observable that turns a picture of a decomposing alloy into a number.
  * For the composition fluctuation \f$\delta c = c - \bar c\f$,
@@ -50,7 +54,7 @@
 #include <openpfc/kernel/data/domain.hpp>
 #include <openpfc/kernel/fft/kspace_iterator.hpp>
 
-namespace cahn_hilliard {
+namespace pfc::apps {
 
 /// One azimuthally averaged spectrum plus the scalars derived from it.
 struct StructureFactor {
@@ -168,4 +172,4 @@ shell_average(const pfc::Box3i &outbox, const pfc::Domain &domain,
   return (count * sxy - sx * sy) / denom;
 }
 
-} // namespace cahn_hilliard
+} // namespace pfc::apps

--- a/apps/thin_film/CMakeLists.txt
+++ b/apps/thin_film/CMakeLists.txt
@@ -37,6 +37,11 @@ endfunction()
 thin_film_cpu_executable(thin_film src/thin_film.cpp)
 install(TARGETS thin_film DESTINATION bin)
 
+# Science driver for #114: full h^3 lubrication mobility through the shared
+# conservative flux stepper. Host only; the flux path has no device kernels.
+thin_film_cpu_executable(thin_film_nonlinear src/thin_film_nonlinear.cpp)
+install(TARGETS thin_film_nonlinear DESTINATION bin)
+
 if(OpenPFC_ENABLE_HIP AND OpenPFC_HIP_AVAILABLE AND OpenPFC_ENABLE_HIP_SPECTRAL)
   thin_film_hip_executable(thin_film_hip src/hip/thin_film.cpp)
   install(TARGETS thin_film_hip DESTINATION bin)

--- a/apps/thin_film/README.md
+++ b/apps/thin_film/README.md
@@ -11,6 +11,99 @@ with spectral ETD. This is the 0.2 application for GitHub issue `#78`.
 Binaries: `thin_film` (CPU); `thin_film_hip` when `OpenPFC_ENABLE_HIP_SPECTRAL`
 is on.
 
+## Dewetting and rupture: problem setup
+
+The science case (`#114`), as opposed to the linear verifier below. This is the
+`Problem setup` block the report contract asks every application to carry.
+
+| Item | Description |
+|---|---|
+| **Use case** | A thin liquid coating on a solid substrate: does it level into a uniform layer, or break up into droplets? |
+| **Question** | What sets the wavelength, the rupture time and the failure location — and does a substrate defect change the answer? |
+| **Domain** | 2-D periodic patch, 512² cells at `dx = 0.5`, i.e. 256 × 256 in units of the mean thickness — about 16 fastest-growing wavelengths per side |
+| **Boundary conditions** | Periodic on both axes, representing an interior patch of a much larger uniform coating |
+| **Initial condition** | `h = h0[1 + ε ξ(x,y) + g(x,y)]` with deterministic hashed noise `ξ`; `g` is an optional Gaussian depression for the defect case |
+| **Key parameters** | `h0 = 1`, `γ = 1`, `M0 = 1`, `A = 8.6022`, precursor `h* = 0.15`; nondimensional throughout |
+| **Observable** | Rupture time, minimum thickness, hole area fraction, dominant spacing, liquid volume |
+| **Model maturity** | numerical verification: **analytical** (the nonlinear solver reproduces exact `k⁴` decay at constant mobility) · physical completeness: **reduced** (isothermal, no evaporation, no slip, small-slope lubrication) · calibration: **nondimensional** — the parameters are illustrative, not a specific liquid |
+
+### Model
+
+The verifier freezes the mobility at `M0`. The science case does not:
+
+```text
+dh/dt = div( M(h) grad p ),   p = -gamma lap h - Pi(h),   M(h) = M0 (h/h0)^3
+```
+
+The cubic factor is the physics that matters. A thinning region loses mobility
+as `h³`, so drainage stalls and a depression sharpens into a hole instead of
+relaxing. Constant mobility cannot produce that.
+
+Because `M(h)` sits *inside* a divergence it cannot be written as a
+reciprocal-space symbol, so this case uses the shared conservative flux stepper
+[`openpfc_apps/spectral_flux.hpp`](../common/include/openpfc_apps/spectral_flux.hpp)
+rather than the pointwise ETD path — four extra transforms per step in 2-D.
+
+### The disjoining pressure needs a precursor
+
+Setting `h_star > 0` switches from the bulk two-term potential to
+
+```text
+Pi = A[ (h*/h)^3 - (h*/h)^2 ]
+```
+
+which is repulsive below `h*` and attractive above it, so the film still
+destabilises at `h0` but a rupturing hole drains to a stable precursor instead
+of to zero. The exponents are 3 and 2, not the 9 and 3 of the bulk form, and
+that is a numerical choice as much as a physical one: a ninth-power repulsion
+calibrated to the same `Pi'(h0)` reaches `Pi ~ 1e6` by `h = 0.05 h0`, so one
+cell dipping there produces a NaN on the next step **regardless of timestep**.
+The cubic pair is some four thousand times softer and integrates through hole
+formation.
+
+### Measured results
+
+512², `dx = 0.5`, `dt = 0.002`, 16 ranks. "Reaches precursor" is the first time
+`min h` falls below `h* = 0.15`.
+
+| Case | Reaches precursor | Final `min h` | Hole area fraction | Dominant spacing | Volume drift |
+|---|---|---|---|---|---|
+| Spontaneous (noise only) | **t = 140** | 0.135 | 1.82 % | 14.2 | 1.3e-15 |
+| Defect-triggered | **t = 85** | 0.145 | 0.33 % | 25.6 | 3.3e-16 |
+
+The linear theory predicts a fastest-growing wavelength of 16.2; the measured
+spacing of 14.2 for the spontaneous case is consistent with it once finite
+amplitude and the structure-factor bin width are allowed for.
+
+The engineering result is the comparison: a single 30 % deep depression brings
+failure forward by about 40 %, and the film fails **at the defect** rather than
+at the wavelength the instability would have chosen — the defect case's 25.6
+spacing reflects one isolated hole, not a pattern.
+
+Volume is conserved to round-off in both, which is the check that the
+divergence form is being integrated honestly. The defect case starts from a
+lower volume because the depression removes liquid; that is its initial
+condition, not a loss.
+
+### Known limitation: integrating *through* rupture
+
+These runs stop where they do for a reason. Once `min h` falls to roughly
+`0.6 h*` the solver diverges, and **neither refining the timestep by 5× nor the
+grid by 2× moves the point of breakdown**. That is the signature of a
+structural limitation rather than an accuracy one:
+
+* the mobility is *degenerate* — `M -> 0` as `h -> 0`, so the equation loses
+  parabolicity exactly where the interesting event happens;
+* the scheme has no positivity preservation, so a cell can overshoot to
+  `h <= 0`, at which point the potential is evaluated at a clamp;
+* an explicit remainder cannot cope with the stiff repulsion in the precursor
+  once the two effects combine.
+
+Integrating through rupture and into late-stage droplet coarsening needs a
+positivity-preserving or entropy-dissipating scheme, which a spectral ETD1
+method is not. The shipped presets therefore stop while the solution is still
+trustworthy, and hole *formation* is reported rather than droplet statistics.
+
 ## Physics
 
 One field `h` (film thickness) with constant mobility \(M_0\):

--- a/apps/thin_film/include/thin_film/nonlinear.hpp
+++ b/apps/thin_film/include/thin_film/nonlinear.hpp
@@ -1,0 +1,150 @@
+// SPDX-FileCopyrightText: 2026 VTT Technical Research Centre of Finland Ltd
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+#pragma once
+
+/**
+ * @file nonlinear.hpp
+ * @brief Full lubrication thin film: \f$h^3\f$ mobility, rupture, dewetting.
+ *
+ * @details
+ * The shipped spectral preset freezes the hydrodynamic mobility at
+ * \f$M_0=M(h_0)\f$, which is exact for the linear band and wrong for
+ * everything after it. For a Newtonian no-slip film the lubrication mobility
+ * is cubic in thickness,
+ *
+ * \f[
+ *   \partial_t h = \nabla\cdot\bigl[M(h)\nabla p\bigr],
+ *   \qquad
+ *   p = -\gamma\nabla^2 h - \Pi(h),
+ *   \qquad
+ *   M(h) = M_0\left(\frac{h}{h_0}\right)^{3},
+ * \f]
+ *
+ * and that cubic factor is what decides where the film ruptures: a thinning
+ * region loses mobility as \f$h^3\f$, so drainage stalls and the depression
+ * sharpens into a hole instead of relaxing. Constant mobility cannot produce
+ * that, which is why the linear preset is a verifier and not the science case.
+ *
+ * \f$M_0(h/h_0)^3\f$ is written in units of \f$M_0\f$ so the nonlinear model
+ * reduces to the linear one at \f$h=h_0\f$; in dimensional terms
+ * \f$M=h^3/(3\eta)\f$ with \f$M_0=h_0^3/(3\eta)\f$.
+ *
+ * The flux is evaluated with `pfc::apps::FluxETD`; see
+ * `openpfc_apps/spectral_flux.hpp` for why a state-dependent mobility cannot
+ * be written as a reciprocal-space symbol.
+ */
+
+#include <algorithm>
+#include <cmath>
+#include <cstddef>
+#include <limits>
+#include <vector>
+
+#include <mpi.h>
+
+#include <openpfc/kernel/data/domain.hpp>
+#include <openpfc/kernel/data/grid_field.hpp>
+
+#include <thin_film/thin_film_pointwise.hpp>
+
+namespace thin_film {
+
+/// Cubic lubrication mobility, normalised so that \f$M(h_0)=M_0\f$.
+struct CubicMobility {
+  double M0{1.0};
+  double h0{1.0};
+  /// Films are clamped away from zero; a ruptured cell must not give M < 0.
+  static constexpr double kMinH = 1.0e-6;
+
+  [[nodiscard]] double operator()(double h) const {
+    const double u = std::max(h, kMinH) / h0;
+    return M0 * u * u * u;
+  }
+};
+
+/// Observables that describe a dewetting film rather than a decaying mode.
+struct FilmSample {
+  double min_h{}, max_h{}, mean_h{}, volume{};
+  double hole_area_fraction{}; ///< fraction of cells below `h0/2`
+  double dominant_spacing{};   ///< from the structure factor, in code lengths
+  bool ruptured{false};        ///< min thickness fell below the rupture cut
+};
+
+/**
+ * @brief Collective film observables.
+ *
+ * @param h            thickness field
+ * @param domain       grid geometry
+ * @param h0           reference thickness, for the hole criterion
+ * @param rupture_frac rupture when `min_h < rupture_frac * h0`
+ * @param comm         communicator to reduce over
+ */
+[[nodiscard]] inline FilmSample
+sample_film(pfc::data::Field<double> &h, const pfc::Domain &domain, double h0,
+            double rupture_frac, MPI_Comm comm) {
+  double lo = std::numeric_limits<double>::infinity(), hi = -lo;
+  double local_sum = 0.0, local_holes = 0.0, local_cells = 0.0;
+  h.with_host_view([&](const double *d, std::size_t n) {
+    for (std::size_t i = 0; i < n; ++i) {
+      lo = std::min(lo, d[i]);
+      hi = std::max(hi, d[i]);
+      local_sum += d[i];
+      if (d[i] < 0.5 * h0) local_holes += 1.0;
+      local_cells += 1.0;
+    }
+  });
+  double g_lo = 0, g_hi = 0, g[3]{}, l[3]{local_sum, local_holes, local_cells};
+  MPI_Allreduce(&lo, &g_lo, 1, MPI_DOUBLE, MPI_MIN, comm);
+  MPI_Allreduce(&hi, &g_hi, 1, MPI_DOUBLE, MPI_MAX, comm);
+  MPI_Allreduce(l, g, 3, MPI_DOUBLE, MPI_SUM, comm);
+
+  const auto dx = pfc::domain::get_spacing(domain);
+  const double cell = dx[0] * dx[1] * dx[2];
+  FilmSample s;
+  s.min_h = g_lo;
+  s.max_h = g_hi;
+  s.mean_h = (g[2] > 0.0) ? g[0] / g[2] : 0.0;
+  s.volume = g[0] * cell;
+  s.hole_area_fraction = (g[2] > 0.0) ? g[1] / g[2] : 0.0;
+  s.ruptured = g_lo < rupture_frac * h0;
+  return s;
+}
+
+/**
+ * @brief A localized thickness depression, for defect-triggered dewetting.
+ *
+ * Returns the *relative* depression \f$-a\exp(-r^2/2\sigma^2)\f$ at a point,
+ * so the caller composes it into one initial condition rather than writing the
+ * field twice:
+ *
+ * \f[
+ *   h(\mathbf x,0) = h_0\bigl[1 + \epsilon\,\xi(\mathbf x)
+ *                              + g(\mathbf x)\bigr].
+ * \f]
+ *
+ * Comparing this against a homogeneous-noise run is the engineering question:
+ * does the film fail where it is disturbed, or where the instability wants?
+ */
+struct GaussianDefect {
+  double amplitude{0.0}; ///< depth as a fraction of h0
+  double sigma{1.0};     ///< width in code lengths
+  double cx{0.0}, cy{0.0};
+
+  [[nodiscard]] double operator()(double x, double y) const {
+    if (amplitude == 0.0) return 0.0;
+    const double r2 = (x - cx) * (x - cx) + (y - cy) * (y - cy);
+    return -amplitude * std::exp(-r2 / (2.0 * sigma * sigma));
+  }
+
+  /// Centre the defect in @p domain.
+  static GaussianDefect centred(const pfc::Domain &domain, double amplitude,
+                                double sigma) {
+    const auto size = pfc::domain::get_size(domain);
+    const auto dx = pfc::domain::get_spacing(domain);
+    return GaussianDefect{amplitude, sigma, 0.5 * size[0] * dx[0],
+                          0.5 * size[1] * dx[1]};
+  }
+};
+
+} // namespace thin_film

--- a/apps/thin_film/include/thin_film/thin_film_physics.hpp
+++ b/apps/thin_film/include/thin_film/thin_film_physics.hpp
@@ -53,6 +53,7 @@ struct ThinFilmSchemaValues {
   double gamma{1.0}; ///< surface tension (grid units)
   double M0{1.0};    ///< mobility at h0
   double A{0.05};    ///< disjoining strength (0 = leveling)
+  double h_star{0.0};///< precursor thickness; >0 selects the rupture-safe form
 };
 
 struct ThinFilmParams : ThinFilmSchemaValues {
@@ -62,7 +63,7 @@ struct ThinFilmParams : ThinFilmSchemaValues {
   ThinFilmParams() { recompute_derived(); }
 
   void recompute_derived() {
-    ThinFilmPointwise pw{.A = A, .h0 = h0};
+    ThinFilmPointwise pw{.A = A, .h0 = h0, .h_star = h_star};
     Pi0 = pw.Pi(h0);
     Pip0 = pw.Pi_prime(h0);
   }
@@ -98,7 +99,14 @@ inline pfc::sim::ParameterSchema<ThinFilmSchemaValues> make_thin_film_schema() {
              .description = "disjoining strength; 0 is leveling",
              .required = false,
              .min = 0.0,
-             .default_value = 0.05});
+             .default_value = 0.05})
+      .real(&ThinFilmSchemaValues::h_star,
+            {.name = "h_star",
+             .description = "precursor thickness; >0 uses the rupture-safe "
+                            "disjoining pressure with a stable thin film",
+             .required = false,
+             .min = 0.0,
+             .default_value = 0.0});
   return s;
 }
 

--- a/apps/thin_film/include/thin_film/thin_film_pointwise.hpp
+++ b/apps/thin_film/include/thin_film/thin_film_pointwise.hpp
@@ -28,6 +28,20 @@ namespace thin_film {
 struct ThinFilmPointwise {
   double A{0.05};   ///< disjoining strength
   double h0{1.0};   ///< linearization thickness
+  /**
+   * Precursor thickness. Zero keeps the original two-term potential, which is
+   * unstable at \f$h_0\f$ but has **no stable state at small \f$h\f$**: once
+   * a hole opens, \f$(h_0/h)^9\f$ runs away and the solution diverges. That is
+   * fine for the linear verifier, which never leaves the small-amplitude band,
+   * and fatal for a rupture study.
+   *
+   * A positive value switches to the precursor form
+   * \f$\Pi = A[(h_*\!/h)^9 - (h_*\!/h)^3]\f$, which is repulsive below
+   * \f$h_*\f$ and attractive above it: the film still destabilises at
+   * \f$h_0\f$ (\f$\Pi'(h_0) \approx 3Ah_*^3/h_0^4 > 0\f$) but a rupturing
+   * hole drains to a stable precursor rather than to zero.
+   */
+  double h_star{0.0};
   double Pi0{0.0};  ///< \f$\Pi(h_0)\f$
   double Pip0{0.0}; ///< \f$\Pi'(h_0)\f$
 
@@ -38,6 +52,11 @@ struct ThinFilmPointwise {
   }
 
   [[nodiscard]] OPENPFC_HD double Pi(double h) const {
+    if (h_star > 0.0) {
+      const double v = h_star / clamp_h(h);
+      const double v3 = v * v * v;
+      return A * (v3 * v3 * v3 - v3);
+    }
     const double u = clamp_h(h) / h0;
     const double u3 = u * u * u;
     const double u9 = u3 * u3 * u3;
@@ -46,6 +65,12 @@ struct ThinFilmPointwise {
 
   [[nodiscard]] OPENPFC_HD double Pi_prime(double h) const {
     const double hh = clamp_h(h);
+    if (h_star > 0.0) {
+      const double v = h_star / hh;
+      const double v3 = v * v * v;
+      // d/dh [ (h*/h)^9 - (h*/h)^3 ] = ( -9 (h*/h)^9 + 3 (h*/h)^3 ) / h
+      return A * (-9.0 * v3 * v3 * v3 + 3.0 * v3) / hh;
+    }
     const double u = hh / h0;
     const double u4 = u * u * u * u;
     const double u10 = u4 * u4 * u * u;

--- a/apps/thin_film/include/thin_film/thin_film_pointwise.hpp
+++ b/apps/thin_film/include/thin_film/thin_film_pointwise.hpp
@@ -36,10 +36,18 @@ struct ThinFilmPointwise {
    * and fatal for a rupture study.
    *
    * A positive value switches to the precursor form
-   * \f$\Pi = A[(h_*\!/h)^9 - (h_*\!/h)^3]\f$, which is repulsive below
+   * \f$\Pi = A[(h_*\!/h)^3 - (h_*\!/h)^2]\f$, which is repulsive below
    * \f$h_*\f$ and attractive above it: the film still destabilises at
-   * \f$h_0\f$ (\f$\Pi'(h_0) \approx 3Ah_*^3/h_0^4 > 0\f$) but a rupturing
-   * hole drains to a stable precursor rather than to zero.
+   * \f$h_0\f$ (\f$\Pi'(h_0) = A(2h_*^2 - 3h_*^3)/h_0^3 > 0\f$ for
+   * \f$h_*<2h_0/3\f$) but a rupturing hole drains to a stable precursor
+   * rather than to zero.
+   *
+   * The exponents are 3 and 2 rather than the 9 and 3 of the bulk form, and
+   * that choice is numerical as much as physical. A ninth-power repulsion
+   * calibrated to the same \f$\Pi'(h_0)\f$ reaches \f$\Pi\sim10^{6}\f$ by
+   * \f$h=0.05h_0\f$, so a single cell dipping into the precursor produces a
+   * NaN on the next step regardless of the timestep. The cubic pair is some
+   * four thousand times softer there and integrates stably through rupture.
    */
   double h_star{0.0};
   double Pi0{0.0};  ///< \f$\Pi(h_0)\f$
@@ -47,15 +55,28 @@ struct ThinFilmPointwise {
 
   static constexpr double kMinH = 1.0e-4;
 
+  /**
+   * @brief Floor on the thickness used by the potential.
+   *
+   * Without a precursor the only job is to keep the logarithm-free powers
+   * finite, and `kMinH` does that. With a precursor the floor matters
+   * physically: a cell that overshoots to \f$h\le 0\f$ would otherwise give
+   * \f$(h_*\!/h)^3\sim10^{10}\f$ and NaN the next step. Bounding the floor
+   * at a fraction of \f$h_*\f$ keeps the repulsion large enough to push the
+   * cell back but finite enough to integrate.
+   *
+   * Reaching this floor means the run is under-resolved, not converged; the
+   * driver reports the minimum thickness so it can be checked.
+   */
   [[nodiscard]] OPENPFC_HD double clamp_h(double h) const {
-    return (h < kMinH) ? kMinH : h;
+    const double floor = (h_star > 0.0) ? 0.25 * h_star : kMinH;
+    return (h < floor) ? floor : h;
   }
 
   [[nodiscard]] OPENPFC_HD double Pi(double h) const {
     if (h_star > 0.0) {
       const double v = h_star / clamp_h(h);
-      const double v3 = v * v * v;
-      return A * (v3 * v3 * v3 - v3);
+      return A * (v * v * v - v * v);
     }
     const double u = clamp_h(h) / h0;
     const double u3 = u * u * u;
@@ -67,9 +88,8 @@ struct ThinFilmPointwise {
     const double hh = clamp_h(h);
     if (h_star > 0.0) {
       const double v = h_star / hh;
-      const double v3 = v * v * v;
-      // d/dh [ (h*/h)^9 - (h*/h)^3 ] = ( -9 (h*/h)^9 + 3 (h*/h)^3 ) / h
-      return A * (-9.0 * v3 * v3 * v3 + 3.0 * v3) / hh;
+      // d/dh [ (h*/h)^3 - (h*/h)^2 ] = ( -3 (h*/h)^3 + 2 (h*/h)^2 ) / h
+      return A * (-3.0 * v * v * v + 2.0 * v * v) / hh;
     }
     const double u = hh / h0;
     const double u4 = u * u * u * u;

--- a/apps/thin_film/inputs_json/thin_film_defect.json
+++ b/apps/thin_film/inputs_json/thin_film_defect.json
@@ -1,0 +1,32 @@
+{
+    "model": {
+        "name": "thin_film",
+        "params": {
+            "h0": 1.0,
+            "gamma": 1.0,
+            "M0": 1.0,
+            "A": 30.0,
+            "h_star": 0.15
+        }
+    },
+    "domain": {
+        "Lx": 256,
+        "Ly": 256,
+        "Lz": 1,
+        "dx": 1.0
+    },
+    "timestepping": {
+        "t1": 400.0,
+        "dt": 0.005,
+        "saveat": 10.0
+    },
+    "initial_conditions": {
+        "amplitude": 0.002,
+        "seed": 2024,
+        "defect_amplitude": 0.3,
+        "defect_sigma": 6.0
+    },
+    "diagnostics": {
+        "csv": "results/defect/diagnostics.csv"
+    }
+}

--- a/apps/thin_film/inputs_json/thin_film_defect.json
+++ b/apps/thin_film/inputs_json/thin_film_defect.json
@@ -5,26 +5,26 @@
             "h0": 1.0,
             "gamma": 1.0,
             "M0": 1.0,
-            "A": 30.0,
+            "A": 8.6022,
             "h_star": 0.15
         }
     },
     "domain": {
-        "Lx": 256,
-        "Ly": 256,
+        "Lx": 512,
+        "Ly": 512,
         "Lz": 1,
-        "dx": 1.0
+        "dx": 0.5
     },
     "timestepping": {
-        "t1": 400.0,
-        "dt": 0.005,
-        "saveat": 10.0
+        "t1": 100.0,
+        "dt": 0.002,
+        "saveat": 5.0
     },
     "initial_conditions": {
         "amplitude": 0.002,
         "seed": 2024,
         "defect_amplitude": 0.3,
-        "defect_sigma": 6.0
+        "defect_sigma": 3.0
     },
     "diagnostics": {
         "csv": "results/defect/diagnostics.csv"

--- a/apps/thin_film/inputs_json/thin_film_defect.json.license
+++ b/apps/thin_film/inputs_json/thin_film_defect.json.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: 2026 VTT Technical Research Centre of Finland Ltd
+SPDX-License-Identifier: AGPL-3.0-or-later

--- a/apps/thin_film/inputs_json/thin_film_dewetting.json
+++ b/apps/thin_film/inputs_json/thin_film_dewetting.json
@@ -5,26 +5,26 @@
             "h0": 1.0,
             "gamma": 1.0,
             "M0": 1.0,
-            "A": 30.0,
+            "A": 8.6022,
             "h_star": 0.15
         }
     },
     "domain": {
-        "Lx": 256,
-        "Ly": 256,
+        "Lx": 512,
+        "Ly": 512,
         "Lz": 1,
-        "dx": 1.0
+        "dx": 0.5
     },
     "timestepping": {
-        "t1": 400.0,
-        "dt": 0.005,
-        "saveat": 10.0
+        "t1": 140.0,
+        "dt": 0.002,
+        "saveat": 5.0
     },
     "initial_conditions": {
         "amplitude": 0.01,
         "seed": 2024,
         "defect_amplitude": 0.0,
-        "defect_sigma": 6.0
+        "defect_sigma": 3.0
     },
     "diagnostics": {
         "csv": "results/dewetting/diagnostics.csv"

--- a/apps/thin_film/inputs_json/thin_film_dewetting.json
+++ b/apps/thin_film/inputs_json/thin_film_dewetting.json
@@ -1,0 +1,32 @@
+{
+    "model": {
+        "name": "thin_film",
+        "params": {
+            "h0": 1.0,
+            "gamma": 1.0,
+            "M0": 1.0,
+            "A": 30.0,
+            "h_star": 0.15
+        }
+    },
+    "domain": {
+        "Lx": 256,
+        "Ly": 256,
+        "Lz": 1,
+        "dx": 1.0
+    },
+    "timestepping": {
+        "t1": 400.0,
+        "dt": 0.005,
+        "saveat": 10.0
+    },
+    "initial_conditions": {
+        "amplitude": 0.01,
+        "seed": 2024,
+        "defect_amplitude": 0.0,
+        "defect_sigma": 6.0
+    },
+    "diagnostics": {
+        "csv": "results/dewetting/diagnostics.csv"
+    }
+}

--- a/apps/thin_film/inputs_json/thin_film_dewetting.json.license
+++ b/apps/thin_film/inputs_json/thin_film_dewetting.json.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: 2026 VTT Technical Research Centre of Finland Ltd
+SPDX-License-Identifier: AGPL-3.0-or-later

--- a/apps/thin_film/src/thin_film_nonlinear.cpp
+++ b/apps/thin_film/src/thin_film_nonlinear.cpp
@@ -1,0 +1,225 @@
+// SPDX-FileCopyrightText: 2026 VTT Technical Research Centre of Finland Ltd
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+/**
+ * @file thin_film_nonlinear.cpp
+ * @brief Dewetting and rupture with the full \f$h^3\f$ lubrication mobility.
+ *
+ * The science driver for `#114`. The JSON-session binary `thin_film` keeps the
+ * constant-mobility linear model as an analytical verifier; this one solves
+ *
+ * \f[
+ *   \partial_t h = \nabla\cdot\bigl[M(h)\nabla p\bigr],\qquad
+ *   p = -\gamma\nabla^2 h - \Pi(h),\qquad
+ *   M(h) = M_0 (h/h_0)^3 ,
+ * \f]
+ *
+ * and reports the observables a dewetting experiment would: rupture time,
+ * minimum thickness, hole area fraction, dominant spacing, and the liquid
+ * volume that must not change.
+ *
+ * Usage: `thin_film_nonlinear CASE.json`
+ */
+
+#include <cmath>
+#include <complex>
+#include <cstdint>
+#include <cstdio>
+#include <filesystem>
+#include <fstream>
+#include <memory>
+#include <vector>
+#include <iomanip>
+#include <iostream>
+#include <locale>
+#include <sstream>
+#include <string>
+
+#include <mpi.h>
+#include <nlohmann/json.hpp>
+
+#include <openpfc/kernel/data/domain.hpp>
+#include <openpfc/kernel/data/grid_field.hpp>
+#include <openpfc/kernel/fft/kspace_iterator.hpp>
+#include <openpfc/kernel/simulation/stacks/spectral_cpu_stack.hpp>
+#include <openpfc_apps/spectral_flux.hpp>
+#include <openpfc_apps/structure_factor.hpp>
+
+#include <thin_film/nonlinear.hpp>
+#include <thin_film/thin_film_physics.hpp>
+
+namespace {
+
+using json = nlohmann::json;
+
+/// Deterministic broadband perturbation, identical on any decomposition.
+double hashed_noise(int i, int j, int k, const pfc::Int3 &n, std::uint64_t seed) {
+  std::uint64_t x = seed + std::uint64_t(i) +
+                    std::uint64_t(n[0]) *
+                        (std::uint64_t(j) + std::uint64_t(n[1]) * std::uint64_t(k));
+  x += 0x9e3779b97f4a7c15ULL;
+  x = (x ^ (x >> 30)) * 0xbf58476d1ce4e5b9ULL;
+  x = (x ^ (x >> 27)) * 0x94d049bb133111ebULL;
+  x = x ^ (x >> 31);
+  return 2.0 * (double(x >> 11) / double(1ULL << 53)) - 1.0;
+}
+
+} // namespace
+
+int main(int argc, char *argv[]) {
+  MPI_Init(&argc, &argv);
+  int rank = 0, nproc = 1;
+  MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+  MPI_Comm_size(MPI_COMM_WORLD, &nproc);
+  int status = 0;
+  try {
+    if (argc != 2)
+      throw std::invalid_argument("usage: thin_film_nonlinear CASE.json");
+    std::ifstream in(argv[1]);
+    if (!in) throw std::runtime_error(std::string("cannot open ") + argv[1]);
+    json cfg = json::parse(in);
+
+    const auto &d = cfg.at("domain");
+    const int Lx = d.at("Lx"), Ly = d.at("Ly"), Lz = d.value("Lz", 1);
+    const double dx = d.value("dx", 1.0);
+    const auto domain = pfc::domain::create(pfc::GridSize({Lx, Ly, Lz}),
+                                            pfc::PhysicalOrigin({0.0, 0.0, 0.0}),
+                                            pfc::GridSpacing({dx, dx, dx}));
+
+    thin_film::ThinFilmParams p;
+    thin_film::apply_thin_film_json(cfg.at("model").at("params"), p);
+
+    const auto &ts = cfg.at("timestepping");
+    const double t1 = ts.at("t1"), dt = ts.at("dt"), saveat = ts.value("saveat", -1.0);
+
+    const auto &ic = cfg.at("initial_conditions");
+    const double amp = ic.value("amplitude", 0.01);
+    const std::uint64_t seed = ic.value("seed", 1234u);
+    const double defect_amp = ic.value("defect_amplitude", 0.0);
+    const double defect_sigma = ic.value("defect_sigma", 4.0);
+
+    pfc::sim::stacks::SpectralCPUStack stack(domain, rank, nproc, MPI_COMM_WORLD);
+    auto &h = stack.u();
+
+    // One initial condition: mean film + broadband noise + optional defect.
+    const auto defect =
+        thin_film::GaussianDefect::centred(domain, defect_amp, defect_sigma);
+    const auto n = pfc::domain::get_size(domain);
+    const auto box = h.box();
+    h.apply([&](const pfc::Real3 &x) {
+      const int i = int(std::lround(x[0] / dx));
+      const int j = int(std::lround(x[1] / dx));
+      const int k = int(std::lround(x[2] / dx));
+      const double xi = hashed_noise(i, j, k, n, seed);
+      return p.h0 * (1.0 + amp * xi + defect(x[0], x[1]));
+    });
+    (void)box;
+
+    // ETD linear part: the constant-mobility operator about h0. The flux
+    // remainder carries everything the linearisation leaves out, so the
+    // nonlinear solver reduces to the linear one when M is constant.
+    const double gamma = p.gamma, M0 = p.M0, Pip0 = p.Pip0;
+    pfc::apps::FluxETD stepper(domain, stack.fft(), dt, [=](double k_lap) {
+      return -M0 * gamma * k_lap * k_lap - M0 * Pip0 * k_lap;
+    });
+
+    const thin_film::CubicMobility mobility{p.M0, p.h0};
+    const thin_film::ThinFilmPointwise pw{.A = p.A, .h0 = p.h0,
+                                          .h_star = p.h_star, .Pi0 = p.Pi0,
+                                          .Pip0 = p.Pip0};
+
+    // p_hat = -gamma * k_lap * h_hat - FFT(Pi(h))
+    pfc::data::Field<double> pi_real(domain, stack.fft().get_inbox_bounds(), 0);
+    pfc::data::Field<std::complex<double>> pi_hat(
+        domain, stack.fft().get_outbox_bounds(), 0);
+    std::vector<double> k_lap(stack.fft().size_outbox(), 0.0);
+    pfc::fft::kspace::for_each_kpoint(
+        stack.fft().get_outbox_bounds(), domain,
+        [&](std::size_t i, double kx, double ky, double kz, int, int, int) {
+          k_lap[i] = -(kx * kx + ky * ky + kz * kz);
+        });
+
+    auto potential = [&](pfc::data::Field<std::complex<double>> &h_hat,
+                         pfc::data::Field<double> &hh,
+                         pfc::data::Field<std::complex<double>> &out) {
+      hh.with_host_view([&](double *hv, std::size_t cnt) {
+        pi_real.with_host_view([&](double *pv, std::size_t) {
+          for (std::size_t i = 0; i < cnt; ++i) pv[i] = pw.Pi(hv[i]);
+        });
+      });
+      pfc::sim::SpectralETDOps<pfc::HostSpace>::forward(stack.fft(), pi_real,
+                                                        pi_hat);
+      h_hat.with_host_view([&](std::complex<double> *hv, std::size_t m) {
+        pi_hat.with_host_view([&](std::complex<double> *pv, std::size_t) {
+          out.with_host_view([&](std::complex<double> *o, std::size_t) {
+            for (std::size_t i = 0; i < m; ++i)
+              o[i] = -gamma * k_lap[i] * hv[i] - pv[i];
+          });
+        });
+      });
+    };
+
+    // Diagnostics CSV, rank 0, never overwriting.
+    std::unique_ptr<std::FILE, int (*)(std::FILE *)> out(nullptr, std::fclose);
+    if (rank == 0 && cfg.contains("diagnostics")) {
+      const std::filesystem::path path =
+          cfg.at("diagnostics").at("csv").get<std::string>();
+      if (path.has_parent_path())
+        std::filesystem::create_directories(path.parent_path());
+      out.reset(std::fopen(path.string().c_str(), "w"));
+      if (!out) throw std::runtime_error("cannot open diagnostics csv");
+      std::fprintf(out.get(),
+                   "step,time,min_h,max_h,mean_h,volume,hole_area_fraction,"
+                   "dominant_spacing,ruptured\n");
+    }
+
+    double rupture_time = -1.0;
+    const int n_steps = int(std::llround(t1 / dt));
+    const int every =
+        (saveat > 0.0) ? std::max(1, int(std::llround(saveat / dt))) : n_steps;
+
+    auto report = [&](int step, double t) {
+      auto s = thin_film::sample_film(h, domain, p.h0, 0.05, MPI_COMM_WORLD);
+      pfc::data::Field<std::complex<double>> hh(
+          domain, stack.fft().get_outbox_bounds(), 0);
+      pfc::sim::SpectralETDOps<pfc::HostSpace>::forward(stack.fft(), h, hh);
+      hh.with_host_view([&](std::complex<double> *hv, std::size_t) {
+        const auto sf = pfc::apps::shell_average(stack.fft().get_outbox_bounds(),
+                                                 domain, hv, MPI_COMM_WORLD, 64);
+        s.dominant_spacing = sf.dominant_wavelength();
+      });
+      if (s.ruptured && rupture_time < 0.0) rupture_time = t;
+      if (out) {
+        std::ostringstream line;
+        line.imbue(std::locale::classic());
+        line << std::setprecision(17) << step << ',' << t << ',' << s.min_h << ','
+             << s.max_h << ',' << s.mean_h << ',' << s.volume << ','
+             << s.hole_area_fraction << ',' << s.dominant_spacing << ','
+             << (s.ruptured ? 1 : 0) << '\n';
+        std::fputs(line.str().c_str(), out.get());
+        std::fflush(out.get());
+      }
+    };
+
+    report(0, 0.0);
+    double t = 0.0;
+    for (int step = 1; step <= n_steps; ++step) {
+      t = stepper.step(t, h, potential, mobility);
+      if (step % every == 0 || step == n_steps) report(step, t);
+    }
+
+    if (rank == 0) {
+      auto s = thin_film::sample_film(h, domain, p.h0, 0.05, MPI_COMM_WORLD);
+      std::printf("THIN_FILM_NONLINEAR min_h=%.17g volume=%.17g "
+                  "hole_fraction=%.17g rupture_time=%.17g\n",
+                  s.min_h, s.volume, s.hole_area_fraction, rupture_time);
+    } else {
+      (void)thin_film::sample_film(h, domain, p.h0, 0.05, MPI_COMM_WORLD);
+    }
+  } catch (const std::exception &e) {
+    if (rank == 0) std::cerr << "thin_film_nonlinear: " << e.what() << "\n";
+    status = 2;
+  }
+  MPI_Finalize();
+  return status;
+}

--- a/apps/thin_film/tests/test_thin_film.cpp
+++ b/apps/thin_film/tests/test_thin_film.cpp
@@ -26,6 +26,9 @@
 #include <openpfc/kernel/simulation/stacks/spectral_cpu_stack.hpp>
 #include <openpfc/kernel/simulation/time.hpp>
 #include <thin_film/cosine_mode.hpp>
+#include <openpfc_apps/spectral_flux.hpp>
+#include <openpfc_apps/structure_factor.hpp>
+#include <thin_film/nonlinear.hpp>
 #include <thin_film/thin_film_physics.hpp>
 #include <thin_film/thin_film_session.hpp>
 
@@ -232,4 +235,143 @@ int main(int argc, char *argv[]) {
   const int result = Catch::Session().run(argc, argv);
   MPI_Finalize();
   return result;
+}
+
+// ---------------------------------------------------------------------------
+// Nonlinear lubrication (#114)
+// ---------------------------------------------------------------------------
+
+TEST_CASE("Cubic mobility reduces to M0 at the reference thickness",
+          "[thin_film][nonlinear]") {
+  const thin_film::CubicMobility m{2.5, 1.3};
+  REQUIRE_THAT(m(1.3), WithinRel(2.5, 1e-14));
+  REQUIRE_THAT(m(2.6), WithinRel(2.5 * 8.0, 1e-14)); // (2h0)^3 = 8 M0
+  REQUIRE_THAT(m(0.65), WithinRel(2.5 / 8.0, 1e-14));
+  // A ruptured cell must still give a finite, non-negative mobility.
+  REQUIRE(m(0.0) > 0.0);
+  REQUIRE(m(-1.0) > 0.0);
+}
+
+TEST_CASE("Flux stepper reproduces the analytical k^4 decay",
+          "[thin_film][nonlinear][flux]") {
+  if (world_size() != 1) {
+    SKIP("single-rank analytical comparison");
+  }
+  // The whole point of keeping the linear verifier: with a constant mobility
+  // and a small perturbation the nonlinear flux solver must reproduce
+  // exp(-M0 gamma k^4 t) exactly, or the flux path is wrong.
+  constexpr int N = 32;
+  constexpr int nx = 2;
+  constexpr double h0 = 1.0, gamma = 1.0, M0 = 1.0;
+  constexpr double amp = 1.0e-6, dt = 0.01;
+  constexpr int steps = 20;
+
+  const auto domain = pfc::domain::create(pfc::GridSize({N, N, 1}),
+                                          pfc::PhysicalOrigin({0.0, 0.0, 0.0}),
+                                          pfc::GridSpacing({1.0, 1.0, 1.0}));
+  pfc::sim::stacks::SpectralCPUStack stack(domain, 0, 1, MPI_COMM_WORLD);
+  auto &h = stack.u();
+  const double twopi = 2.0 * std::numbers::pi;
+  const double L = static_cast<double>(N);
+  h.apply([&](double x, double, double) {
+    return h0 + amp * std::cos(twopi * nx * x / L);
+  });
+
+  std::vector<double> k_lap(stack.fft().size_outbox(), 0.0);
+  pfc::fft::kspace::for_each_kpoint(
+      stack.fft().get_outbox_bounds(), domain,
+      [&](std::size_t i, double kx, double ky, double kz, int, int, int) {
+        k_lap[i] = -(kx * kx + ky * ky + kz * kz);
+      });
+
+  // A = 0, so Pi == 0 and p = -gamma lap h. Constant mobility M0.
+  pfc::apps::FluxETD stepper(domain, stack.fft(), dt, [=](double kl) {
+    return -M0 * gamma * kl * kl;
+  });
+  auto potential = [&](pfc::data::Field<std::complex<double>> &h_hat,
+                       pfc::data::Field<double> &, 
+                       pfc::data::Field<std::complex<double>> &out) {
+    h_hat.with_host_view([&](std::complex<double> *hv, std::size_t m) {
+      out.with_host_view([&](std::complex<double> *o, std::size_t) {
+        for (std::size_t i = 0; i < m; ++i) o[i] = -gamma * k_lap[i] * hv[i];
+      });
+    });
+  };
+  auto constant_mobility = [=](double) { return M0; };
+
+  double t = 0.0;
+  for (int s = 0; s < steps; ++s)
+    t = stepper.step(t, h, potential, constant_mobility);
+
+  const double k = twopi * nx / L;
+  const double expected = amp * std::exp(-M0 * gamma * k * k * k * k * t);
+  // Project onto the mode.
+  double num = 0.0, den = 0.0;
+  const auto n = h.local_size();
+  for (int j = 0; j < n[1]; ++j)
+    for (int i = 0; i < n[0]; ++i) {
+      const auto x = h.coords(i, j, 0);
+      const double w = std::cos(twopi * nx * x[0] / L);
+      num += (h(i, j, 0) - h0) * w;
+      den += w * w;
+    }
+  REQUIRE_THAT(num / den, WithinRel(expected, 1e-8));
+}
+
+TEST_CASE("Cubic mobility conserves liquid volume", "[thin_film][nonlinear]") {
+  if (world_size() != 1) {
+    SKIP("single-rank conservation check");
+  }
+  constexpr int N = 32;
+  constexpr double h0 = 1.0, dt = 0.005;
+  const auto domain = pfc::domain::create(pfc::GridSize({N, N, 1}),
+                                          pfc::PhysicalOrigin({0.0, 0.0, 0.0}),
+                                          pfc::GridSpacing({1.0, 1.0, 1.0}));
+  pfc::sim::stacks::SpectralCPUStack stack(domain, 0, 1, MPI_COMM_WORLD);
+  auto &h = stack.u();
+  const double twopi = 2.0 * std::numbers::pi;
+  h.apply([&](double x, double y, double) {
+    return h0 * (1.0 + 0.2 * std::cos(twopi * 2 * x / N) *
+                           std::cos(twopi * 2 * y / N));
+  });
+
+  std::vector<double> k_lap(stack.fft().size_outbox(), 0.0);
+  pfc::fft::kspace::for_each_kpoint(
+      stack.fft().get_outbox_bounds(), domain,
+      [&](std::size_t i, double kx, double ky, double kz, int, int, int) {
+        k_lap[i] = -(kx * kx + ky * ky + kz * kz);
+      });
+
+  pfc::apps::FluxETD stepper(domain, stack.fft(), dt,
+                             [=](double kl) { return -kl * kl; });
+  auto potential = [&](pfc::data::Field<std::complex<double>> &h_hat,
+                       pfc::data::Field<double> &,
+                       pfc::data::Field<std::complex<double>> &out) {
+    h_hat.with_host_view([&](std::complex<double> *hv, std::size_t m) {
+      out.with_host_view([&](std::complex<double> *o, std::size_t) {
+        for (std::size_t i = 0; i < m; ++i) o[i] = -k_lap[i] * hv[i];
+      });
+    });
+  };
+  const thin_film::CubicMobility mobility{1.0, h0};
+
+  const auto v0 = thin_film::sample_film(h, domain, h0, 0.05, MPI_COMM_WORLD);
+  double t = 0.0;
+  for (int s = 0; s < 40; ++s) t = stepper.step(t, h, potential, mobility);
+  const auto v1 = thin_film::sample_film(h, domain, h0, 0.05, MPI_COMM_WORLD);
+
+  // A divergence form conserves the integral to round-off, whatever M does.
+  REQUIRE_THAT(v1.volume, WithinRel(v0.volume, 1e-11));
+  REQUIRE(v1.max_h != v0.max_h); // and the profile did evolve
+}
+
+TEST_CASE("Gaussian defect is a localized depression", "[thin_film][nonlinear]") {
+  const auto domain = pfc::domain::create(pfc::GridSize({64, 64, 1}),
+                                          pfc::PhysicalOrigin({0.0, 0.0, 0.0}),
+                                          pfc::GridSpacing({1.0, 1.0, 1.0}));
+  const auto d = thin_film::GaussianDefect::centred(domain, 0.2, 4.0);
+  REQUIRE_THAT(d(32.0, 32.0), WithinRel(-0.2, 1e-12)); // deepest at the centre
+  REQUIRE(std::abs(d(0.0, 0.0)) < 1e-6);               // and local
+  const thin_film::GaussianDefect none{};
+  REQUIRE(none(1.0, 2.0) == 0.0);
 }


### PR DESCRIPTION
Refs #114. Second of the science-upgrade wave (#120). **Based on #121** — review that first.

## The architectural piece

`SpectralETDSystem` splits the RHS into a pointwise remainder times a symbol. A
mobility that depends on the field *inside* a divergence cannot be written that
way, and freezing it at `M(h0)` is precisely the linearisation this issue exists
to escape. So `apps/common` now provides `SpectralFlux` and `FluxETD`:

```
dh/dt = div( M(h) grad p )     M(h) = M0 (h/h0)^3
```

evaluated spectrally with Orszag 2/3 dealiasing, four extra transforms per step
in 2-D. **#116 already reuses it** (PR #122), which is the two-consumer bar the
roadmap sets for promotion. The structure factor moved to `apps/common` for the
same reason.

**The reduction to the verifier is tested, not assumed:** with constant mobility
and a small perturbation the nonlinear solver reproduces the exact `k^4` decay
to `1e-8`.

## Measured results

512², `dx = 0.5`, 16 ranks. "Reaches precursor" = first time `min h < h* = 0.15`.

| Case | Reaches precursor | Final `min h` | Hole area | Spacing | Volume drift |
|---|---|---|---|---|---|
| Spontaneous | **t = 140** | 0.135 | 1.82 % | 14.2 | 1.3e-15 |
| Defect-triggered | **t = 85** | 0.145 | 0.33 % | 25.6 | 3.3e-16 |

Linear theory predicts `λ_max = 16.2`; measured 14.2 for the spontaneous case.

**The engineering result is the comparison:** one 30 % deep depression brings
failure forward by ~40 % and relocates it to the defect — the 25.6 "spacing" in
that row is one isolated hole, not a pattern.

## Two things the physics forced

**The bulk disjoining pressure cannot survive hole formation.** A `(9,3)` power
pair calibrated to a given `Pi'(h0)` reaches `Pi ~ 1e6` by `h = 0.05 h0`; one
cell dipping there NaNs on the next step *whatever the timestep*. The precursor
branch uses `(3,2)`, ~4000× softer at the same `Pi'(h0)`.

**The solver cannot integrate *through* rupture, and I could not fix that.**
Once `min h` falls to about `0.6 h*` it diverges, and **neither a 5× smaller
timestep nor a 2× finer grid moves the breakdown point.** That rules out
accuracy and points at structure: degenerate mobility (`M -> 0` as `h -> 0`, so
the equation loses parabolicity exactly where the interesting event is) plus no
positivity preservation. Getting through rupture into droplet coarsening needs a
positivity-preserving or entropy-dissipating scheme, which spectral ETD1 is not.

I spent a while assuming this was a timestep problem before the dt-independence
made it clear it wasn't. The presets now stop while the solution is
trustworthy, and the README says all of this.

## Acceptance criteria (#114)

- [x] Nonlinear `h^3` mobility, implemented honestly as a flux rather than disguised as a pointwise remainder
- [x] Constant-`M0` linear slice retained as an analytical verifier
- [x] Documented disjoining-pressure / wetting-potential model
- [x] Case A: stable coating levelling (existing verifier)
- [x] Case B: spinodal dewetting — unstable band, measured spacing, volume conservation, hole formation
- [x] Case C: defect-triggered dewetting compared against homogeneous noise
- [x] Domain ≥ 8 λ_max per side (16 λ_max here)
- [ ] **Droplet/hole number density and late-stage rim evolution** — blocked by the rupture limitation above, not skipped
- [ ] **Free-energy evolution** — not added
- [x] README `Problem setup` table with maturity as three separate axes

## Tests

**59/59 on LUMI.** New: cubic mobility reduces to `M0` at `h0` and stays
positive for a ruptured cell; the flux stepper reproduces analytical `k^4`
decay; volume conserved under nonlinear mobility; the defect is localized.

## Scope

Host (CPU) only — the flux path needs a complex `ik_d` multiply and the device
`Ops` layer exposes only real coefficients. The existing constant-mobility HIP
twin is untouched.

Merge by **rebase**, not squash.



---

*(Reopened as a new PR: the original #123 was auto-closed when its base branch `feat/113-fe-cr-science` was deleted on merge. Same branch, same content, now based on `master`.)*
