### PR TITLE
feat(thin_film): conservative finite-difference solver that integrates through rupture

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,7 @@ results
 *.sbatch
 !docs/lumi_slurm/*.sbatch
 !apps/kobayashi/slurm/*.sbatch
+!apps/thin_film/slurm/*.sbatch
 !scripts/*.sbatch
 apps/kobayashi/slurm/builds/
 .trash

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,27 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 
 ### Added
 
+- `thin_film_fd` (`#124`): a conservative face-flux finite-difference solver
+  for the same `h^3` lubrication equation as `thin_film_nonlinear`, distributed
+  via `pfc::decomposition` + `pfc::comm::SparseExchange` (the `apps/allen_cahn`
+  pattern). Forming the flux at cell faces makes mass conservation exact to
+  round-off for any timestep (telescoping, not a `k=0`-mode argument) and,
+  with a harmonic-mean face mobility, keeps the film positive through
+  rupture where the spectral solver structurally cannot: on the 512²,
+  `dx=0.5` science case, the spontaneous run reaches a stable precursor
+  plateau (`min h ~ 0.151`-`0.152`, never crossing `h*=0.15`) with 19.6 % hole
+  area and its hole count falling from 227 to 204 between `t=345` and
+  `t=400` (coalescence), volume conserved to `1.3e-15` relative. The
+  arithmetic-mean face average was measured too, as a negative control: it
+  overflows within 5 time units of approaching `h*`. A controlled
+  single-Fourier-mode comparison against the spectral solver agrees to 2 %
+  in `min h` and `1e-6` relative in volume; the broadband-noise flagship
+  comparison shows a real, explained timing offset (near-Nyquist noise damps
+  ~6x slower in the 2nd-order FD operator than in the spectral scheme's
+  exact/dealiased treatment). Stable timestep measured directly:
+  `dt=0.001` at this resolution; `dt>=0.003` overflows. Curvature-operator
+  order 2 vs 4 compared directly (~1 % difference, not resolution-starved).
+  See `apps/thin_film/README.md`, "Two methods, one problem".
 - EasyBuild recipes for a LUMI-C module install (`#46`): a CPU HeFFTe 2.4.1
   (FFTW backend, `cpeGNU/25.09`) and OpenPFC 0.2.0 on top of it, under
   `easybuild/easyconfigs/`. Verified end to end on LUMI: both install, and

--- a/apps/thin_film/CMakeLists.txt
+++ b/apps/thin_film/CMakeLists.txt
@@ -42,6 +42,13 @@ install(TARGETS thin_film DESTINATION bin)
 thin_film_cpu_executable(thin_film_nonlinear src/thin_film_nonlinear.cpp)
 install(TARGETS thin_film_nonlinear DESTINATION bin)
 
+# Two-method flagship (#124): the same h^3 lubrication equation, integrated by
+# a conservative face-flux FD scheme (MPI Cartesian decomposition + halo
+# exchange) instead of spectral ETD, so it can be pushed through rupture
+# where thin_film_nonlinear structurally cannot. Same JSON case files.
+thin_film_cpu_executable(thin_film_fd src/thin_film_fd.cpp)
+install(TARGETS thin_film_fd DESTINATION bin)
+
 if(OpenPFC_ENABLE_HIP AND OpenPFC_HIP_AVAILABLE AND OpenPFC_ENABLE_HIP_SPECTRAL)
   thin_film_hip_executable(thin_film_hip src/hip/thin_film.cpp)
   install(TARGETS thin_film_hip DESTINATION bin)

--- a/apps/thin_film/README.md
+++ b/apps/thin_film/README.md
@@ -8,8 +8,11 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 Lubrication **dewetting / coating** of a periodic liquid film, integrated
 with spectral ETD. This is the 0.2 application for GitHub issue `#78`.
 
-Binaries: `thin_film` (CPU); `thin_film_hip` when `OpenPFC_ENABLE_HIP_SPECTRAL`
-is on.
+Binaries: `thin_film` (CPU, linear verifier); `thin_film_nonlinear` (CPU, full
+`h^3` lubrication, spectral ETD); `thin_film_fd` (CPU, the same `h^3`
+lubrication, conservative face-flux FD -- integrates *through* rupture where
+the two spectral solvers cannot, see "Two methods, one problem" below);
+`thin_film_hip` when `OpenPFC_ENABLE_HIP_SPECTRAL` is on.
 
 ## Dewetting and rupture: problem setup
 
@@ -101,8 +104,173 @@ structural limitation rather than an accuracy one:
 
 Integrating through rupture and into late-stage droplet coarsening needs a
 positivity-preserving or entropy-dissipating scheme, which a spectral ETD1
-method is not. The shipped presets therefore stop while the solution is still
-trustworthy, and hole *formation* is reported rather than droplet statistics.
+method is not. The shipped spectral presets therefore stop while the solution
+is still trustworthy, and hole *formation* is reported rather than droplet
+statistics -- **that scheme** is `thin_film_nonlinear`. A different scheme,
+`thin_film_fd`, does not stop here; see the next section.
+
+## Two methods, one problem (`#124`)
+
+The insight this application is built to demonstrate: **the same degenerate
+mobility that breaks the spectral scheme is what makes a conservative
+finite-volume scheme well behaved.** `M(h) -> 0` as `h -> 0` is fatal for a
+pointwise/spectral treatment (the equation loses parabolicity exactly where
+the interesting event happens) but is exactly the property a face-centred
+flux needs: if the mobility at a face is formed from the mobilities of the
+two cells it separates, the flux out of a vanishing cell vanishes with it,
+and the cell cannot be driven negative. Two solvers, same equation:
+
+| | `thin_film_nonlinear` (spectral ETD1) | `thin_film_fd` (conservative FD) |
+|---|---|---|
+| Flux | pointwise `M(h) grad p` in real space, transformed as a whole | formed *at cell faces*, `M_face (p_R - p_L)/dx` |
+| Mass conservation | exact in the continuum (`k=0` mode untouched); not face-by-face | **exact to round-off, for any `dt`**, by telescoping (Test: `FD flux divergence sums to zero...`) |
+| Positivity | none -- a cell can be driven to `h <= 0` | preserved in practice with a harmonic-mean face mobility (measured below) |
+| Good for | the smooth pre-rupture regime: rupture *time*, dominant wavelength, defect-vs-spontaneous comparison, at spectral accuracy and one FFT-pencil decomposition | rupture *through* to hole formation and rim/droplet coarsening; anywhere the film gets thin |
+| Stops at | `min h ~ 0.6 h*` (diverges) | does not stop; pins at the precursor and keeps integrating |
+| Parallelism | HeFFTe pencil decomposition | `pfc::decomposition` Cartesian grid + `pfc::comm::SparseExchange` halo exchange (same pattern as `apps/allen_cahn`) |
+
+### Problem setup: the FD case
+
+Same equation, same domain, same initial-condition family as the spectral
+science case above -- the *only* things that change are the discretization
+and (necessarily) the timestep and run length, since this solver is the one
+that does not have to stop at `min h ~ 0.6 h*`.
+
+| Item | Description |
+|---|---|
+| **Use case** | Same dewetting film as above, continued *through* rupture: hole formation, rim growth, and coarsening -- the regime `thin_film_nonlinear` cannot reach |
+| **Domain** | 2-D periodic, 512² cells at `dx = 0.5`, identical to the spectral case |
+| **Boundary conditions** | Periodic on both axes, via `pfc::comm::SparseExchange` (separated halo layout, `apps/allen_cahn`-style) |
+| **Initial condition** | Same hashed-noise / Gaussian-defect family as `thin_film_nonlinear`, byte-identical when the same seed is used (verified: t=0 `min_h`/`max_h`/volume match to 15 significant digits between the two binaries) |
+| **Key parameters** | Same physical parameters, plus `"fd": {"face_mobility": "harmonic"\|"arithmetic", "order": 2\|4}` |
+| **Observable** | Everything `thin_film_nonlinear` reports, plus a connected-component hole count (`n_holes`, rank-0 gather + flood fill) |
+| **Model maturity** | numerical verification: **analytical** (reproduces the exact `k^4` capillary decay and the linearized unstable growth rate `M0 k^2(Pi'(h0) - gamma k^2)`, both to 5 %) · physical completeness: same reduced lubrication model as the spectral case · calibration: nondimensional, same as the spectral case; face-mobility choice verified empirically (below), not assumed |
+
+### Face mobility: harmonic beats arithmetic, measured
+
+Two symmetric averages of the two cells' mobilities at a face are provided.
+Driving the same precursor case (`A = 8.6022`, `h* = 0.15`, a deep localized
+defect) with each, on identical grids:
+
+| Face average | Behaviour |
+|---|---|
+| **Harmonic**, `2 M_L M_R / (M_L + M_R)` | `min h` settles at `0.151`-`0.157`, just above `h*`, and **stays there** for as long as the run continues (checked to `t = 500`, `5*10^5` steps) |
+| **Arithmetic**, `(M_L + M_R)/2` | identical up to `min h ~ 0.33`, then overflows to `inf`/`NaN` within about 5 time units, right as the thinnest cell approaches `h*` |
+
+The mechanism is exactly what the harmonic mean is for: it is zero whenever
+*either* side of a face is dry, so the flux out of a thinning cell shuts off
+as that cell empties. The arithmetic mean only halves the flux in the same
+situation -- not enough to stop a cell from being pulled through zero once
+the destabilizing `Pi'(h)` term is strong enough, which is exactly the
+regime a rupture study needs. `thin_film_fd` defaults to harmonic;
+`"face_mobility": "arithmetic"` is kept only to reproduce this comparison
+(`FD face mobility: harmonic mean...` test).
+
+### Stable timestep
+
+The curvature operator inside `p` is a discrete Laplacian, so it inherits a
+`dt <~ dx^4` explicit stability limit -- a real cost, not a rounding
+footnote. Measured on the 512² / `dx = 0.5` case (order-2 curvature
+operator, harmonic face mobility): **`dt = 0.001` runs the whole way through
+rupture with no sign of instability; `dt = 0.002`-`0.0025` already show
+spurious excess thinning inside 5 time units that is not present at smaller
+`dt` (a numerical, not physical, effect); `dt >= 0.003` overflows within a
+few hundred steps.** `thin_film_fd`'s shipped cases use `dt = 0.001`.
+
+### Curvature-operator order: 2 vs 4
+
+`"fd": {"order": 4}` swaps the 5-point curvature Laplacian for the 9-point
+one (`pfc::field::fd::laplacian2d_xy_periodic_separated<4>`); the face flux
+itself is unchanged (still the natural 2-point difference -- that is what
+"flux at a face" means). On the 64² / `dx = 0.5` probe case, same `dt`
+(`5*10^-4`, stable for both), same 250 time units: order 2 gives
+`min h = 0.7171`, order 4 gives `min h = 0.7248`, about a 1 % difference at
+this resolution -- consistent with the 4th-order operator's smaller
+truncation error, not a change in the physics. The shipped cases use order 2
+because it is cheaper and the accuracy difference at this `dx` is minor;
+order 4 is there for anyone who wants to check that the answer is not
+resolution-dependent in the curvature operator specifically.
+
+### Measured agreement: the smooth pre-rupture regime
+
+**Controlled, single-mode comparison** (the rigorous check: a deterministic
+cosine perturbation near `k_peak`, not noise, both solvers built from the
+same physics module, `FD and spectral agree in the smooth pre-rupture
+regime` test): after 100 steps of exponential growth from the same initial
+condition, `thin_film_fd`'s `min h` agrees with the spectral run's to 2 %,
+and volume agrees to `1e-6` relative -- both still far from the precursor.
+This is the comparison that isolates discretization error from everything
+else, and it is where "the two methods agree" is unambiguously true.
+
+**The actual 512², broadband-noise flagship case** is a different, harder
+comparison, and it is reported here honestly rather than only where it is
+flattering. The two binaries start from a *bit-identical* initial condition
+(`thin_film_dewetting.json` and `thin_film_fd_dewetting.json` differ only in
+`t1`/`dt`/the `"fd"` block; `t = 0` `min_h`/`max_h`/volume match to 15
+significant digits). They do **not** track each other closely afterwards:
+
+| | Spectral (`thin_film_nonlinear`) | FD (`thin_film_fd`) |
+|---|---|---|
+| Crosses/approaches `h*` at | `t = 140` (crosses, keeps falling) | `t ~ 340`-`400` (approaches asymptotically, does not cross) |
+| `min h` at `t = 100` | `0.705` | `0.990` |
+
+That is a real, reproducible timing offset, not noise -- rerunning either
+side changes nothing (deterministic hashed noise). The likely mechanism:
+spectral ETD treats every wavenumber exactly and applies Orszag 2/3
+dealiasing, which removes the top third of wavenumbers outright; the FD
+scheme's 2nd-order discrete Laplacian damps near-Nyquist content at a
+*finite* rate that is only `(2 - 2cos(k dx))/(dx^2 k^2)` of the continuum
+value -- at this `dx = 0.5`, that ratio is `0.41` at the Nyquist wavenumber,
+so the biharmonic damping of single-cell noise is about `6x` weaker than the
+continuum/spectral value. The broadband hashed-noise initial condition is
+dominated by exactly that near-Nyquist content (it is spatially white), so
+the two schemes clear the noise floor at genuinely different rates before
+the coherent dewetting pattern takes over -- a real, explainable structural
+difference in how each method treats initial noise, not a bug in either
+one. The single-mode comparison above is the one to trust for "do the two
+methods agree"; the broadband comparison is the one to trust for "how long
+until this specific noisy run rewards patience."
+
+### Measured results: through rupture and into coarsening
+
+512², `dx = 0.5`, `dt = 0.001`, harmonic face mobility, order-2 curvature,
+single rank (see "Run distributed" below for the MPI check). "Reaches
+precursor" here means "approaches to within 1 % of `h* = 0.15` and stays
+there" -- the FD solver does not cross below `h*`, it is *pinned* there, in
+contrast to the spectral runs above, which cross it and then diverge.
+
+| Case | Approaches precursor | Min `h` reached | Hole area fraction (final) | `n_holes` peak -> final | Volume drift |
+|---|---|---|---|---|---|
+| Spontaneous (`t1=400`) | `t ~ 340` | 0.1515 | 19.6 % | 227 (`t=345`) -> 204 (`t=400`) | `4.3e-11` abs (`1.3e-15` rel) |
+| Defect-triggered (`t1=300`) | not yet reached (`min h = 0.164` at `t=300`) | 0.164 | 1.3 % | 1 -> 1 | `1.5e-10` abs (`4.6e-15` rel) |
+
+The spontaneous case is the headline result: **it forms holes, keeps them
+positive, conserves volume to round-off, and its hole count falls from 227
+to 204 between `t=345` and `t=400`** -- coalescence, i.e. coarsening, is
+directly observed, not just hole *formation*. The rim collects the drained
+liquid (`max h` rises past `1.4`, up from `1.01` at `t=0`). The
+defect-triggered case is slower to reach the precursor here than in the
+spectral run (which reached it by `t=85`) for the same reason the broadband
+comparison above diverges in timing; it has a single, isolated hole
+throughout, matching the spectral run's qualitative finding that a defect
+produces one hole rather than a pattern.
+
+Both cases were run as a single `sbatch` job on `standard-g`
+(`apps/thin_film/slurm/fd_flagship.sbatch`, 16 MPI ranks, one node,
+CPU-only); the spectral comparisons above were run interactively (16 ranks,
+shared allocation) since they are the same, previously-characterized
+512²/`dt=0.002` cases the existing presets already ship.
+
+### Run distributed: MPI correctness check
+
+`thin_film_fd` decomposes the domain with `pfc::decomposition::create` and
+exchanges halos with `pfc::comm::SparseExchange`, the same building blocks
+as `apps/allen_cahn`. Checked directly: the same case
+(`thin_film_dewetting.json`-style, 5 time units) run at 1 rank and 4 ranks
+gives **bit-identical `min h` and `max h`** at every save point; `volume`
+and `mean h` differ only at the `1e-13` relative level expected from a
+different `MPI_Allreduce` summation order. The physics does not depend on
+the decomposition; only floating-point summation order does.
 
 ## Physics
 
@@ -158,13 +326,37 @@ Dewetting: 128², \(A=0.05\), cosine near \(k_{\mathrm{peak}}\). Leveling:
 JSON `model.params`: `h0`, `gamma`, `M0`, `A`. Initial condition
 `"type": "cosine_mode"` with `h0` / `amplitude` / `nx` / `ny` / `nz`.
 
+The `h^3` lubrication science cases (`#114`, `#124`) take a different JSON
+shape (`domain.Lx`/`Ly`/`Lz`/`dx`, `model.params` adds `h_star`,
+`timestepping.t1`/`dt`/`saveat`, `initial_conditions.amplitude`/`seed`/
+`defect_amplitude`/`defect_sigma`, `diagnostics.csv`) and the same case file
+drives *either* binary:
+
+```bash
+mpirun -n 16 ./apps/thin_film/thin_film_nonlinear \
+  ../apps/thin_film/inputs_json/thin_film_dewetting.json   # spectral, stops before rupture
+mpirun -n 16 ./apps/thin_film/thin_film_fd \
+  ../apps/thin_film/inputs_json/thin_film_fd_dewetting.json  # FD, continues through it
+```
+
+`thin_film_fd`'s cases add an optional `"fd": {"face_mobility":
+"harmonic"|"arithmetic", "order": 2|4}` block (defaults: harmonic, 2). See
+"Two methods, one problem" above for what those knobs do and the measured
+comparison. `apps/thin_film/slurm/fd_flagship.sbatch` reproduces the
+512²-through-rupture runs on LUMI's `standard-g`.
+
 ## Tests
 
 `ctest -R thin-film` checks \(\Pi'(h_0)\), the \(L(k)\) formula, volume
 conservation, an unstable mode vs \(\exp(\lambda t)\), a stable high-\(k\)
-mode decaying, and \(A=0\) leveling. HIP builds add `HIP_ThinFilmETD` and
-`thin-film-hip-smoke`. LUMI-G smoke: job 21781449 (`small-g`, 16², mean
-\(h=1\)).
+mode decaying, and \(A=0\) leveling, plus the nonlinear/flux and FD suites
+(`[nonlinear]`, `[fd]` tags): cubic mobility, the flux stepper's exact
+\(k^4\) decay, a Gaussian defect, and for the FD solver -- exact mass
+conservation via `compute_rhs`, the linearized \(k^4\) decay and unstable
+growth rate, harmonic-vs-arithmetic positivity through a driven rupture, and
+FD-vs-spectral agreement on a controlled single-mode case. HIP builds add
+`HIP_ThinFilmETD` and `thin-film-hip-smoke`. LUMI-G smoke: job 21781449
+(`small-g`, 16², mean \(h=1\)).
 
 ## Layout
 
@@ -173,6 +365,13 @@ mode decaying, and \(A=0\) leveling. HIP builds add `HIP_ThinFilmETD` and
 | `include/thin_film/thin_film_physics.hpp` | `SpectralETDPhysics` + schema |
 | `include/thin_film/thin_film_pointwise.hpp` | Device-capable \(\Pi\) remainder |
 | `include/thin_film/thin_film_session.hpp` | JSON session, field `h`, 2/3 dealias |
-| `src/thin_film.cpp` / `src/hip/thin_film.cpp` | CPU / HIP `main` |
-| `inputs_json/dewetting.json` | Unstable coating |
-| `inputs_json/leveling.json` | \(A=0\) capillary smoothing |
+| `include/thin_film/nonlinear.hpp` | `CubicMobility`, `sample_film`, `GaussianDefect` (shared by both nonlinear solvers) |
+| `include/thin_film/fd_flux.hpp` | Conservative face-flux FD solver: `FDFluxSolver`, `FaceMobility`, `sample_film_fd`, `count_dry_regions_rank0` |
+| `src/thin_film.cpp` / `src/hip/thin_film.cpp` | CPU / HIP `main` (linear verifier) |
+| `src/thin_film_nonlinear.cpp` | CPU `main`, spectral `h^3` lubrication |
+| `src/thin_film_fd.cpp` | CPU `main`, conservative FD `h^3` lubrication |
+| `inputs_json/dewetting.json` | Unstable coating (linear verifier) |
+| `inputs_json/leveling.json` | \(A=0\) capillary smoothing (linear verifier) |
+| `inputs_json/thin_film_dewetting.json` / `thin_film_fd_dewetting.json` | Spontaneous dewetting, spectral / FD |
+| `inputs_json/thin_film_defect.json` / `thin_film_fd_defect.json` | Defect-triggered dewetting, spectral / FD |
+| `slurm/fd_flagship.sbatch` | Reproduces the 512² FD through-rupture runs on `standard-g` |

--- a/apps/thin_film/include/thin_film/fd_flux.hpp
+++ b/apps/thin_film/include/thin_film/fd_flux.hpp
@@ -1,0 +1,434 @@
+// SPDX-FileCopyrightText: 2026 VTT Technical Research Centre of Finland Ltd
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+#pragma once
+
+/**
+ * @file fd_flux.hpp
+ * @brief Conservative face-flux finite-difference stepper for the thin film
+ *        equation, distributed over MPI via a separated halo exchange.
+ *
+ * @details
+ * Solves the same equation as the spectral solver in `nonlinear.hpp`,
+ *
+ * \f[
+ *   \partial_t h = \nabla\cdot\bigl[M(h)\nabla p\bigr],\qquad
+ *   p = -\gamma\nabla^2 h - \Pi(h),\qquad
+ *   M(h) = M_0(h/h_0)^3,
+ * \f]
+ *
+ * but where the spectral solver forms `M(h) grad p` pointwise in real space
+ * and transforms the whole product (so the flux only exists implicitly, as
+ * whatever the FFT of a real-space product happens to be), this stepper
+ * forms the flux **at cell faces**:
+ *
+ * \f[
+ *   F_{i+1/2,j} = M_{i+1/2,j}\,\frac{p_{i+1,j}-p_{i,j}}{\Delta x},
+ *   \qquad
+ *   \frac{dh_{i,j}}{dt} = \frac{F_{i+1/2,j}-F_{i-1/2,j}}{\Delta x}
+ *                        + \frac{F_{i,j+1/2}-F_{i,j-1/2}}{\Delta y}.
+ * \f]
+ *
+ * Two structural properties fall out of this that the spectral scheme does
+ * not have:
+ *
+ * 1. **Exact mass conservation.** Every interior face flux is computed
+ *    identically by the two ranks (or two cells) that share it -- same two
+ *    `h`/`p` values, same symmetric averaging formula, hence the same
+ *    floating-point result -- so it cancels in the telescoping sum
+ *    `sum_cells dh/dt` to machine round-off, for *any* timestep. The
+ *    spectral scheme's flux only telescopes in the continuum; discretely it
+ *    conserves volume because a Fourier mode with `k=0` is untouched, not
+ *    because of face-by-face cancellation.
+ * 2. **Positivity under a degenerate mobility.** `M(h) -> 0` as `h -> 0`.
+ *    With the *harmonic* mean of the two neighbouring mobilities at a face,
+ *    `M_face = 2 M_L M_R / (M_L + M_R)`, the face mobility itself vanishes
+ *    whenever either neighbour is dry, so the flux out of (or into) a
+ *    vanishing cell vanishes with it: an empty cell cannot be driven
+ *    negative by drainage. The arithmetic mean `M_face = (M_L+M_R)/2` does
+ *    not have this property -- it only halves the flux, so a dry cell can
+ *    still be pulled below zero by a wet neighbour. Both are provided
+ *    (`FaceMobility::Harmonic`, `FaceMobility::Arithmetic`); see
+ *    `apps/thin_film/README.md` for the measured difference.
+ *
+ * The curvature term `-gamma*lap(h)` inside `p` is formed with the shared
+ * order-2 or order-4 central Laplacian
+ * (`pfc::field::fd::laplacian2d_xy_periodic_separated`); the face-flux
+ * difference itself is always the natural 2-point (second-order) form,
+ * since that is what "flux at a face" means for a finite-volume update --
+ * only the curvature operator's order is a free choice here.
+ *
+ * MPI parallelism reuses the same building blocks as `apps/allen_cahn`
+ * (`pfc::decomposition`, `pfc::comm::SparseExchange`,
+ * `pfc::halo::allocate_face_halos` / `copy_to_face_layout`): a "separated"
+ * halo layout where the owned cells are a plain, unpadded `nx*ny` buffer and
+ * the neighbour layers live in a side array, indexed exactly as
+ * `pfc::field::fd::laplacian2d_xy_periodic_separated` expects.
+ */
+
+#include <algorithm>
+#include <array>
+#include <cmath>
+#include <cstddef>
+#include <limits>
+#include <stdexcept>
+#include <vector>
+
+#include <mpi.h>
+
+#include <openpfc/kernel/data/domain.hpp>
+#include <openpfc/kernel/decomposition/comm_sparse_exchange.hpp>
+#include <openpfc/kernel/decomposition/decomposition.hpp>
+#include <openpfc/kernel/decomposition/halo_face_layout.hpp>
+#include <openpfc/kernel/field/finite_difference.hpp>
+
+#include <thin_film/nonlinear.hpp>
+#include <thin_film/thin_film_pointwise.hpp>
+
+namespace thin_film {
+
+/// How the two cell-centred mobilities either side of a face are combined.
+enum class FaceMobility { Arithmetic, Harmonic };
+
+/**
+ * @brief Combine the mobility on either side of a face into one face value.
+ *
+ * `Harmonic` is the positivity-preserving choice for a degenerate mobility:
+ * it is zero whenever either side is zero, regardless of the other side.
+ * `Arithmetic` only halves the flux in that situation, which is not enough
+ * to stop a dry cell from being pulled negative -- see the "Face mobility
+ * choice" measurement in the README.
+ */
+[[nodiscard]] inline double face_mobility(FaceMobility kind, double m_left,
+                                          double m_right) {
+  switch (kind) {
+  case FaceMobility::Harmonic: {
+    const double s = m_left + m_right;
+    return (s > 0.0) ? (2.0 * m_left * m_right / s) : 0.0;
+  }
+  case FaceMobility::Arithmetic:
+  default:
+    return 0.5 * (m_left + m_right);
+  }
+}
+
+namespace detail {
+
+/// Value at `(ix+1, iy)`, reading the owned buffer or the +X halo slab.
+[[nodiscard]] inline double at_xp(const double *core, const double *hpx, int ix,
+                                  int iy, int nx, int hw) {
+  return (ix + 1 < nx) ? core[(ix + 1) + iy * nx] : hpx[iy * hw + 0];
+}
+/// Value at `(ix-1, iy)`, reading the owned buffer or the -X halo slab.
+[[nodiscard]] inline double at_xm(const double *core, const double *hnx, int ix,
+                                  int iy, int nx, int hw) {
+  return (ix - 1 >= 0) ? core[(ix - 1) + iy * nx] : hnx[iy * hw + (hw - 1)];
+}
+/// Value at `(ix, iy+1)`, reading the owned buffer or the +Y halo slab.
+[[nodiscard]] inline double at_yp(const double *core, const double *hpy, int ix,
+                                  int iy, int nx, int ny, int /*hw*/) {
+  return (iy + 1 < ny) ? core[ix + (iy + 1) * nx] : hpy[ix];
+}
+/// Value at `(ix, iy-1)`, reading the owned buffer or the -Y halo slab.
+[[nodiscard]] inline double at_ym(const double *core, const double *hny, int ix,
+                                  int iy, int nx, int hw) {
+  return (iy - 1 >= 0) ? core[ix + (iy - 1) * nx] : hny[(hw - 1) * nx + ix];
+}
+
+/// Runtime dispatch over the two supported curvature-operator orders.
+inline void laplacian2d_dispatch(int order, const double *core,
+                                 const std::array<const double *, 6> &face_halos,
+                                 double *lap, int nx, int ny, double inv_dx2,
+                                 double inv_dy2, int hw) {
+  switch (order) {
+  case 2:
+    pfc::field::fd::laplacian2d_xy_periodic_separated<2>(
+        core, face_halos, lap, nx, ny, 1, inv_dx2, inv_dy2, hw);
+    return;
+  case 4:
+    pfc::field::fd::laplacian2d_xy_periodic_separated<4>(
+        core, face_halos, lap, nx, ny, 1, inv_dx2, inv_dy2, hw);
+    return;
+  default:
+    throw std::invalid_argument(
+        "FDFluxSolver: order must be 2 or 4 (curvature-operator order)");
+  }
+}
+
+} // namespace detail
+
+/**
+ * @brief Conservative face-flux thin-film stepper, one MPI rank's share.
+ *
+ * Owns the scratch buffers (`p`, `lap_h`, `dh/dt`) and the two halo
+ * exchangers (one for `h`, at the curvature operator's halo width; one for
+ * `p`, always width 1, since the face flux is always the natural 2-point
+ * difference). The caller owns the state vector `h` itself and passes the
+ * same buffer to every call -- `FDFluxSolver` binds its `h` exchanger to
+ * `h.data()` at construction, so `h` must not be resized afterwards.
+ */
+class FDFluxSolver {
+public:
+  /**
+   * @param domain Global grid geometry (2-D: `Lz` / grid size along z must
+   *               be 1).
+   * @param decomp Domain decomposition (`pfc::decomposition::create`).
+   * @param rank   This MPI rank.
+   * @param comm   Communicator matching @p decomp.
+   * @param h      Owned-cell state buffer, already sized to this rank's
+   *               local `nx*ny`; kept bound for the lifetime of the solver.
+   * @param order  Curvature-operator (`lap(h)`) order: 2 or 4.
+   */
+  FDFluxSolver(const pfc::Domain &domain,
+               const pfc::decomposition::Decomposition &decomp, int rank,
+               MPI_Comm comm, std::vector<double> &h, int order = 2)
+      : domain_(domain), decomp_(decomp), rank_(rank), order_(order),
+        hw_(order / 2),
+        nx_(pfc::decomposition::local_box(decomp_, rank_).size[0]),
+        ny_(pfc::decomposition::local_box(decomp_, rank_).size[1]),
+        dx_(pfc::domain::get_spacing(domain_)[0]),
+        dy_(pfc::domain::get_spacing(domain_)[1]),
+        p_(static_cast<std::size_t>(nx_) * static_cast<std::size_t>(ny_), 0.0),
+        lap_h_(static_cast<std::size_t>(nx_) * static_cast<std::size_t>(ny_), 0.0),
+        dhdt_(static_cast<std::size_t>(nx_) * static_cast<std::size_t>(ny_), 0.0),
+        // Analytic (not decomposition-validated) counts: this is a strictly
+        // 2-D solver (`nz == 1`), so the Z faces are never exchanged, and
+        // `pfc::halo::allocate_face_halos(decomp, rank, hw)` would otherwise
+        // reject `hw > 1` outright -- it sizes the Z slabs from the *global*
+        // Z extent, which is 1 here, regardless of the curvature operator's
+        // in-plane halo width.
+        h_halos_(pfc::halo::allocate_face_halos<double>(
+            pfc::halo::face_halo_counts_analytic(nx_, ny_, 1, hw_))),
+        p_halos_(pfc::halo::allocate_face_halos<double>(
+            pfc::halo::face_halo_counts_analytic(nx_, ny_, 1, 1))),
+        exch_h_(h.data(), h.size(), decomp_, rank_, comm, hw_,
+               {.dirs = pfc::halo::presets::Axes2D()}),
+        exch_p_(p_.data(), p_.size(), decomp_, rank_, comm, 1,
+               {.dirs = pfc::halo::presets::Axes2D()}) {
+    if (order_ != 2 && order_ != 4) {
+      throw std::invalid_argument("FDFluxSolver: order must be 2 or 4");
+    }
+    if (pfc::decomposition::local_box(decomp_, rank_).size[2] != 1) {
+      throw std::invalid_argument("FDFluxSolver: domain must be 2-D (Lz == 1)");
+    }
+    if (h.size() != p_.size()) {
+      throw std::invalid_argument(
+          "FDFluxSolver: h must be sized to this rank's local nx*ny");
+    }
+  }
+
+  [[nodiscard]] int nx() const noexcept { return nx_; }
+  [[nodiscard]] int ny() const noexcept { return ny_; }
+  [[nodiscard]] double dx() const noexcept { return dx_; }
+  [[nodiscard]] double dy() const noexcept { return dy_; }
+  [[nodiscard]] int order() const noexcept { return order_; }
+  [[nodiscard]] const pfc::decomposition::Decomposition &decomposition() const {
+    return decomp_;
+  }
+  /// Pressure field from the most recent `compute_rhs` / `step` call.
+  [[nodiscard]] const std::vector<double> &pressure() const { return p_; }
+
+  /**
+   * @brief Evaluate `dh/dt` for the current state, without advancing it.
+   *
+   * Exposed separately from `step()` so tests can assert exact mass
+   * conservation (`sum(dh/dt) == 0` to round-off, for any `h`, before any
+   * timestep even enters the picture) and so a caller could build a
+   * higher-order explicit integrator (RK2/RK3) on top.
+   */
+  /**
+   * @tparam Mobility Callable `double operator()(double h) const`. Usually
+   *         `thin_film::CubicMobility`, but any functor works -- a lambda
+   *         returning a constant is what lets the linear `k^4`-decay test
+   *         reproduce the analytical constant-mobility limit without going
+   *         through the nonlinear `h^3` law at all.
+   */
+  template <class Mobility>
+  void compute_rhs(std::vector<double> &h, double gamma, const ThinFilmPointwise &pw,
+                   const Mobility &mobility, FaceMobility kind,
+                   std::vector<double> &dhdt_out) {
+    // 1. h halo exchange, then the curvature operator lap(h) on the full
+    //    owned domain.
+    exch_h_.exchange();
+    pfc::halo::copy_to_face_layout(exch_h_.halos(), h_halos_);
+    std::array<const double *, 6> h_face_ptrs{
+        h_halos_[0].data(), h_halos_[1].data(), h_halos_[2].data(),
+        h_halos_[3].data(), h_halos_[4].data(), h_halos_[5].data()};
+    const double inv_dx2 = 1.0 / (dx_ * dx_);
+    const double inv_dy2 = 1.0 / (dy_ * dy_);
+    detail::laplacian2d_dispatch(order_, h.data(), h_face_ptrs, lap_h_.data(), nx_,
+                                 ny_, inv_dx2, inv_dy2, hw_);
+
+    // 2. p = -gamma*lap(h) - Pi(h), owned cells only -- Pi is pointwise.
+    for (std::size_t c = 0; c < p_.size(); ++c) {
+      p_[c] = -gamma * lap_h_[c] - pw.Pi(h[c]);
+    }
+
+    // 3. p halo exchange (width 1: the flux only ever needs the nearest
+    //    neighbour, whatever order the curvature operator used).
+    exch_p_.exchange();
+    pfc::halo::copy_to_face_layout(exch_p_.halos(), p_halos_);
+
+    // 4. Face fluxes and their divergence.
+    for (int iy = 0; iy < ny_; ++iy) {
+      for (int ix = 0; ix < nx_; ++ix) {
+        const std::size_t c =
+            static_cast<std::size_t>(ix) + static_cast<std::size_t>(iy) * nx_;
+        const double hc = h[c];
+        const double pc = p_[c];
+
+        const double h_xp = detail::at_xp(h.data(), h_halos_[0].data(), ix, iy,
+                                          nx_, hw_);
+        const double h_xm = detail::at_xm(h.data(), h_halos_[1].data(), ix, iy,
+                                          nx_, hw_);
+        const double h_yp = detail::at_yp(h.data(), h_halos_[2].data(), ix, iy,
+                                          nx_, ny_, hw_);
+        const double h_ym = detail::at_ym(h.data(), h_halos_[3].data(), ix, iy,
+                                          nx_, hw_);
+
+        const double p_xp = detail::at_xp(p_.data(), p_halos_[0].data(), ix, iy,
+                                          nx_, 1);
+        const double p_xm = detail::at_xm(p_.data(), p_halos_[1].data(), ix, iy,
+                                          nx_, 1);
+        const double p_yp = detail::at_yp(p_.data(), p_halos_[2].data(), ix, iy,
+                                          nx_, ny_, 1);
+        const double p_ym = detail::at_ym(p_.data(), p_halos_[3].data(), ix, iy,
+                                          nx_, 1);
+
+        const double Mc = mobility(hc);
+        const double Mxp = face_mobility(kind, Mc, mobility(h_xp));
+        const double Mxm = face_mobility(kind, mobility(h_xm), Mc);
+        const double Myp = face_mobility(kind, Mc, mobility(h_yp));
+        const double Mym = face_mobility(kind, mobility(h_ym), Mc);
+
+        const double Fxp = Mxp * (p_xp - pc) / dx_;
+        const double Fxm = Mxm * (pc - p_xm) / dx_;
+        const double Fyp = Myp * (p_yp - pc) / dy_;
+        const double Fym = Mym * (pc - p_ym) / dy_;
+
+        dhdt_out[c] = (Fxp - Fxm) / dx_ + (Fyp - Fym) / dy_;
+      }
+    }
+  }
+
+  /// One explicit-Euler step of size `dt`.
+  template <class Mobility>
+  void step(std::vector<double> &h, double dt, double gamma,
+            const ThinFilmPointwise &pw, const Mobility &mobility,
+            FaceMobility kind) {
+    compute_rhs(h, gamma, pw, mobility, kind, dhdt_);
+    for (std::size_t c = 0; c < h.size(); ++c) h[c] += dt * dhdt_[c];
+  }
+
+private:
+  pfc::Domain domain_;
+  pfc::decomposition::Decomposition decomp_;
+  int rank_;
+  int order_;
+  int hw_;
+  int nx_, ny_;
+  double dx_, dy_;
+  std::vector<double> p_, lap_h_, dhdt_;
+  std::array<std::vector<double>, 6> h_halos_, p_halos_;
+  pfc::comm::SparseExchange<pfc::HostSpace, double> exch_h_;
+  pfc::comm::SparseExchange<pfc::HostSpace, double> exch_p_;
+};
+
+/// Same observables as `thin_film::sample_film`, for a raw FD state vector.
+[[nodiscard]] inline FilmSample
+sample_film_fd(const std::vector<double> &h, const pfc::Domain &domain, double h0,
+               double rupture_frac, MPI_Comm comm) {
+  double lo = std::numeric_limits<double>::infinity(), hi = -lo;
+  double local_sum = 0.0, local_holes = 0.0, local_cells = 0.0;
+  for (double v : h) {
+    lo = std::min(lo, v);
+    hi = std::max(hi, v);
+    local_sum += v;
+    if (v < 0.5 * h0) local_holes += 1.0;
+    local_cells += 1.0;
+  }
+  double g_lo = 0, g_hi = 0, g[3]{}, l[3]{local_sum, local_holes, local_cells};
+  MPI_Allreduce(&lo, &g_lo, 1, MPI_DOUBLE, MPI_MIN, comm);
+  MPI_Allreduce(&hi, &g_hi, 1, MPI_DOUBLE, MPI_MAX, comm);
+  MPI_Allreduce(l, g, 3, MPI_DOUBLE, MPI_SUM, comm);
+
+  const auto dx = pfc::domain::get_spacing(domain);
+  const double cell = dx[0] * dx[1] * dx[2];
+  FilmSample s;
+  s.min_h = g_lo;
+  s.max_h = g_hi;
+  s.mean_h = (g[2] > 0.0) ? g[0] / g[2] : 0.0;
+  s.volume = g[0] * cell;
+  s.hole_area_fraction = (g[2] > 0.0) ? g[1] / g[2] : 0.0;
+  s.ruptured = g_lo < rupture_frac * h0;
+  return s;
+}
+
+/**
+ * @brief Number of 4-connected dry regions (`h < threshold`) on a global,
+ *        rank-0-gathered copy of the field.
+ *
+ * A diagnostic, not a distributed algorithm: flood-fills the whole global
+ * grid on rank 0 with a simple union-find, treating the domain as doubly
+ * periodic (wraps at both edges) since that is the actual boundary
+ * condition. `global_xy` must already be assembled in `[gx + gy*nx_glob]`
+ * order, e.g. via `pfc::apps::gather_global_xy_rank0`. Cheap enough for the
+ * diagnostic cadence this application uses it at (every `saveat`, not every
+ * step) on grids up to a few hundred thousand cells; call only on rank 0.
+ */
+[[nodiscard]] inline int count_dry_regions_rank0(const std::vector<double> &global_xy,
+                                                 int nx_glob, int ny_glob,
+                                                 double threshold) {
+  const std::size_t n =
+      static_cast<std::size_t>(nx_glob) * static_cast<std::size_t>(ny_glob);
+  std::vector<int> parent(n);
+  for (std::size_t i = 0; i < n; ++i) parent[i] = static_cast<int>(i);
+  std::vector<int> rank_of(n, 0);
+
+  auto find = [&](int x) {
+    while (parent[static_cast<std::size_t>(x)] != x) {
+      const int p = parent[static_cast<std::size_t>(x)];
+      parent[static_cast<std::size_t>(x)] = parent[static_cast<std::size_t>(p)];
+      x = p;
+    }
+    return x;
+  };
+  auto unite = [&](int a, int b) {
+    a = find(a);
+    b = find(b);
+    if (a == b) return;
+    auto &ra = rank_of[static_cast<std::size_t>(a)];
+    auto &rb = rank_of[static_cast<std::size_t>(b)];
+    if (ra < rb) std::swap(a, b);
+    parent[static_cast<std::size_t>(b)] = a;
+    if (ra == rb) ++ra;
+  };
+
+  auto is_dry = [&](int gx, int gy) {
+    return global_xy[static_cast<std::size_t>(gx) +
+                     static_cast<std::size_t>(gy) *
+                         static_cast<std::size_t>(nx_glob)] < threshold;
+  };
+
+  for (int gy = 0; gy < ny_glob; ++gy) {
+    for (int gx = 0; gx < nx_glob; ++gx) {
+      if (!is_dry(gx, gy)) continue;
+      const int c = gx + gy * nx_glob;
+      const int xp = (gx + 1) % nx_glob;
+      const int yp = (gy + 1) % ny_glob;
+      if (is_dry(xp, gy)) unite(c, xp + gy * nx_glob);
+      if (is_dry(gx, yp)) unite(c, gx + yp * nx_glob);
+    }
+  }
+
+  int count = 0;
+  for (int gy = 0; gy < ny_glob; ++gy) {
+    for (int gx = 0; gx < nx_glob; ++gx) {
+      if (!is_dry(gx, gy)) continue;
+      if (find(gx + gy * nx_glob) == gx + gy * nx_glob) ++count;
+    }
+  }
+  return count;
+}
+
+} // namespace thin_film

--- a/apps/thin_film/inputs_json/thin_film_fd_defect.json
+++ b/apps/thin_film/inputs_json/thin_film_fd_defect.json
@@ -1,0 +1,36 @@
+{
+    "model": {
+        "name": "thin_film",
+        "params": {
+            "h0": 1.0,
+            "gamma": 1.0,
+            "M0": 1.0,
+            "A": 8.6022,
+            "h_star": 0.15
+        }
+    },
+    "domain": {
+        "Lx": 512,
+        "Ly": 512,
+        "Lz": 1,
+        "dx": 0.5
+    },
+    "timestepping": {
+        "t1": 300.0,
+        "dt": 0.001,
+        "saveat": 5.0
+    },
+    "initial_conditions": {
+        "amplitude": 0.002,
+        "seed": 2024,
+        "defect_amplitude": 0.3,
+        "defect_sigma": 3.0
+    },
+    "fd": {
+        "face_mobility": "harmonic",
+        "order": 2
+    },
+    "diagnostics": {
+        "csv": "results/fd_defect/diagnostics.csv"
+    }
+}

--- a/apps/thin_film/inputs_json/thin_film_fd_defect.json.license
+++ b/apps/thin_film/inputs_json/thin_film_fd_defect.json.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: 2026 VTT Technical Research Centre of Finland Ltd
+SPDX-License-Identifier: AGPL-3.0-or-later

--- a/apps/thin_film/inputs_json/thin_film_fd_dewetting.json
+++ b/apps/thin_film/inputs_json/thin_film_fd_dewetting.json
@@ -1,0 +1,36 @@
+{
+    "model": {
+        "name": "thin_film",
+        "params": {
+            "h0": 1.0,
+            "gamma": 1.0,
+            "M0": 1.0,
+            "A": 8.6022,
+            "h_star": 0.15
+        }
+    },
+    "domain": {
+        "Lx": 512,
+        "Ly": 512,
+        "Lz": 1,
+        "dx": 0.5
+    },
+    "timestepping": {
+        "t1": 400.0,
+        "dt": 0.001,
+        "saveat": 5.0
+    },
+    "initial_conditions": {
+        "amplitude": 0.01,
+        "seed": 2024,
+        "defect_amplitude": 0.0,
+        "defect_sigma": 3.0
+    },
+    "fd": {
+        "face_mobility": "harmonic",
+        "order": 2
+    },
+    "diagnostics": {
+        "csv": "results/fd_dewetting/diagnostics.csv"
+    }
+}

--- a/apps/thin_film/inputs_json/thin_film_fd_dewetting.json.license
+++ b/apps/thin_film/inputs_json/thin_film_fd_dewetting.json.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: 2026 VTT Technical Research Centre of Finland Ltd
+SPDX-License-Identifier: AGPL-3.0-or-later

--- a/apps/thin_film/slurm/fd_flagship.sbatch
+++ b/apps/thin_film/slurm/fd_flagship.sbatch
@@ -1,0 +1,38 @@
+#!/bin/bash
+# SPDX-FileCopyrightText: 2026 VTT Technical Research Centre of Finland Ltd
+# SPDX-License-Identifier: AGPL-3.0-or-later
+#
+#SBATCH --account=project_462001519
+#SBATCH --partition=standard-g
+#SBATCH --nodes=1
+#SBATCH --ntasks=16
+#SBATCH --cpus-per-task=1
+#SBATCH --time=03:00:00
+#SBATCH --job-name=tf-fd-flagship
+#SBATCH --output=/flash/project_462001519/juaho/tmp-shared/tf_fd_flagship_%j.out
+
+# Flagship two-method comparison (#124): the conservative face-flux FD
+# solver integrated through rupture, 512x512 dx=0.5 -- the same physical
+# case as apps/thin_film/inputs_json/thin_film_dewetting.json /
+# thin_film_defect.json, run far enough past the point where the spectral
+# solver diverges to reach hole formation and rim/droplet coarsening.
+#
+# CPU-only MPI job (no HIP/GPU kernels in the FD path); submitted on
+# standard-g per the shared-allocation policy for long/large runs.
+
+set -euo pipefail
+
+BUILD_DIR=/flash/project_462001519/juaho/build/tf-fd-rupture
+BIN="${BUILD_DIR}/apps/thin_film/thin_film_fd"
+CASES_DIR=/pfs/lustref1/flash/project_462001519/juaho/dev/openpfc/.claude/worktrees/agent-a38076156c6ff0ac4/apps/thin_film/inputs_json
+
+cd "${BUILD_DIR}/apps/thin_film"
+mkdir -p results/fd_dewetting results/fd_defect
+
+echo "=== spontaneous (FD) ==="
+srun "${BIN}" "${CASES_DIR}/thin_film_fd_dewetting.json"
+
+echo "=== defect-triggered (FD) ==="
+srun "${BIN}" "${CASES_DIR}/thin_film_fd_defect.json"
+
+echo "=== done ==="

--- a/apps/thin_film/src/thin_film_fd.cpp
+++ b/apps/thin_film/src/thin_film_fd.cpp
@@ -1,0 +1,226 @@
+// SPDX-FileCopyrightText: 2026 VTT Technical Research Centre of Finland Ltd
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+/**
+ * @file thin_film_fd.cpp
+ * @brief Conservative face-flux FD solver for the full h^3 lubrication
+ *        model -- the solver that integrates through rupture where the
+ *        spectral `thin_film_nonlinear` cannot.
+ *
+ * Same equation, same JSON schema as `thin_film_nonlinear` (`#114`), so the
+ * *same* case file drives both binaries -- that is the point: it is what
+ * lets the two be cross-validated on one physical case rather than two
+ * loosely comparable ones. An optional `"fd"` block selects this solver's
+ * own knobs (face mobility average, curvature-operator order):
+ *
+ * @code
+ * "fd": { "face_mobility": "harmonic", "order": 2, "hole_threshold_frac": 0.5 }
+ * @endcode
+ *
+ * Usage: `thin_film_fd CASE.json`
+ */
+
+#include <cstdint>
+#include <cstdio>
+#include <filesystem>
+#include <fstream>
+#include <iomanip>
+#include <iostream>
+#include <locale>
+#include <memory>
+#include <sstream>
+#include <string>
+#include <vector>
+
+#include <mpi.h>
+#include <nlohmann/json.hpp>
+
+#include <openpfc/kernel/data/domain.hpp>
+#include <openpfc/kernel/decomposition/decomposition.hpp>
+#include <openpfc/kernel/simulation/spectral_etd_system.hpp>
+#include <openpfc/kernel/simulation/stacks/spectral_cpu_stack.hpp>
+#include <openpfc_apps/gather.hpp>
+#include <openpfc_apps/structure_factor.hpp>
+
+#include <thin_film/fd_flux.hpp>
+#include <thin_film/nonlinear.hpp>
+#include <thin_film/thin_film_physics.hpp>
+
+namespace {
+
+using json = nlohmann::json;
+
+/// Deterministic broadband perturbation, identical to `thin_film_nonlinear`'s
+/// so the two solvers start from bit-identical initial conditions.
+double hashed_noise(int i, int j, int k, const pfc::Int3 &n, std::uint64_t seed) {
+  std::uint64_t x = seed + std::uint64_t(i) +
+                    std::uint64_t(n[0]) *
+                        (std::uint64_t(j) + std::uint64_t(n[1]) * std::uint64_t(k));
+  x += 0x9e3779b97f4a7c15ULL;
+  x = (x ^ (x >> 30)) * 0xbf58476d1ce4e5b9ULL;
+  x = (x ^ (x >> 27)) * 0x94d049bb133111ebULL;
+  x = x ^ (x >> 31);
+  return 2.0 * (double(x >> 11) / double(1ULL << 53)) - 1.0;
+}
+
+thin_film::FaceMobility parse_face_mobility(const std::string &s) {
+  if (s == "harmonic") return thin_film::FaceMobility::Harmonic;
+  if (s == "arithmetic") return thin_film::FaceMobility::Arithmetic;
+  throw std::invalid_argument("fd.face_mobility must be \"harmonic\" or "
+                              "\"arithmetic\", got \"" +
+                              s + "\"");
+}
+
+} // namespace
+
+int main(int argc, char *argv[]) {
+  MPI_Init(&argc, &argv);
+  int rank = 0, nproc = 1;
+  MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+  MPI_Comm_size(MPI_COMM_WORLD, &nproc);
+  int status = 0;
+  try {
+    if (argc != 2) throw std::invalid_argument("usage: thin_film_fd CASE.json");
+    std::ifstream in(argv[1]);
+    if (!in) throw std::runtime_error(std::string("cannot open ") + argv[1]);
+    json cfg = json::parse(in);
+
+    const auto &d = cfg.at("domain");
+    const int Lx = d.at("Lx"), Ly = d.at("Ly"), Lz = d.value("Lz", 1);
+    const double dx = d.value("dx", 1.0);
+    if (Lz != 1) throw std::invalid_argument("thin_film_fd: 2-D only (Lz must be 1)");
+    const auto domain = pfc::domain::create(pfc::GridSize({Lx, Ly, Lz}),
+                                            pfc::PhysicalOrigin({0.0, 0.0, 0.0}),
+                                            pfc::GridSpacing({dx, dx, dx}));
+    const auto decomp = pfc::decomposition::create(domain, nproc);
+
+    thin_film::ThinFilmParams p;
+    thin_film::apply_thin_film_json(cfg.at("model").at("params"), p);
+
+    const auto &ts = cfg.at("timestepping");
+    const double t1 = ts.at("t1"), dt = ts.at("dt"), saveat = ts.value("saveat", -1.0);
+
+    const auto &ic = cfg.at("initial_conditions");
+    const double amp = ic.value("amplitude", 0.01);
+    const std::uint64_t seed = ic.value("seed", 1234u);
+    const double defect_amp = ic.value("defect_amplitude", 0.0);
+    const double defect_sigma = ic.value("defect_sigma", 4.0);
+
+    const json fd_cfg = cfg.value("fd", json::object());
+    const auto face_kind =
+        parse_face_mobility(fd_cfg.value("face_mobility", std::string("harmonic")));
+    const int order = fd_cfg.value("order", 2);
+    const double hole_threshold_frac = fd_cfg.value("hole_threshold_frac", 0.5);
+    const int sf_bins = fd_cfg.value("structure_factor_bins", 64);
+
+    const auto &box = pfc::decomposition::local_box(decomp, rank);
+    const int nx = box.size[0], ny = box.size[1];
+    std::vector<double> h(static_cast<std::size_t>(nx) * static_cast<std::size_t>(ny));
+
+    const auto defect =
+        thin_film::GaussianDefect::centred(domain, defect_amp, defect_sigma);
+    const pfc::Int3 n{Lx, Ly, Lz};
+    for (int iy = 0; iy < ny; ++iy) {
+      for (int ix = 0; ix < nx; ++ix) {
+        const int gx = box.low[0] + ix, gy = box.low[1] + iy;
+        const double xi = hashed_noise(gx, gy, 0, n, seed);
+        const double x = gx * dx, y = gy * dx;
+        h[static_cast<std::size_t>(ix) + static_cast<std::size_t>(iy) * nx] =
+            p.h0 * (1.0 + amp * xi + defect(x, y));
+      }
+    }
+
+    thin_film::FDFluxSolver solver(domain, decomp, rank, MPI_COMM_WORLD, h, order);
+    const thin_film::CubicMobility mobility{p.M0, p.h0};
+    const thin_film::ThinFilmPointwise pw{.A = p.A, .h0 = p.h0,
+                                          .h_star = p.h_star, .Pi0 = p.Pi0,
+                                          .Pip0 = p.Pip0};
+
+    // Rank-0-only serial FFT for the dominant-spacing diagnostic: the FD
+    // solver's Cartesian decomposition has nothing to do with heffte's
+    // pencils, so this is a second, independent, single-process transform
+    // over a gathered copy of the field -- a diagnostic, not part of the
+    // solve. `MPI_COMM_SELF` keeps it entirely local to rank 0.
+    std::unique_ptr<pfc::sim::stacks::SpectralCPUStack> diag_stack;
+    if (rank == 0) {
+      diag_stack =
+          std::make_unique<pfc::sim::stacks::SpectralCPUStack>(domain, 0, 1,
+                                                                MPI_COMM_SELF);
+    }
+
+    std::unique_ptr<std::FILE, int (*)(std::FILE *)> out(nullptr, std::fclose);
+    if (rank == 0 && cfg.contains("diagnostics")) {
+      const std::filesystem::path path =
+          cfg.at("diagnostics").at("csv").get<std::string>();
+      if (path.has_parent_path())
+        std::filesystem::create_directories(path.parent_path());
+      out.reset(std::fopen(path.string().c_str(), "w"));
+      if (!out) throw std::runtime_error("cannot open diagnostics csv");
+      std::fprintf(out.get(),
+                   "step,time,min_h,max_h,mean_h,volume,hole_area_fraction,"
+                   "dominant_spacing,n_holes,ruptured\n");
+    }
+
+    double rupture_time = -1.0;
+    const int n_steps = int(std::llround(t1 / dt));
+    const int every =
+        (saveat > 0.0) ? std::max(1, int(std::llround(saveat / dt))) : n_steps;
+
+    std::vector<double> global_xy;
+    auto report = [&](int step, double t) {
+      auto s = thin_film::sample_film_fd(h, domain, p.h0, 0.05, MPI_COMM_WORLD);
+      pfc::apps::gather_global_xy_rank0(decomp, rank, nproc, MPI_COMM_WORLD, h, Lx,
+                                        Ly, global_xy);
+      int n_holes = 0;
+      if (rank == 0) {
+        auto &diag_u = diag_stack->u();
+        diag_u.with_host_view([&](double *dv, std::size_t cnt) {
+          for (std::size_t i = 0; i < cnt && i < global_xy.size(); ++i)
+            dv[i] = global_xy[i];
+        });
+        pfc::data::Field<std::complex<double>> hh(
+            domain, diag_stack->fft().get_outbox_bounds(), 0);
+        pfc::sim::SpectralETDOps<pfc::HostSpace>::forward(diag_stack->fft(), diag_u,
+                                                           hh);
+        hh.with_host_view([&](std::complex<double> *hv, std::size_t) {
+          const auto sf = pfc::apps::shell_average(diag_stack->fft().get_outbox_bounds(),
+                                                    domain, hv, MPI_COMM_SELF, sf_bins);
+          s.dominant_spacing = sf.dominant_wavelength();
+        });
+        n_holes = thin_film::count_dry_regions_rank0(
+            global_xy, Lx, Ly, hole_threshold_frac * p.h0);
+      }
+      if (s.ruptured && rupture_time < 0.0) rupture_time = t;
+      if (out) {
+        std::ostringstream line;
+        line.imbue(std::locale::classic());
+        line << std::setprecision(17) << step << ',' << t << ',' << s.min_h << ','
+             << s.max_h << ',' << s.mean_h << ',' << s.volume << ','
+             << s.hole_area_fraction << ',' << s.dominant_spacing << ',' << n_holes
+             << ',' << (s.ruptured ? 1 : 0) << '\n';
+        std::fputs(line.str().c_str(), out.get());
+        std::fflush(out.get());
+      }
+    };
+
+    report(0, 0.0);
+    double t = 0.0;
+    for (int step = 1; step <= n_steps; ++step) {
+      solver.step(h, dt, p.gamma, pw, mobility, face_kind);
+      t = dt * step;
+      if (step % every == 0 || step == n_steps) report(step, t);
+    }
+
+    auto s = thin_film::sample_film_fd(h, domain, p.h0, 0.05, MPI_COMM_WORLD);
+    if (rank == 0) {
+      std::printf("THIN_FILM_FD min_h=%.17g volume=%.17g hole_fraction=%.17g "
+                  "rupture_time=%.17g\n",
+                  s.min_h, s.volume, s.hole_area_fraction, rupture_time);
+    }
+  } catch (const std::exception &e) {
+    if (rank == 0) std::cerr << "thin_film_fd: " << e.what() << "\n";
+    status = 2;
+  }
+  MPI_Finalize();
+  return status;
+}

--- a/apps/thin_film/tests/test_thin_film.cpp
+++ b/apps/thin_film/tests/test_thin_film.cpp
@@ -12,15 +12,18 @@
 #include <catch2/catch_test_macros.hpp>
 #include <catch2/matchers/catch_matchers_floating_point.hpp>
 
+#include <algorithm>
 #include <cmath>
 #include <mpi.h>
 #include <numbers>
 #include <stdexcept>
+#include <vector>
 
 #include <nlohmann/json.hpp>
 
 #include <openpfc/kernel/data/domain.hpp>
 #include <openpfc/kernel/data/grid_field.hpp>
+#include <openpfc/kernel/decomposition/decomposition.hpp>
 #include <openpfc/kernel/simulation/simulation_state.hpp>
 #include <openpfc/kernel/simulation/spectral_etd_system.hpp>
 #include <openpfc/kernel/simulation/stacks/spectral_cpu_stack.hpp>
@@ -28,6 +31,7 @@
 #include <thin_film/cosine_mode.hpp>
 #include <openpfc_apps/spectral_flux.hpp>
 #include <openpfc_apps/structure_factor.hpp>
+#include <thin_film/fd_flux.hpp>
 #include <thin_film/nonlinear.hpp>
 #include <thin_film/thin_film_physics.hpp>
 #include <thin_film/thin_film_session.hpp>
@@ -374,4 +378,338 @@ TEST_CASE("Gaussian defect is a localized depression", "[thin_film][nonlinear]")
   REQUIRE(std::abs(d(0.0, 0.0)) < 1e-6);               // and local
   const thin_film::GaussianDefect none{};
   REQUIRE(none(1.0, 2.0) == 0.0);
+}
+
+// ---------------------------------------------------------------------------
+// Conservative face-flux FD solver (#124): the two-method flagship.
+// ---------------------------------------------------------------------------
+
+namespace {
+
+/// Common single-rank FD fixture: `N x N`, `dx = 1`, decomposition of one.
+struct FDFixture {
+  static constexpr int N = 32;
+  pfc::Domain domain = pfc::domain::create(pfc::GridSize({N, N, 1}),
+                                           pfc::PhysicalOrigin({0.0, 0.0, 0.0}),
+                                           pfc::GridSpacing({1.0, 1.0, 1.0}));
+  pfc::decomposition::Decomposition decomp = pfc::decomposition::create(domain, 1);
+  pfc::Box3i box = pfc::decomposition::local_box(decomp, 0);
+  int nx = box.size[0];
+  int ny = box.size[1];
+};
+
+std::vector<double> cosine_field(const FDFixture &fx, double h0, double amp, int mx,
+                                 int my) {
+  std::vector<double> h(static_cast<std::size_t>(fx.nx) *
+                        static_cast<std::size_t>(fx.ny));
+  const double twopi = 2.0 * std::numbers::pi;
+  for (int iy = 0; iy < fx.ny; ++iy) {
+    for (int ix = 0; ix < fx.nx; ++ix) {
+      const double w = std::cos(twopi * mx * ix / fx.N) * std::cos(twopi * my * iy / fx.N);
+      h[static_cast<std::size_t>(ix) + static_cast<std::size_t>(iy) * fx.nx] =
+          h0 * (1.0 + amp * w);
+    }
+  }
+  return h;
+}
+
+double sum_vec(const std::vector<double> &v) {
+  double s = 0.0;
+  for (double x : v) s += x;
+  return s;
+}
+
+} // namespace
+
+TEST_CASE("FD flux divergence sums to zero to round-off, before any timestep",
+          "[thin_film][fd][mass]") {
+  if (world_size() != 1) {
+    SKIP("single-rank FD fixture");
+  }
+  FDFixture fx;
+  auto h = cosine_field(fx, /*h0=*/1.0, /*amp=*/0.2, /*mx=*/3, /*my=*/2);
+
+  thin_film::ThinFilmParams p; // defaults: h0=1, gamma=1, M0=1, A=0.05
+  const thin_film::ThinFilmPointwise pw{.A = p.A, .h0 = p.h0, .h_star = p.h_star,
+                                        .Pi0 = p.Pi0, .Pip0 = p.Pip0};
+  const thin_film::CubicMobility mobility{p.M0, p.h0};
+
+  thin_film::FDFluxSolver solver(fx.domain, fx.decomp, 0, MPI_COMM_WORLD, h,
+                                 /*order=*/2);
+  std::vector<double> dhdt(h.size());
+  solver.compute_rhs(h, p.gamma, pw, mobility, thin_film::FaceMobility::Harmonic,
+                     dhdt);
+
+  // The divergence form telescopes exactly: every interior face flux is
+  // added once and subtracted once, so the sum over all cells is zero to
+  // round-off *before any timestep is taken* -- this is a statement about
+  // the spatial discretization, not about dt.
+  REQUIRE_THAT(sum_vec(dhdt), WithinAbs(0.0, 1e-10));
+
+  // And volume stays put over many explicit steps, whatever dt is (subject
+  // to the scheme's own stability limit).
+  const auto v0 = thin_film::sample_film_fd(h, fx.domain, p.h0, 0.05, MPI_COMM_WORLD);
+  for (int s = 0; s < 50; ++s) {
+    solver.step(h, /*dt=*/1.0e-3, p.gamma, pw, mobility,
+               thin_film::FaceMobility::Harmonic);
+  }
+  const auto v1 = thin_film::sample_film_fd(h, fx.domain, p.h0, 0.05, MPI_COMM_WORLD);
+  REQUIRE_THAT(v1.volume, WithinRel(v0.volume, 1.0e-9));
+  REQUIRE(v1.max_h != v0.max_h); // and the profile did evolve
+}
+
+TEST_CASE("FD reproduces the analytical k^4 decay at constant mobility",
+          "[thin_film][fd][dispersion]") {
+  if (world_size() != 1) {
+    SKIP("single-rank analytical comparison");
+  }
+  // Bypass CubicMobility with a constant-mobility lambda, exactly as the
+  // spectral test does -- this isolates the FD curvature/flux operators
+  // from the h^3 nonlinearity, so any mismatch against exp(-M0 gamma k^4 t)
+  // is discretization error in those operators, not the nonlinearity.
+  FDFixture fx;
+  constexpr double h0 = 1.0, gamma = 1.0, M0 = 1.0;
+  constexpr double amp = 1.0e-4, dt = 1.0e-3;
+  constexpr int steps = 200;
+  constexpr int mode = 2;
+  auto h = cosine_field(fx, h0, amp, mode, 0);
+
+  const thin_film::ThinFilmPointwise pw{.A = 0.0, .h0 = h0}; // A=0: Pi == 0
+  const auto constant_mobility = [](double) { return M0; };
+
+  thin_film::FDFluxSolver solver(fx.domain, fx.decomp, 0, MPI_COMM_WORLD, h,
+                                 /*order=*/2);
+  for (int s = 0; s < steps; ++s) {
+    solver.step(h, dt, gamma, pw, constant_mobility, thin_film::FaceMobility::Harmonic);
+  }
+
+  const double twopi = 2.0 * std::numbers::pi;
+  const double k = twopi * mode / fx.N;
+  const double expected = amp * std::exp(-M0 * gamma * k * k * k * k * dt * steps);
+  double num = 0.0, den = 0.0;
+  for (int iy = 0; iy < fx.ny; ++iy) {
+    for (int ix = 0; ix < fx.nx; ++ix) {
+      const double w = std::cos(twopi * mode * ix / fx.N);
+      num += (h[static_cast<std::size_t>(ix) + static_cast<std::size_t>(iy) * fx.nx] -
+             h0) *
+             w;
+      den += w * w;
+    }
+  }
+  // Order-2 central differences on a coarse grid (32 points, wavelength 16
+  // points) carry an O((k dx)^2) discretization error the spectral method
+  // does not have; 5% captures that while still catching a wrong sign,
+  // missing factor, or wrong exponent in the FD operators.
+  REQUIRE_THAT(num / den, WithinRel(expected, 0.05));
+}
+
+TEST_CASE("FD reproduces the analytical unstable growth rate with the "
+          "disjoining pressure linearized in",
+          "[thin_film][fd][dispersion]") {
+  if (world_size() != 1) {
+    SKIP("single-rank analytical comparison");
+  }
+  // Mirrors the spectral suite's "ETD conserves volume and matches linear
+  // growth/decay": constant mobility, but now A != 0 so the destabilizing
+  // Pi'(h0) term is exercised too, not just the stabilizing curvature term
+  // the k^4-decay test above isolates. lambda(k) = M0 k^2 (Pip0 - gamma k^2)
+  // is the same formula `ThinFilmPhysics::linear_symbol` encodes for the
+  // spectral path; here it is the FD flux/curvature operators being
+  // checked against it instead.
+  FDFixture fx;
+  constexpr double h0 = 1.0, gamma = 1.0, M0 = 1.0, A = 0.05;
+  constexpr double amp = 1.0e-4, dt = 1.0e-3;
+  constexpr int steps = 200;
+  constexpr int mode = 2;
+  auto h = cosine_field(fx, h0, amp, mode, 0);
+
+  thin_film::ThinFilmParams p;
+  thin_film::apply_thin_film_json({{"h0", h0}, {"gamma", gamma}, {"M0", M0}, {"A", A}},
+                                  p);
+  const thin_film::ThinFilmPointwise pw{.A = p.A, .h0 = p.h0, .h_star = p.h_star,
+                                        .Pi0 = p.Pi0, .Pip0 = p.Pip0};
+  const auto constant_mobility = [](double) { return M0; };
+
+  thin_film::FDFluxSolver solver(fx.domain, fx.decomp, 0, MPI_COMM_WORLD, h,
+                                 /*order=*/2);
+  for (int s = 0; s < steps; ++s) {
+    solver.step(h, dt, gamma, pw, constant_mobility, thin_film::FaceMobility::Harmonic);
+  }
+
+  const double twopi = 2.0 * std::numbers::pi;
+  const double k = twopi * mode / fx.N;
+  const double lambda = M0 * k * k * (p.Pip0 - gamma * k * k);
+  REQUIRE(lambda > 0.0); // this mode must be unstable, or the test proves nothing
+  const double expected = amp * std::exp(lambda * dt * steps);
+  double num = 0.0, den = 0.0;
+  for (int iy = 0; iy < fx.ny; ++iy) {
+    for (int ix = 0; ix < fx.nx; ++ix) {
+      const double w = std::cos(twopi * mode * ix / fx.N);
+      num += (h[static_cast<std::size_t>(ix) + static_cast<std::size_t>(iy) * fx.nx] -
+             h0) *
+             w;
+      den += w * w;
+    }
+  }
+  REQUIRE_THAT(num / den, WithinRel(expected, 0.05));
+}
+
+TEST_CASE("FD face mobility: harmonic mean stays non-negative through rupture, "
+          "arithmetic mean does not",
+          "[thin_film][fd][positivity]") {
+  if (world_size() != 1) {
+    SKIP("single-rank rupture drive");
+  }
+  // A deep, localized precursor-form defect (same shape as the science
+  // case's defect-triggered dewetting, `thin_film_defect.json`, just deeper
+  // and on a much smaller grid) driven forward long enough to cross into
+  // the precursor. This is the actual claim the application makes about
+  // the face-mobility choice -- checked here, not just asserted in the
+  // README -- and it was calibrated against exactly this behaviour with
+  // `apps/thin_film/inputs_json/thin_film_fd_probe2*.json` on a real run:
+  // harmonic settles just above `h_star`; arithmetic overflows once the
+  // dip gets close to it (there, at t ~ 24 of 30; here, well inside the
+  // step budget below).
+  constexpr int N = 32;
+  const auto domain = pfc::domain::create(pfc::GridSize({N, N, 1}),
+                                          pfc::PhysicalOrigin({0.0, 0.0, 0.0}),
+                                          pfc::GridSpacing({0.5, 0.5, 0.5}));
+  const auto decomp = pfc::decomposition::create(domain, 1);
+  const auto box = pfc::decomposition::local_box(decomp, 0);
+  const int nx = box.size[0], ny = box.size[1];
+
+  thin_film::ThinFilmParams p;
+  thin_film::apply_thin_film_json({{"A", 8.6022}, {"h_star", 0.15}}, p);
+  const thin_film::ThinFilmPointwise pw{.A = p.A, .h0 = p.h0, .h_star = p.h_star,
+                                        .Pi0 = p.Pi0, .Pip0 = p.Pip0};
+  const thin_film::CubicMobility mobility{p.M0, p.h0};
+  const auto defect = thin_film::GaussianDefect::centred(domain, /*amplitude=*/0.87,
+                                                         /*sigma=*/3.0);
+  constexpr double dt = 5.0e-4;
+  constexpr int steps = 50000;
+
+  auto run = [&](thin_film::FaceMobility kind) {
+    std::vector<double> h(static_cast<std::size_t>(nx) * static_cast<std::size_t>(ny));
+    for (int iy = 0; iy < ny; ++iy) {
+      for (int ix = 0; ix < nx; ++ix) {
+        const double x = ix * 0.5, y = iy * 0.5;
+        h[static_cast<std::size_t>(ix) + static_cast<std::size_t>(iy) * nx] =
+            p.h0 * (1.0 + defect(x, y));
+      }
+    }
+    thin_film::FDFluxSolver solver(domain, decomp, 0, MPI_COMM_WORLD, h, /*order=*/2);
+    double min_h = *std::min_element(h.begin(), h.end());
+    for (int s = 0; s < steps; ++s) {
+      solver.step(h, dt, p.gamma, pw, mobility, kind);
+      min_h = std::min(min_h, *std::min_element(h.begin(), h.end()));
+      if (!std::isfinite(min_h)) break;
+    }
+    return min_h;
+  };
+
+  const double min_harmonic = run(thin_film::FaceMobility::Harmonic);
+  const double min_arithmetic = run(thin_film::FaceMobility::Arithmetic);
+
+  REQUIRE(std::isfinite(min_harmonic));
+  REQUIRE(min_harmonic > -1.0e-9); // stays non-negative to round-off
+  REQUIRE(min_harmonic < 0.5 * p.h0); // and it actually got close to rupture
+  // The arithmetic mean only halves the flux out of a near-empty cell; it
+  // does not have to stop that cell from being driven below zero, and in
+  // this case it does not: the run overflows before the loop ends.
+  REQUIRE_FALSE(std::isfinite(min_arithmetic));
+}
+
+TEST_CASE("FD and spectral agree in the smooth pre-rupture regime",
+          "[thin_film][fd][spectral][agreement]") {
+  if (world_size() != 1) {
+    SKIP("single-rank cross-validation");
+  }
+  // Same equation, same IC, same domain, both methods still small-amplitude
+  // (no precursor engaged): this is the cross-validation the two-method
+  // story depends on. Growth is exponential here, so the two solutions
+  // should differ only by discretization error, not by O(1) physics.
+  constexpr int N = 64;
+  constexpr double h0 = 1.0, gamma = 1.0, M0 = 1.0, A = 0.05;
+  constexpr double amp = 1.0e-3, dt = 2.0e-3;
+  constexpr int steps = 100;
+  constexpr int mode = 2;
+
+  thin_film::ThinFilmParams p;
+  thin_film::apply_thin_film_json({{"h0", h0}, {"gamma", gamma}, {"M0", M0}, {"A", A}},
+                                  p);
+  const thin_film::ThinFilmPointwise pw{.A = p.A, .h0 = p.h0, .h_star = p.h_star,
+                                        .Pi0 = p.Pi0, .Pip0 = p.Pip0};
+  const thin_film::CubicMobility mobility{p.M0, p.h0};
+  const double twopi = 2.0 * std::numbers::pi;
+
+  // FD.
+  const auto domain = pfc::domain::create(pfc::GridSize({N, N, 1}),
+                                          pfc::PhysicalOrigin({0.0, 0.0, 0.0}),
+                                          pfc::GridSpacing({1.0, 1.0, 1.0}));
+  const auto decomp = pfc::decomposition::create(domain, 1);
+  const auto box = pfc::decomposition::local_box(decomp, 0);
+  const int nx = box.size[0], ny = box.size[1];
+  std::vector<double> h_fd(static_cast<std::size_t>(nx) *
+                           static_cast<std::size_t>(ny));
+  for (int iy = 0; iy < ny; ++iy)
+    for (int ix = 0; ix < nx; ++ix)
+      h_fd[static_cast<std::size_t>(ix) + static_cast<std::size_t>(iy) * nx] =
+          h0 * (1.0 + amp * std::cos(twopi * mode * ix / N));
+  thin_film::FDFluxSolver fd_solver(domain, decomp, 0, MPI_COMM_WORLD, h_fd,
+                                    /*order=*/2);
+  for (int s = 0; s < steps; ++s) {
+    fd_solver.step(h_fd, dt, p.gamma, pw, mobility, thin_film::FaceMobility::Harmonic);
+  }
+  const auto fd_sample =
+      thin_film::sample_film_fd(h_fd, domain, h0, 0.05, MPI_COMM_WORLD);
+
+  // Spectral.
+  pfc::sim::stacks::SpectralCPUStack stack(domain, 0, 1, MPI_COMM_WORLD);
+  auto &h_spec = stack.u();
+  h_spec.apply([&](double x, double, double) {
+    return h0 * (1.0 + amp * std::cos(twopi * mode * x / N));
+  });
+  const double k_lap_scale = -(twopi * mode / N) * (twopi * mode / N);
+  (void)k_lap_scale;
+  std::vector<double> k_lap(stack.fft().size_outbox(), 0.0);
+  pfc::fft::kspace::for_each_kpoint(
+      stack.fft().get_outbox_bounds(), domain,
+      [&](std::size_t i, double kx, double ky, double kz, int, int, int) {
+        k_lap[i] = -(kx * kx + ky * ky + kz * kz);
+      });
+  pfc::apps::FluxETD stepper(domain, stack.fft(), dt, [=](double kl) {
+    return -M0 * gamma * kl * kl - M0 * p.Pip0 * kl;
+  });
+  auto potential = [&](pfc::data::Field<std::complex<double>> &h_hat,
+                       pfc::data::Field<double> &hh,
+                       pfc::data::Field<std::complex<double>> &out) {
+    std::vector<double> pi_real(hh.local_size()[0] * hh.local_size()[1]);
+    hh.with_host_view([&](double *hv, std::size_t cnt) {
+      for (std::size_t i = 0; i < cnt; ++i) pi_real[i] = pw.Pi(hv[i]);
+    });
+    pfc::data::Field<double> pi_field(domain, stack.fft().get_inbox_bounds(), 0);
+    pi_field.with_host_view([&](double *pv, std::size_t cnt) {
+      for (std::size_t i = 0; i < cnt; ++i) pv[i] = pi_real[i];
+    });
+    pfc::data::Field<std::complex<double>> pi_hat(domain, stack.fft().get_outbox_bounds(),
+                                                  0);
+    pfc::sim::SpectralETDOps<pfc::HostSpace>::forward(stack.fft(), pi_field, pi_hat);
+    h_hat.with_host_view([&](std::complex<double> *hvv, std::size_t m) {
+      pi_hat.with_host_view([&](std::complex<double> *pvv, std::size_t) {
+        out.with_host_view([&](std::complex<double> *o, std::size_t) {
+          for (std::size_t i = 0; i < m; ++i) o[i] = -gamma * k_lap[i] * hvv[i] - pvv[i];
+        });
+      });
+    });
+  };
+  double t = 0.0;
+  for (int s = 0; s < steps; ++s) t = stepper.step(t, h_spec, potential, mobility);
+  const auto spec_sample = thin_film::sample_film(h_spec, domain, h0, 0.05, MPI_COMM_WORLD);
+
+  // Both are unstable-mode growth from the same IC; require them to agree to
+  // a couple of percent in the two headline observables this application
+  // reports -- min thickness and total volume -- while amplitude is still
+  // small (no precursor engaged on either side).
+  REQUIRE_THAT(fd_sample.min_h, WithinRel(spec_sample.min_h, 0.02));
+  REQUIRE_THAT(fd_sample.volume, WithinRel(spec_sample.volume, 1.0e-6));
 }


### PR DESCRIPTION
## Summary

Adds `thin_film_fd`: a conservative face-flux finite-difference solver for the same `h^3` lubrication equation as `thin_film_nonlinear` (spectral ETD1). Where the spectral solver structurally cannot integrate through rupture (degenerate mobility, no positivity preservation, global spectral basis ringing at a sharp rim), this scheme forms the flux **at cell faces** — `F = M_face (p_R - p_L)/dx` — so the flux out of a vanishing cell vanishes with it, and mass conservation is exact by telescoping regardless of timestep.

Distributed via `pfc::decomposition` + `pfc::comm::SparseExchange` (the same separated-halo pattern as `apps/allen_cahn`), verified: 1-rank vs 4-rank runs of the same case give bit-identical `min h`/`max h`.

Full writeup: `apps/thin_film/README.md`, new section **"Two methods, one problem"**.

## Does it get through rupture?

Yes. 512², `dx = 0.5` (identical domain to the spectral science case), harmonic-mean face mobility, order-2 curvature operator, `dt = 0.001`:

| Case | Approaches precursor | Min `h` reached | Hole area (final) | `n_holes` peak → final | Volume drift |
|---|---|---|---|---|---|
| Spontaneous (`t1=400`) | `t ~ 340` | 0.1515 | 19.6 % | 227 (`t=345`) → 204 (`t=400`) | `4.3e-11` abs (`1.3e-15` rel) |
| Defect-triggered (`t1=300`) | not yet (`0.164` at `t=300`) | 0.164 | 1.3 % | 1 → 1 | `1.5e-10` abs (`4.6e-15` rel) |

The spontaneous run is the headline: it forms holes, **stays positive throughout, conserves volume to round-off, and its hole count falls from 227 to 204** — coalescence observed directly, not just hole formation. `min h` does not cross `h*=0.15`; it is *pinned* just above it (harmonic-mean face mobility shuts off flux out of a near-dry cell), in contrast to the spectral solver, which crosses `h*` and then diverges shortly after.

**Face mobility, measured, not assumed:** harmonic mean settles at the precursor and stays there to `t=500` (5×10⁵ steps checked); the arithmetic mean is bit-for-bit identical until `min h ~ 0.33`, then overflows to `inf`/`NaN` within ~5 time units, right as the thinnest cell approaches `h*`. This is the actual empirical basis for defaulting to harmonic, not a theoretical assumption.

**Stable `dt`, measured directly** on the 512² case: `dt=0.001` is stable through the whole run; `dt=0.002`–`0.0025` already show spurious excess thinning inside 5 time units (numerical, not physical); `dt≥0.003` overflows within a few hundred steps.

**Curvature-operator order 2 vs 4** compared directly on a 64² probe: `min h = 0.7171` (order 2) vs `0.7248` (order 4) after 250 time units at the same `dt` — a ~1% difference consistent with truncation error, not a resolution-starved answer.

## FD-vs-spectral agreement

**Controlled, single-mode comparison** (deterministic cosine near `k_peak`, not noise — the rigorous check): after 100 steps of exponential growth from the same IC, FD's `min h` agrees with spectral's to **2%**, volume to **1e-6 relative**. This is where "the two methods agree" is unambiguously true.

**The actual 512², broadband-noise flagship comparison** is reported honestly rather than only where flattering. Both binaries start from a *bit-identical* IC (`t=0` `min_h`/`max_h`/volume match to 15 significant digits) but do **not** track each other afterwards: spectral crosses `h*` at `t=140`; FD only approaches it by `t~340-400`. This is a real, reproducible timing offset (deterministic noise — reruns change nothing), not a bug: spectral ETD treats every wavenumber exactly and 2/3-dealiases (removing the top third outright), while FD's 2nd-order discrete Laplacian damps near-Nyquist content at only `0.41×` the continuum rate at this `dx` (so ~6× weaker biharmonic damping of single-cell noise) — the broadband hashed-noise IC is dominated by exactly that content, so the two schemes clear the noise floor at genuinely different rates before the coherent dewetting pattern takes over. The single-mode comparison is the one to trust for "do the methods agree"; the broadband one is the one to trust for "how long until this specific noisy run pays off."

## Tests

New Catch2 cases (`ctest -R thin-film`, all passing):
- exact mass conservation to round-off via `compute_rhs`, independent of `dt`
- linearized `k^4` capillary decay (constant mobility) — matches the spectral verifier's structure
- linearized unstable growth rate `M0 k^2(Pi'(h0) - gamma k^2)` (constant mobility, `A≠0`) — same formula the spectral `linear_symbol` encodes
- harmonic-vs-arithmetic positivity through a driven rupture (the measurement behind the face-mobility claim above)
- FD-vs-spectral agreement on the controlled single-mode case

## Deferred / out of scope

- No attempt to close the broadband-noise timing gap (would need either a higher-order face-flux reconstruction or matching the spectral scheme's dealiasing behavior — flagged as a real, explained structural difference rather than something patched over).
- No droplet-size-distribution statistics beyond the connected-component hole count (rank-0 gather + flood fill); full Lifshitz–Slyozov-style coarsening exponent would need a much longer run than fits this PR's budget.
- Order-4 curvature operator is available (`"fd":{"order":4}`) but not used in the shipped presets (order 2 is cheaper and the difference is minor at this resolution).

Merge by **rebase**, not squash.