### PR TITLE
feat(common): GPU flux path and heroic-scale dewetting run

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -114,7 +114,35 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 - Conservative flux nonlinearity for the applications whose mobility depends on
   the field inside a divergence (`#114`): `pfc::apps::SpectralFlux` and
   `pfc::apps::FluxETD` in `apps/common`, evaluating `div(M(u) grad p)`
-  spectrally with Orszag 2/3 dealiasing and an ETD1 update. Host only.
+  spectrally with Orszag 2/3 dealiasing and an ETD1 update. Now templated on
+  `MemorySpace` and running on GPU as well as host -- see the entry below.
+- GPU flux path and a heroic-scale GPU dewetting run: `SpectralFlux<MemorySpace>`
+  and `FluxETD<MemorySpace>` route every elementwise step (the complex `i*k_d`
+  gradient, the dealias mask, the ETD combine) through
+  `pfc::sim::SpectralETDOps<MemorySpace>`, which already carried a
+  complex-coefficient `combine_raw` overload with real CUDA/HIP kernels behind
+  it; the mobility `M(u)` is evaluated on device with the same
+  `OPENPFC_INSTANTIATE_SPECTRAL_POINTWISE` mechanism the physics nonlinearities
+  use, fused with the gradient multiply in one kernel launch
+  (`pfc::apps::MobilityGradPointwise`). New `thin_film_nonlinear_hip` binary
+  (same JSON schema and observables as `thin_film_nonlinear`), gated on
+  `OpenPFC_ENABLE_HIP AND OpenPFC_HIP_AVAILABLE AND OpenPFC_ENABLE_HIP_SPECTRAL`,
+  plus a HIP-vs-host parity `ctest` case. The host path is unchanged
+  arithmetically (same operand order throughout, verified bit-identical by
+  construction). Measured on LUMI (128², `dt=0.002`, 10000 steps, 1 GCD vs 1
+  CPU rank): `min_h` agrees to a relative `1.6e-13`, liquid volume to
+  `4.4e-15` -- FFTW-vs-rocFFT round-off, not a numerical difference.
+  Heroic run (LUMI job 21857011): the spontaneous-dewetting preset at 4096²
+  (dx=0.5, ~128 fastest-growing wavelengths per side, 64x the validated 512²
+  case's area) on 16 GCDs (2 `standard-g` nodes), `t1=140`, `dt=0.002`
+  (70000 steps) in 2333.6 s (33.3 ms/step). Volume conserved to a relative
+  1.5e-14 through the valid window; the precursor is reached at `t=115`
+  (`min_h=0.133`) -- earlier than the 512² case's `t=140`, consistent with
+  more independent nucleation sites racing to rupture first over 64x the
+  area. The run then hits the documented, out-of-scope divergence near
+  `min_h~0.6 h*` around `t=130`-`135`, reproducing the known breakdown at a
+  resolution and domain size the CPU verifier never exercised -- confirming
+  it is a scale-independent modelling limitation, not a GPU-path defect.
 - `thin_film` science case: full `h^3` lubrication mobility, a precursor
   disjoining pressure that survives hole formation, and spontaneous versus
   defect-triggered dewetting presets. A 30 % deep defect brings failure forward

--- a/apps/common/include/openpfc_apps/spectral_flux.hpp
+++ b/apps/common/include/openpfc_apps/spectral_flux.hpp
@@ -58,10 +58,23 @@
  *
  * ## Scope
  *
- * Host (CPU) only. The device `Ops` layer exposes real-coefficient multiplies,
- * and the gradient needs a complex \f$ik_d\f$, so a GPU flux path needs kernels
- * that do not exist yet. Applications keep their existing constant-mobility HIP
- * twins; the nonlinear science presets are CPU.
+ * `SpectralFlux<MemorySpace>` and `FluxETD<MemorySpace>` run on host *and*
+ * device: every elementwise step (the complex \f$ik_d\f$ gradient, the
+ * dealias mask, the ETD combine) goes through
+ * `pfc::sim::SpectralETDOps<MemorySpace>`, which for `CUDASpace`/`HIPSpace`
+ * dispatches to the real CUDA/HIP kernels behind `combine_raw` — including its
+ * **complex**-coefficient overload (`combine_two_term_{cuda,hip}_impl` with
+ * `const Complex *e, const Complex *w`), which is exactly what a complex
+ * `i k_d` multiply needs. The one piece that is not a diagonal k-space
+ * operator is the real-space mobility \f$M(u)\f$; it is evaluated with the
+ * same device-capable pointwise mechanism the physics nonlinearities use
+ * (`Ops::pointwise`, `OPENPFC_INSTANTIATE_SPECTRAL_POINTWISE`), fused with the
+ * multiply against the gradient in one kernel launch via `MobilityGradPointwise`
+ * (see below). A caller wiring the mobility onto a device build must supply an
+ * `OPENPFC_HD`, trivially-copyable `Mobility` and instantiate
+ * `MobilityGradPointwise<Mobility>` in one `.cu`/`.hip` translation unit,
+ * exactly as a physics functor does; `apps/thin_film/src/gpu/` is the worked
+ * example (`CubicMobility` on `pfc::HIPSpace`).
  */
 
 #include <cmath>
@@ -69,43 +82,74 @@
 #include <cstddef>
 #include <functional>
 #include <numbers>
+#include <span>
 #include <stdexcept>
+#include <type_traits>
 #include <vector>
 
 #include <openpfc/kernel/data/domain.hpp>
 #include <openpfc/kernel/data/grid_field.hpp>
+#include <openpfc/kernel/data/host_device.hpp>
+#include <openpfc/kernel/execution/memory_space.hpp>
 #include <openpfc/kernel/fft/kspace_iterator.hpp>
 #include <openpfc/kernel/simulation/spectral_etd_ops.hpp>
+#include <openpfc/kernel/simulation/spectral_pointwise.hpp>
+#include <openpfc/runtime/gpu/spectral_etd_ops_gpu.hpp>
 
 namespace pfc::apps {
 
 /**
- * @brief Spectral evaluation of \f$\nabla\cdot[M(u)\nabla p]\f$ on the host.
+ * @brief Device-capable adapter: `M(u) * grad` in one pointwise kernel.
+ *
+ * @details
+ * `pfc::sim::SpectralCell` carries three real inputs per cell (`psi`,
+ * `psi_mf`, `p_star`); `SpectralFlux` repurposes the mean-field slot to carry
+ * the already-transformed real-space gradient, so the mobility evaluation and
+ * its multiply against the gradient are one launch instead of two. `Mobility`
+ * must be trivially copyable and expose `OPENPFC_HD double operator()(double)
+ * const` (a small value struct such as `thin_film::CubicMobility`, or a
+ * capture-by-value lambda for the host-only path).
  */
-class SpectralFlux {
-  using Ops = pfc::sim::SpectralETDOps<pfc::HostSpace>;
+template <class Mobility> struct MobilityGradPointwise {
+  Mobility mobility{};
+
+  [[nodiscard]] OPENPFC_HD double
+  nonlinearity(const pfc::sim::SpectralCell &cell) const {
+    return mobility(cell.psi) * cell.psi_mf;
+  }
+};
+
+/**
+ * @brief Spectral evaluation of \f$\nabla\cdot[M(u)\nabla p]\f$.
+ *
+ * @tparam MemorySpace `HostSpace` (default), `CUDASpace`, or `HIPSpace`.
+ */
+template <class MemorySpace = pfc::HostSpace> class SpectralFlux {
+  using Ops = pfc::sim::SpectralETDOps<MemorySpace>;
 
 public:
-  using Complex = Ops::Complex;
-  using RealField = Ops::RealField;
-  using ComplexField = Ops::ComplexField;
-  using FFT = Ops::FFT;
+  using Complex = typename Ops::Complex;
+  using RealField = typename Ops::RealField;
+  using ComplexField = typename Ops::ComplexField;
+  using FFT = typename Ops::FFT;
+  using real_coeffs = typename Ops::real_coeffs;
+  using complex_scratch = typename Ops::complex_scratch;
 
   SpectralFlux(const pfc::Domain &domain, FFT &fft)
-      : m_domain(domain), m_fft(fft),
-        m_grad_hat(domain, fft.get_outbox_bounds(), 0),
-        m_grad(domain, fft.get_inbox_bounds(), 0),
+      : m_fft(fft), m_grad(domain, fft.get_inbox_bounds(), 0),
         m_flux_hat(domain, fft.get_outbox_bounds(), 0) {
     const auto size = pfc::domain::get_size(domain);
     for (int d = 0; d < 3; ++d) m_active[d] = size[d] > 1;
     const std::size_t n = fft.size_outbox();
-    for (int d = 0; d < 3; ++d) m_k[d].assign(n, 0.0);
+
+    std::vector<double> k[3];
+    for (int d = 0; d < 3; ++d) k[d].assign(n, 0.0);
     // Orszag 2/3 mask. M(u) grad p is a strongly nonlinear product, so the
     // transform of the flux carries wave numbers the grid cannot represent.
     // Without this the aliased content folds back and the run diverges once
     // the profile steepens -- and it does so independently of the timestep,
     // which is how the omission shows itself.
-    m_mask.assign(n, 1.0);
+    std::vector<double> mask_host(n, 1.0);
     const auto dx = pfc::domain::get_spacing(domain);
     double cut[3]{};
     for (int d = 0; d < 3; ++d)
@@ -113,72 +157,121 @@ public:
     pfc::fft::kspace::for_each_kpoint(
         fft.get_outbox_bounds(), domain,
         [&](std::size_t i, double kx, double ky, double kz, int, int, int) {
-          m_k[0][i] = kx;
-          m_k[1][i] = ky;
-          m_k[2][i] = kz;
+          k[0][i] = kx;
+          k[1][i] = ky;
+          k[2][i] = kz;
           const double a[3]{std::abs(kx), std::abs(ky), std::abs(kz)};
           for (int d = 0; d < 3; ++d)
-            if (m_active[d] && a[d] > cut[d]) m_mask[i] = 0.0;
+            if (m_active[d] && a[d] > cut[d]) mask_host[i] = 0.0;
         });
+
+    m_mask = Ops::make_real(n);
+    Ops::upload(m_mask, std::span<const double>(mask_host));
+
+    std::vector<Complex> zero(n, Complex{0.0, 0.0});
+    std::vector<Complex> ones(n, Complex{1.0, 0.0});
+    m_zero_c = Ops::make_complex(n);
+    m_ones_c = Ops::make_complex(n);
+    Ops::upload(m_zero_c, std::span<const Complex>(zero));
+    Ops::upload(m_ones_c, std::span<const Complex>(ones));
+
+    for (int d = 0; d < 3; ++d) {
+      if (!m_active[d]) continue;
+      std::vector<Complex> ik(n);
+      for (std::size_t i = 0; i < n; ++i) ik[i] = Complex{0.0, k[d][i]};
+      m_ik[d] = Ops::make_complex(n);
+      Ops::upload(m_ik[d], std::span<const Complex>(ik));
+    }
+
+    m_grad_hat_scratch = Ops::make_complex(n);
+    m_flux_hat_masked = Ops::make_complex(n);
+    m_out_accum = Ops::make_complex(n);
+    m_geometry = geometry_of(m_grad);
   }
 
   /**
-   * @brief Accumulate \f$\nabla\cdot[M(u)\nabla p]\f$ into @p out_hat.
+   * @brief Overwrite @p out_hat with \f$\nabla\cdot[M(u)\nabla p]\f$.
    *
    * @param p_hat    transform of the potential
    * @param u        real field the mobility depends on
-   * @param mobility callable `double(double u)` returning \f$M(u)\f$
+   * @param mobility callable `OPENPFC_HD double(double u)` returning
+   *                 \f$M(u)\f$; must be trivially copyable (device builds
+   *                 additionally need `MobilityGradPointwise<Mobility>`
+   *                 explicitly instantiated in one device translation unit)
    * @param out_hat  overwritten with the divergence
    */
   template <class Mobility>
   void divergence(ComplexField &p_hat, RealField &u, Mobility &&mobility,
                   ComplexField &out_hat) {
-    const std::size_t n_out = m_fft.size_outbox();
-    out_hat.with_host_view([&](Complex *out, std::size_t) {
-      for (std::size_t i = 0; i < n_out; ++i) out[i] = Complex{0.0, 0.0};
-    });
+    using MobilityT = std::decay_t<Mobility>;
+    static_assert(std::is_trivially_copyable_v<MobilityT>,
+                  "SpectralFlux::divergence: Mobility must be trivially "
+                  "copyable to run through the device pointwise launcher");
+    const MobilityGradPointwise<MobilityT> functor{mobility};
 
+    bool first = true;
     for (int d = 0; d < 3; ++d) {
       if (!m_active[d]) continue;
 
-      // grad_hat = i k_d p_hat
-      p_hat.with_host_view([&](Complex *p, std::size_t) {
-        m_grad_hat.with_host_view([&](Complex *g, std::size_t) {
-          for (std::size_t i = 0; i < n_out; ++i)
-            g[i] = Complex{0.0, m_k[d][i]} * p[i];
-        });
-      });
-      Ops::backward(m_fft, m_grad_hat, m_grad);
+      // grad_hat = i k_d * p_hat  (second combine term zeroed)
+      Ops::combine(p_hat, p_hat, m_ik[d], m_zero_c, m_grad_hat_scratch);
+      Ops::backward(m_fft, m_grad_hat_scratch, m_grad);
 
-      // grad *= M(u), in real space, where the nonlinearity actually lives
-      u.with_host_view([&](const double *uu, std::size_t count) {
-        m_grad.with_host_view([&](double *g, std::size_t) {
-          for (std::size_t i = 0; i < count; ++i) g[i] *= mobility(uu[i]);
-        });
-      });
+      // grad *= M(u), in real space, where the nonlinearity actually lives.
+      // Fused into one kernel: n_out = mobility(psi) * psi_mf, with psi_mf
+      // repurposed to carry the gradient (see MobilityGradPointwise).
+      Ops::pointwise(m_geometry, 0.0, u, &m_grad, nullptr, m_grad, nullptr,
+                     functor);
+
       Ops::forward(m_fft, m_grad, m_flux_hat);
+      Ops::multiply(m_flux_hat, m_mask, m_flux_hat_masked);
 
-      // out_hat += i k_d * dealias(flux_hat)
-      m_flux_hat.with_host_view([&](Complex *f, std::size_t) {
-        out_hat.with_host_view([&](Complex *out, std::size_t) {
-          for (std::size_t i = 0; i < n_out; ++i)
-            out[i] += Complex{0.0, m_k[d][i]} * (m_mask[i] * f[i]);
-        });
-      });
+      // out_hat = i k_d * dealias(flux_hat)  [first active axis]
+      // out_hat += i k_d * dealias(flux_hat) [subsequent axes]
+      if (first) {
+        Ops::combine(p_hat, m_flux_hat_masked, m_zero_c, m_ik[d], m_out_accum);
+        first = false;
+      } else {
+        Ops::combine(out_hat, m_flux_hat_masked, m_ones_c, m_ik[d], m_out_accum);
+      }
+      Ops::swap(out_hat, m_out_accum);
+    }
+    if (first) {
+      // No active axis (degenerate 1x1x1 domain): out_hat must still be
+      // zeroed, matching every other path through this loop.
+      Ops::combine(out_hat, out_hat, m_zero_c, m_zero_c, m_out_accum);
+      Ops::swap(out_hat, m_out_accum);
     }
   }
 
-  [[nodiscard]] const pfc::Domain &domain() const noexcept { return m_domain; }
-
 private:
-  pfc::Domain m_domain;
+  static pfc::sim::PointwiseGeometry geometry_of(const RealField &f) {
+    const auto &o = f.origin();
+    const auto &s = f.spacing();
+    const auto &box = f.box();
+    return pfc::sim::PointwiseGeometry{.nx = box.size[0],
+                                       .ny = box.size[1],
+                                       .nz = box.size[2],
+                                       .low_x = box.low[0],
+                                       .low_y = box.low[1],
+                                       .low_z = box.low[2],
+                                       .origin_x = o[0],
+                                       .origin_y = o[1],
+                                       .origin_z = o[2],
+                                       .dx = s[0],
+                                       .dy = s[1],
+                                       .dz = s[2]};
+  }
+
   FFT &m_fft;
   bool m_active[3]{};
-  std::vector<double> m_k[3];
-  std::vector<double> m_mask;
-  ComplexField m_grad_hat;
+  real_coeffs m_mask;
+  complex_scratch m_ik[3];
+  complex_scratch m_zero_c, m_ones_c;
   RealField m_grad;
   ComplexField m_flux_hat;
+  complex_scratch m_grad_hat_scratch, m_flux_hat_masked, m_out_accum;
+  pfc::sim::PointwiseGeometry m_geometry{};
 };
 
 /**
@@ -190,15 +283,19 @@ private:
  * * `mobility(u)` — the state-dependent \f$M(u)\f$.
  *
  * plus the linear symbol \f$L(k)\f$ used for the exponential integrator.
+ *
+ * @tparam MemorySpace `HostSpace` (default), `CUDASpace`, or `HIPSpace`.
  */
-class FluxETD {
-  using Ops = pfc::sim::SpectralETDOps<pfc::HostSpace>;
+template <class MemorySpace = pfc::HostSpace> class FluxETD {
+  using Ops = pfc::sim::SpectralETDOps<MemorySpace>;
 
 public:
-  using Complex = Ops::Complex;
-  using RealField = Ops::RealField;
-  using ComplexField = Ops::ComplexField;
-  using FFT = Ops::FFT;
+  using Complex = typename Ops::Complex;
+  using RealField = typename Ops::RealField;
+  using ComplexField = typename Ops::ComplexField;
+  using FFT = typename Ops::FFT;
+  using real_coeffs = typename Ops::real_coeffs;
+  using complex_scratch = typename Ops::complex_scratch;
 
   /**
    * @param domain grid geometry
@@ -207,27 +304,36 @@ public:
    * @param L      linear symbol as a function of \f$k_{\mathrm{lap}}\f$
    */
   FluxETD(const pfc::Domain &domain, FFT &fft, double dt,
-          const std::function<double(double)> &L)
+         const std::function<double(double)> &L)
       : m_fft(fft), m_dt(dt), m_flux(domain, fft),
         m_u_hat(domain, fft.get_outbox_bounds(), 0),
         m_p_hat(domain, fft.get_outbox_bounds(), 0),
         m_div_hat(domain, fft.get_outbox_bounds(), 0) {
     const std::size_t n = fft.size_outbox();
-    m_expL.assign(n, 1.0);
-    m_phi1.assign(n, dt);
-    m_L.assign(n, 0.0);
+    std::vector<double> expL(n, 1.0), phi1(n, dt), negL(n, 0.0), ones(n, 1.0);
     pfc::fft::kspace::for_each_kpoint(
         fft.get_outbox_bounds(), domain,
         [&](std::size_t i, double kx, double ky, double kz, int, int, int) {
           const double k_lap = -(kx * kx + ky * ky + kz * kz);
           const double l = L(k_lap);
-          m_L[i] = l;
+          negL[i] = -l;
           const double a = l * dt;
-          m_expL[i] = std::exp(a);
+          expL[i] = std::exp(a);
           // (e^a - 1)/l, by series where the quotient loses precision.
-          m_phi1[i] = (std::abs(a) < 1.0e-8) ? dt * (1.0 + 0.5 * a)
-                                             : (m_expL[i] - 1.0) / l;
+          phi1[i] = (std::abs(a) < 1.0e-8) ? dt * (1.0 + 0.5 * a)
+                                          : (expL[i] - 1.0) / l;
         });
+
+    m_expL = Ops::make_real(n);
+    m_phi1 = Ops::make_real(n);
+    m_negL = Ops::make_real(n);
+    m_ones = Ops::make_real(n);
+    Ops::upload(m_expL, std::span<const double>(expL));
+    Ops::upload(m_phi1, std::span<const double>(phi1));
+    Ops::upload(m_negL, std::span<const double>(negL));
+    Ops::upload(m_ones, std::span<const double>(ones));
+    m_nl_scratch = Ops::make_complex(n);
+    m_candidate = Ops::make_complex(n);
   }
 
   /**
@@ -237,18 +343,15 @@ public:
   double step(double t, RealField &u, Potential &&potential, Mobility &&mobility) {
     Ops::forward(m_fft, u, m_u_hat);
     potential(m_u_hat, u, m_p_hat);
-    m_flux.divergence(m_p_hat, u, mobility, m_div_hat);
+    m_flux.divergence(m_p_hat, u, std::forward<Mobility>(mobility), m_div_hat);
 
-    const std::size_t n = m_fft.size_outbox();
-    m_u_hat.with_host_view([&](Complex *uh, std::size_t) {
-      m_div_hat.with_host_view([&](Complex *div, std::size_t) {
-        for (std::size_t i = 0; i < n; ++i) {
-          // N = full flux divergence minus the part already carried by L.
-          const Complex nl = div[i] - m_L[i] * uh[i];
-          uh[i] = m_expL[i] * uh[i] + m_phi1[i] * nl;
-        }
-      });
-    });
+    // N = full flux divergence minus the part already carried by L:
+    //   nl_hat = div_hat - L * u_hat = (-L)*u_hat + 1*div_hat
+    Ops::combine(m_u_hat, m_div_hat, m_negL, m_ones, m_nl_scratch);
+    // candidate = exp(L dt) * u_hat + phi1(L dt) * nl_hat
+    Ops::combine(m_u_hat, m_nl_scratch, m_expL, m_phi1, m_candidate);
+    Ops::swap(m_u_hat, m_candidate);
+
     Ops::backward(m_fft, m_u_hat, u);
     return t + m_dt;
   }
@@ -258,9 +361,10 @@ public:
 private:
   FFT &m_fft;
   double m_dt;
-  SpectralFlux m_flux;
+  SpectralFlux<MemorySpace> m_flux;
   ComplexField m_u_hat, m_p_hat, m_div_hat;
-  std::vector<double> m_expL, m_phi1, m_L;
+  real_coeffs m_expL, m_phi1, m_negL, m_ones;
+  complex_scratch m_nl_scratch, m_candidate;
 };
 
 } // namespace pfc::apps

--- a/apps/thin_film/CMakeLists.txt
+++ b/apps/thin_film/CMakeLists.txt
@@ -38,7 +38,8 @@ thin_film_cpu_executable(thin_film src/thin_film.cpp)
 install(TARGETS thin_film DESTINATION bin)
 
 # Science driver for #114: full h^3 lubrication mobility through the shared
-# conservative flux stepper. Host only; the flux path has no device kernels.
+# conservative flux stepper (pfc::apps::SpectralFlux / FluxETD), templated on
+# MemorySpace -- host build here, HIP twin below.
 thin_film_cpu_executable(thin_film_nonlinear src/thin_film_nonlinear.cpp)
 install(TARGETS thin_film_nonlinear DESTINATION bin)
 
@@ -53,6 +54,10 @@ if(OpenPFC_ENABLE_HIP AND OpenPFC_HIP_AVAILABLE AND OpenPFC_ENABLE_HIP_SPECTRAL)
   thin_film_hip_executable(thin_film_hip src/hip/thin_film.cpp)
   install(TARGETS thin_film_hip DESTINATION bin)
   message(STATUS "thin_film_hip (MPI + HIP spectral) enabled")
+
+  thin_film_hip_executable(thin_film_nonlinear_hip src/hip/thin_film_nonlinear.cpp)
+  install(TARGETS thin_film_nonlinear_hip DESTINATION bin)
+  message(STATUS "thin_film_nonlinear_hip (MPI + HIP spectral flux) enabled")
   if(THIN_FILM_ENABLE_TESTS AND OpenPFC_BUILD_TESTS)
     include(CTest)
     add_test(NAME thin-film-hip-smoke

--- a/apps/thin_film/README.md
+++ b/apps/thin_film/README.md
@@ -9,10 +9,13 @@ Lubrication **dewetting / coating** of a periodic liquid film, integrated
 with spectral ETD. This is the 0.2 application for GitHub issue `#78`.
 
 Binaries: `thin_film` (CPU, linear verifier); `thin_film_nonlinear` (CPU, full
-`h^3` lubrication, spectral ETD); `thin_film_fd` (CPU, the same `h^3`
+`h^3` lubrication, spectral ETD, `#114`); `thin_film_fd` (CPU, the same `h^3`
 lubrication, conservative face-flux FD -- integrates *through* rupture where
 the two spectral solvers cannot, see "Two methods, one problem" below);
-`thin_film_hip` when `OpenPFC_ENABLE_HIP_SPECTRAL` is on.
+`thin_film_hip` / `thin_film_nonlinear_hip` when `OpenPFC_ENABLE_HIP_SPECTRAL`
+is on. The nonlinear flux path (`pfc::apps::SpectralFlux` / `FluxETD`) runs on
+host and device -- see
+[`spectral_flux.hpp`](../common/include/openpfc_apps/spectral_flux.hpp).
 
 ## Dewetting and rupture: problem setup
 
@@ -46,6 +49,11 @@ Because `M(h)` sits *inside* a divergence it cannot be written as a
 reciprocal-space symbol, so this case uses the shared conservative flux stepper
 [`openpfc_apps/spectral_flux.hpp`](../common/include/openpfc_apps/spectral_flux.hpp)
 rather than the pointwise ETD path — four extra transforms per step in 2-D.
+`SpectralFlux` / `FluxETD` are templated on `MemorySpace`, so `thin_film_nonlinear`
+(host) and `thin_film_nonlinear_hip` (device) run the identical physics; the
+mobility \(M(h)\) is evaluated on device with the same pointwise mechanism the
+\(\Pi\) remainder uses (`OPENPFC_INSTANTIATE_SPECTRAL_POINTWISE`, see
+`src/gpu/thin_film_pointwise.inc`).
 
 ### The disjoining pressure needs a precursor
 
@@ -330,11 +338,13 @@ The `h^3` lubrication science cases (`#114`, `#124`) take a different JSON
 shape (`domain.Lx`/`Ly`/`Lz`/`dx`, `model.params` adds `h_star`,
 `timestepping.t1`/`dt`/`saveat`, `initial_conditions.amplitude`/`seed`/
 `defect_amplitude`/`defect_sigma`, `diagnostics.csv`) and the same case file
-drives *either* binary:
+drives *any* of the three nonlinear binaries:
 
 ```bash
 mpirun -n 16 ./apps/thin_film/thin_film_nonlinear \
   ../apps/thin_film/inputs_json/thin_film_dewetting.json   # spectral, stops before rupture
+./apps/thin_film/thin_film_nonlinear_hip \
+  ../apps/thin_film/inputs_json/thin_film_dewetting.json   # same JSON, same observables, on device
 mpirun -n 16 ./apps/thin_film/thin_film_fd \
   ../apps/thin_film/inputs_json/thin_film_fd_dewetting.json  # FD, continues through it
 ```
@@ -355,8 +365,10 @@ mode decaying, and \(A=0\) leveling, plus the nonlinear/flux and FD suites
 conservation via `compute_rhs`, the linearized \(k^4\) decay and unstable
 growth rate, harmonic-vs-arithmetic positivity through a driven rupture, and
 FD-vs-spectral agreement on a controlled single-mode case. HIP builds add
-`HIP_ThinFilmETD` and `thin-film-hip-smoke`. LUMI-G smoke: job 21781449
-(`small-g`, 16², mean \(h=1\)).
+`HIP_ThinFilmETD` (constant-mobility session parity) and a nonlinear-flux
+HIP-vs-host parity case (`[thin_film][hip][nonlinear]`), plus
+`thin-film-hip-smoke`. LUMI-G smoke: job 21781449 (`small-g`, 16², mean
+\(h=1\)).
 
 ## Layout
 
@@ -365,13 +377,16 @@ FD-vs-spectral agreement on a controlled single-mode case. HIP builds add
 | `include/thin_film/thin_film_physics.hpp` | `SpectralETDPhysics` + schema |
 | `include/thin_film/thin_film_pointwise.hpp` | Device-capable \(\Pi\) remainder |
 | `include/thin_film/thin_film_session.hpp` | JSON session, field `h`, 2/3 dealias |
-| `include/thin_film/nonlinear.hpp` | `CubicMobility`, `sample_film`, `GaussianDefect` (shared by both nonlinear solvers) |
+| `include/thin_film/nonlinear.hpp` | `CubicMobility`, `PotentialPointwise`, `sample_film`, `GaussianDefect` (shared by all three nonlinear solvers) |
+| `include/thin_film/nonlinear_driver.hpp` | `MemorySpace`-templated `run_thin_film_nonlinear` (host and device) |
 | `include/thin_film/fd_flux.hpp` | Conservative face-flux FD solver: `FDFluxSolver`, `FaceMobility`, `sample_film_fd`, `count_dry_regions_rank0` |
 | `src/thin_film.cpp` / `src/hip/thin_film.cpp` | CPU / HIP `main` (linear verifier) |
-| `src/thin_film_nonlinear.cpp` | CPU `main`, spectral `h^3` lubrication |
+| `src/thin_film_nonlinear.cpp` / `src/hip/thin_film_nonlinear.cpp` | CPU / HIP `main`, spectral `h^3` lubrication |
 | `src/thin_film_fd.cpp` | CPU `main`, conservative FD `h^3` lubrication |
+| `src/gpu/thin_film_pointwise.{hip,inc}` | Device instantiations: \(\Pi\) remainder, \(\Pi(h)\), \(M(h)\cdot\nabla p\) |
 | `inputs_json/dewetting.json` | Unstable coating (linear verifier) |
 | `inputs_json/leveling.json` | \(A=0\) capillary smoothing (linear verifier) |
 | `inputs_json/thin_film_dewetting.json` / `thin_film_fd_dewetting.json` | Spontaneous dewetting, spectral / FD |
 | `inputs_json/thin_film_defect.json` / `thin_film_fd_defect.json` | Defect-triggered dewetting, spectral / FD |
+| `inputs_json/thin_film_dewetting_heroic.json` | Heroic-scale device run |
 | `slurm/fd_flagship.sbatch` | Reproduces the 512² FD through-rupture runs on `standard-g` |

--- a/apps/thin_film/include/thin_film/nonlinear.hpp
+++ b/apps/thin_film/include/thin_film/nonlinear.hpp
@@ -45,21 +45,42 @@
 
 #include <openpfc/kernel/data/domain.hpp>
 #include <openpfc/kernel/data/grid_field.hpp>
+#include <openpfc/kernel/data/host_device.hpp>
+#include <openpfc/kernel/execution/memory_space.hpp>
+#include <openpfc/kernel/simulation/spectral_pointwise.hpp>
 
 #include <thin_film/thin_film_pointwise.hpp>
 
 namespace thin_film {
 
 /// Cubic lubrication mobility, normalised so that \f$M(h_0)=M_0\f$.
+///
+/// Trivially copyable and `OPENPFC_HD` so it can run through
+/// `pfc::apps::MobilityGradPointwise` on host or device (see
+/// `apps/thin_film/src/gpu/thin_film_pointwise.inc`).
 struct CubicMobility {
   double M0{1.0};
   double h0{1.0};
   /// Films are clamped away from zero; a ruptured cell must not give M < 0.
   static constexpr double kMinH = 1.0e-6;
 
-  [[nodiscard]] double operator()(double h) const {
-    const double u = std::max(h, kMinH) / h0;
+  [[nodiscard]] OPENPFC_HD double operator()(double h) const {
+    const double u = (h > kMinH ? h : kMinH) / h0;
     return M0 * u * u * u;
+  }
+};
+
+/**
+ * @brief Device-capable adapter: \f$\Pi(h)\f$ as a `SpectralPointwise`
+ *        functor, for computing the full disjoining potential (not the
+ *        ETD remainder `ThinFilmPointwise::nonlinearity`).
+ */
+struct PotentialPointwise {
+  ThinFilmPointwise pw{};
+
+  [[nodiscard]] OPENPFC_HD double
+  nonlinearity(const pfc::sim::SpectralCell &cell) const {
+    return pw.Pi(cell.psi);
   }
 };
 
@@ -80,9 +101,10 @@ struct FilmSample {
  * @param rupture_frac rupture when `min_h < rupture_frac * h0`
  * @param comm         communicator to reduce over
  */
+template <class MemorySpace = pfc::HostSpace>
 [[nodiscard]] inline FilmSample
-sample_film(pfc::data::Field<double> &h, const pfc::Domain &domain, double h0,
-            double rupture_frac, MPI_Comm comm) {
+sample_film(pfc::data::Field<double, MemorySpace> &h, const pfc::Domain &domain,
+           double h0, double rupture_frac, MPI_Comm comm) {
   double lo = std::numeric_limits<double>::infinity(), hi = -lo;
   double local_sum = 0.0, local_holes = 0.0, local_cells = 0.0;
   h.with_host_view([&](const double *d, std::size_t n) {

--- a/apps/thin_film/include/thin_film/nonlinear_driver.hpp
+++ b/apps/thin_film/include/thin_film/nonlinear_driver.hpp
@@ -1,0 +1,282 @@
+// SPDX-FileCopyrightText: 2026 VTT Technical Research Centre of Finland Ltd
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+#pragma once
+
+/**
+ * @file nonlinear_driver.hpp
+ * @brief `MemorySpace`-templated body shared by `thin_film_nonlinear` (CPU)
+ *        and `thin_film_nonlinear_hip` (device).
+ *
+ * @details
+ * Dewetting and rupture with the full \f$h^3\f$ lubrication mobility, the
+ * science driver for `#114`. `thin_film` (the JSON-session binary) keeps the
+ * constant-mobility linear model as an analytical verifier; this one solves
+ *
+ * \f[
+ *   \partial_t h = \nabla\cdot\bigl[M(h)\nabla p\bigr],\qquad
+ *   p = -\gamma\nabla^2 h - \Pi(h),\qquad
+ *   M(h) = M_0 (h/h_0)^3 ,
+ * \f]
+ *
+ * and reports the observables a dewetting experiment would: rupture time,
+ * minimum thickness, hole area fraction, dominant spacing, and the liquid
+ * volume that must not change.
+ *
+ * The `MemorySpace`/`Stack` split keeps this file free of any GPU-specific
+ * `#include`: `run()` is instantiated with `pfc::HostSpace` +
+ * `pfc::sim::stacks::SpectralCPUStack` from `src/thin_film_nonlinear.cpp`,
+ * and with `pfc::HIPSpace` + `pfc::sim::stacks::GPUSpectralStack<HIPSpace>`
+ * from `src/hip/thin_film_nonlinear.cpp` — the caller's `main()` picks the
+ * stack and therefore the includes.
+ */
+
+#include <cmath>
+#include <complex>
+#include <cstdint>
+#include <cstdio>
+#include <filesystem>
+#include <fstream>
+#include <iomanip>
+#include <iostream>
+#include <locale>
+#include <memory>
+#include <span>
+#include <sstream>
+#include <string>
+#include <vector>
+
+#include <mpi.h>
+#include <nlohmann/json.hpp>
+
+#include <openpfc/kernel/data/domain.hpp>
+#include <openpfc/kernel/data/grid_field.hpp>
+#include <openpfc/kernel/fft/kspace_iterator.hpp>
+#include <openpfc/kernel/simulation/spectral_etd_ops.hpp>
+#include <openpfc/runtime/gpu/spectral_etd_ops_gpu.hpp>
+#include <openpfc_apps/spectral_flux.hpp>
+#include <openpfc_apps/structure_factor.hpp>
+
+#include <thin_film/nonlinear.hpp>
+#include <thin_film/thin_film_physics.hpp>
+
+namespace thin_film {
+
+namespace detail {
+
+/// Deterministic broadband perturbation, identical on any decomposition.
+inline double hashed_noise(int i, int j, int k, const pfc::Int3 &n,
+                           std::uint64_t seed) {
+  std::uint64_t x = seed + std::uint64_t(i) +
+                    std::uint64_t(n[0]) *
+                        (std::uint64_t(j) + std::uint64_t(n[1]) * std::uint64_t(k));
+  x += 0x9e3779b97f4a7c15ULL;
+  x = (x ^ (x >> 30)) * 0xbf58476d1ce4e5b9ULL;
+  x = (x ^ (x >> 27)) * 0x94d049bb133111ebULL;
+  x = x ^ (x >> 31);
+  return 2.0 * (double(x >> 11) / double(1ULL << 53)) - 1.0;
+}
+
+inline pfc::sim::PointwiseGeometry geometry_of(const pfc::Domain &domain,
+                                               const pfc::Box3i &box) {
+  const auto o = pfc::domain::get_origin(domain);
+  const auto s = pfc::domain::get_spacing(domain);
+  return pfc::sim::PointwiseGeometry{.nx = box.size[0],
+                                     .ny = box.size[1],
+                                     .nz = box.size[2],
+                                     .low_x = box.low[0],
+                                     .low_y = box.low[1],
+                                     .low_z = box.low[2],
+                                     .origin_x = o[0],
+                                     .origin_y = o[1],
+                                     .origin_z = o[2],
+                                     .dx = s[0],
+                                     .dy = s[1],
+                                     .dz = s[2]};
+}
+
+} // namespace detail
+
+/**
+ * @brief Parse @p json_path, run the nonlinear dewetting case, print
+ *        `THIN_FILM_NONLINEAR ...` on rank 0.
+ *
+ * @tparam MemorySpace `pfc::HostSpace`, `pfc::CUDASpace`, or `pfc::HIPSpace`.
+ * @tparam Stack       `pfc::sim::stacks::SpectralCPUStack` (host) or
+ *                     `pfc::sim::stacks::GPUSpectralStack<MemorySpace>`
+ *                     (device); must expose `.u()` and `.fft()`.
+ */
+template <class MemorySpace, class Stack>
+int run_thin_film_nonlinear(int rank, int nproc, MPI_Comm comm,
+                            const std::string &json_path) {
+  using Ops = pfc::sim::SpectralETDOps<MemorySpace>;
+  using RealField = typename Ops::RealField;
+  using ComplexField = typename Ops::ComplexField;
+  using real_coeffs = typename Ops::real_coeffs;
+  using complex_scratch = typename Ops::complex_scratch;
+  using json = nlohmann::json;
+
+  int status = 0;
+  try {
+    std::ifstream in(json_path);
+    if (!in) throw std::runtime_error("cannot open " + json_path);
+    json cfg = json::parse(in);
+
+    const auto &d = cfg.at("domain");
+    const int Lx = d.at("Lx"), Ly = d.at("Ly"), Lz = d.value("Lz", 1);
+    const double dx = d.value("dx", 1.0);
+    const auto domain = pfc::domain::create(pfc::GridSize({Lx, Ly, Lz}),
+                                            pfc::PhysicalOrigin({0.0, 0.0, 0.0}),
+                                            pfc::GridSpacing({dx, dx, dx}));
+
+    thin_film::ThinFilmParams p;
+    thin_film::apply_thin_film_json(cfg.at("model").at("params"), p);
+
+    const auto &ts = cfg.at("timestepping");
+    const double t1 = ts.at("t1"), dt = ts.at("dt"), saveat = ts.value("saveat", -1.0);
+
+    const auto &ic = cfg.at("initial_conditions");
+    const double amp = ic.value("amplitude", 0.01);
+    const std::uint64_t seed = ic.value("seed", 1234u);
+    const double defect_amp = ic.value("defect_amplitude", 0.0);
+    const double defect_sigma = ic.value("defect_sigma", 4.0);
+
+    Stack stack(domain, rank, nproc, comm);
+    auto &h = stack.u();
+
+    // One initial condition: mean film + broadband noise + optional defect.
+    // `Field::apply()` writes through `operator()`, which needs direct
+    // element access -- unavailable for a device buffer. `with_host_view` is
+    // the memory-space-agnostic way to write a field (see
+    // `SpectralETDSession::field_checksum` for the same pattern); origin is
+    // always (0,0,0) here, so the physical coordinate of local (i,j,k) is
+    // exactly `(box.low + (i,j,k)) * dx` -- the same integers the original
+    // `lround(x / dx)` round-trip recovered, computed directly instead.
+    const auto defect =
+        thin_film::GaussianDefect::centred(domain, defect_amp, defect_sigma);
+    const auto n = pfc::domain::get_size(domain);
+    {
+      const auto box = h.box();
+      h.with_host_view([&](double *d, std::size_t) {
+        for (int k = 0; k < box.size[2]; ++k) {
+          for (int j = 0; j < box.size[1]; ++j) {
+            for (int i = 0; i < box.size[0]; ++i) {
+              const int gi = box.low[0] + i;
+              const int gj = box.low[1] + j;
+              const int gk = box.low[2] + k;
+              const double x0 = static_cast<double>(gi) * dx;
+              const double x1 = static_cast<double>(gj) * dx;
+              const double xi = detail::hashed_noise(gi, gj, gk, n, seed);
+              d[h.idx(i, j, k)] = p.h0 * (1.0 + amp * xi + defect(x0, x1));
+            }
+          }
+        }
+      });
+    }
+
+    // ETD linear part: the constant-mobility operator about h0. The flux
+    // remainder carries everything the linearisation leaves out, so the
+    // nonlinear solver reduces to the linear one when M is constant.
+    const double gamma = p.gamma, M0 = p.M0, Pip0 = p.Pip0;
+    pfc::apps::FluxETD<MemorySpace> stepper(domain, stack.fft(), dt, [=](double k_lap) {
+      return -M0 * gamma * k_lap * k_lap - M0 * Pip0 * k_lap;
+    });
+
+    const thin_film::CubicMobility mobility{p.M0, p.h0};
+    const thin_film::ThinFilmPointwise pw{.A = p.A, .h0 = p.h0,
+                                          .h_star = p.h_star, .Pi0 = p.Pi0,
+                                          .Pip0 = p.Pip0};
+    const thin_film::PotentialPointwise potential_pw{pw};
+
+    // p_hat = -gamma * k_lap * h_hat - FFT(Pi(h))
+    RealField pi_real(domain, stack.fft().get_inbox_bounds(), 0);
+    ComplexField pi_hat(domain, stack.fft().get_outbox_bounds(), 0);
+    const std::size_t n_out = stack.fft().size_outbox();
+    std::vector<double> neg_gamma_klap(n_out, 0.0), neg_ones(n_out, -1.0);
+    pfc::fft::kspace::for_each_kpoint(
+        stack.fft().get_outbox_bounds(), domain,
+        [&](std::size_t i, double kx, double ky, double kz, int, int, int) {
+          const double k_lap = -(kx * kx + ky * ky + kz * kz);
+          neg_gamma_klap[i] = -gamma * k_lap;
+        });
+    real_coeffs neg_gamma_klap_dev = Ops::make_real(n_out);
+    real_coeffs neg_ones_dev = Ops::make_real(n_out);
+    Ops::upload(neg_gamma_klap_dev, std::span<const double>(neg_gamma_klap));
+    Ops::upload(neg_ones_dev, std::span<const double>(neg_ones));
+    complex_scratch p_scratch = Ops::make_complex(n_out);
+    const auto pw_geometry = detail::geometry_of(domain, h.box());
+
+    auto potential = [&](ComplexField &h_hat, RealField &hh, ComplexField &out) {
+      // pi_real = Pi(h)
+      Ops::pointwise(pw_geometry, 0.0, hh, nullptr, nullptr, pi_real, nullptr,
+                     potential_pw);
+      Ops::forward(stack.fft(), pi_real, pi_hat);
+      // out = (-gamma * k_lap) * h_hat + (-1) * pi_hat
+      Ops::combine(h_hat, pi_hat, neg_gamma_klap_dev, neg_ones_dev, p_scratch);
+      Ops::swap(out, p_scratch);
+    };
+
+    // Diagnostics CSV, rank 0, never overwriting.
+    std::unique_ptr<std::FILE, int (*)(std::FILE *)> out(nullptr, std::fclose);
+    if (rank == 0 && cfg.contains("diagnostics")) {
+      const std::filesystem::path path =
+          cfg.at("diagnostics").at("csv").get<std::string>();
+      if (path.has_parent_path())
+        std::filesystem::create_directories(path.parent_path());
+      out.reset(std::fopen(path.string().c_str(), "w"));
+      if (!out) throw std::runtime_error("cannot open diagnostics csv");
+      std::fprintf(out.get(),
+                   "step,time,min_h,max_h,mean_h,volume,hole_area_fraction,"
+                   "dominant_spacing,ruptured\n");
+    }
+
+    double rupture_time = -1.0;
+    const int n_steps = int(std::llround(t1 / dt));
+    const int every =
+        (saveat > 0.0) ? std::max(1, int(std::llround(saveat / dt))) : n_steps;
+
+    auto report = [&](int step, double t) {
+      auto s = thin_film::sample_film(h, domain, p.h0, 0.05, comm);
+      ComplexField hh(domain, stack.fft().get_outbox_bounds(), 0);
+      Ops::forward(stack.fft(), h, hh);
+      hh.with_host_view([&](std::complex<double> *hv, std::size_t) {
+        const auto sf = pfc::apps::shell_average(stack.fft().get_outbox_bounds(),
+                                                 domain, hv, comm, 64);
+        s.dominant_spacing = sf.dominant_wavelength();
+      });
+      if (s.ruptured && rupture_time < 0.0) rupture_time = t;
+      if (out) {
+        std::ostringstream line;
+        line.imbue(std::locale::classic());
+        line << std::setprecision(17) << step << ',' << t << ',' << s.min_h << ','
+             << s.max_h << ',' << s.mean_h << ',' << s.volume << ','
+             << s.hole_area_fraction << ',' << s.dominant_spacing << ','
+             << (s.ruptured ? 1 : 0) << '\n';
+        std::fputs(line.str().c_str(), out.get());
+        std::fflush(out.get());
+      }
+    };
+
+    report(0, 0.0);
+    double t = 0.0;
+    for (int step = 1; step <= n_steps; ++step) {
+      t = stepper.step(t, h, potential, mobility);
+      if (step % every == 0 || step == n_steps) report(step, t);
+    }
+
+    if (rank == 0) {
+      auto s = thin_film::sample_film(h, domain, p.h0, 0.05, comm);
+      std::printf("THIN_FILM_NONLINEAR min_h=%.17g volume=%.17g "
+                  "hole_fraction=%.17g rupture_time=%.17g\n",
+                  s.min_h, s.volume, s.hole_area_fraction, rupture_time);
+    } else {
+      (void)thin_film::sample_film(h, domain, p.h0, 0.05, comm);
+    }
+  } catch (const std::exception &e) {
+    if (rank == 0) std::cerr << "thin_film_nonlinear: " << e.what() << "\n";
+    status = 2;
+  }
+  return status;
+}
+
+} // namespace thin_film

--- a/apps/thin_film/inputs_json/thin_film_dewetting_heroic.json
+++ b/apps/thin_film/inputs_json/thin_film_dewetting_heroic.json
@@ -1,0 +1,32 @@
+{
+    "model": {
+        "name": "thin_film",
+        "params": {
+            "h0": 1.0,
+            "gamma": 1.0,
+            "M0": 1.0,
+            "A": 8.6022,
+            "h_star": 0.15
+        }
+    },
+    "domain": {
+        "Lx": 4096,
+        "Ly": 4096,
+        "Lz": 1,
+        "dx": 0.5
+    },
+    "timestepping": {
+        "t1": 140.0,
+        "dt": 0.002,
+        "saveat": 5.0
+    },
+    "initial_conditions": {
+        "amplitude": 0.01,
+        "seed": 2024,
+        "defect_amplitude": 0.0,
+        "defect_sigma": 3.0
+    },
+    "diagnostics": {
+        "csv": "diagnostics.csv"
+    }
+}

--- a/apps/thin_film/inputs_json/thin_film_dewetting_heroic.json.license
+++ b/apps/thin_film/inputs_json/thin_film_dewetting_heroic.json.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: 2026 VTT Technical Research Centre of Finland Ltd
+SPDX-License-Identifier: AGPL-3.0-or-later

--- a/apps/thin_film/src/gpu/thin_film_pointwise.inc
+++ b/apps/thin_film/src/gpu/thin_film_pointwise.inc
@@ -3,10 +3,23 @@
 
 /**
  * @file thin_film_pointwise.inc
- * @brief Device instantiation of thin-film pointwise Π remainder.
+ * @brief Device instantiations for thin-film pointwise/flux kernels.
+ *
+ * Three functors, one device translation unit each links into:
+ *  - `ThinFilmPointwise`        — the ETD remainder used by `thin_film`
+ *    (JSON session, constant mobility);
+ *  - `PotentialPointwise`       — the full disjoining pressure \f$\Pi(h)\f$,
+ *    used by `thin_film_nonlinear[_hip]`'s potential evaluation;
+ *  - `pfc::apps::MobilityGradPointwise<CubicMobility>` — the fused
+ *    \f$M(h)\cdot\nabla p\f$ kernel behind `pfc::apps::SpectralFlux`.
  */
 
 #include <openpfc/runtime/gpu/spectral_pointwise_gpu.hpp>
+#include <openpfc_apps/spectral_flux.hpp>
+#include <thin_film/nonlinear.hpp>
 #include <thin_film/thin_film_pointwise.hpp>
 
 OPENPFC_INSTANTIATE_SPECTRAL_POINTWISE(thin_film::ThinFilmPointwise)
+OPENPFC_INSTANTIATE_SPECTRAL_POINTWISE(thin_film::PotentialPointwise)
+OPENPFC_INSTANTIATE_SPECTRAL_POINTWISE(
+    pfc::apps::MobilityGradPointwise<thin_film::CubicMobility>)

--- a/apps/thin_film/src/hip/thin_film_nonlinear.cpp
+++ b/apps/thin_film/src/hip/thin_film_nonlinear.cpp
@@ -1,0 +1,46 @@
+// SPDX-FileCopyrightText: 2026 VTT Technical Research Centre of Finland Ltd
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+/**
+ * @file thin_film_nonlinear.cpp
+ * @brief `thin_film_nonlinear_hip` main: `run_thin_film_nonlinear` on HIP.
+ *
+ * Same JSON schema and observables as `thin_film_nonlinear`; see
+ * `thin_film/nonlinear_driver.hpp` for the shared, `MemorySpace`-templated
+ * physics and `apps/thin_film/src/gpu/thin_film_pointwise.inc` for the device
+ * instantiations (`ThinFilmPointwise`, `PotentialPointwise`, and
+ * `pfc::apps::MobilityGradPointwise<CubicMobility>`) this binary links
+ * against.
+ */
+
+#if !defined(OpenPFC_ENABLE_HIP_SPECTRAL)
+#error "thin_film_nonlinear_hip requires HIP spectral support (rocFFT HeFFTe)"
+#endif
+
+#include <iostream>
+#include <stdexcept>
+
+#include <mpi.h>
+
+#include <openpfc/runtime/gpu/gpu_spectral_stack.hpp>
+#include <thin_film/nonlinear_driver.hpp>
+
+int main(int argc, char *argv[]) {
+  MPI_Init(&argc, &argv);
+  int rank = 0, nproc = 1;
+  MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+  MPI_Comm_size(MPI_COMM_WORLD, &nproc);
+  int status = 0;
+  try {
+    if (argc != 2)
+      throw std::invalid_argument("usage: thin_film_nonlinear_hip CASE.json");
+    status = thin_film::run_thin_film_nonlinear<
+        pfc::HIPSpace, pfc::sim::stacks::GPUSpectralStack<pfc::HIPSpace>>(
+        rank, nproc, MPI_COMM_WORLD, argv[1]);
+  } catch (const std::exception &e) {
+    if (rank == 0) std::cerr << "thin_film_nonlinear_hip: " << e.what() << "\n";
+    status = 2;
+  }
+  MPI_Finalize();
+  return status;
+}

--- a/apps/thin_film/src/thin_film_nonlinear.cpp
+++ b/apps/thin_film/src/thin_film_nonlinear.cpp
@@ -3,68 +3,19 @@
 
 /**
  * @file thin_film_nonlinear.cpp
- * @brief Dewetting and rupture with the full \f$h^3\f$ lubrication mobility.
+ * @brief `thin_film_nonlinear` main: `run_thin_film_nonlinear` on the host.
  *
- * The science driver for `#114`. The JSON-session binary `thin_film` keeps the
- * constant-mobility linear model as an analytical verifier; this one solves
- *
- * \f[
- *   \partial_t h = \nabla\cdot\bigl[M(h)\nabla p\bigr],\qquad
- *   p = -\gamma\nabla^2 h - \Pi(h),\qquad
- *   M(h) = M_0 (h/h_0)^3 ,
- * \f]
- *
- * and reports the observables a dewetting experiment would: rupture time,
- * minimum thickness, hole area fraction, dominant spacing, and the liquid
- * volume that must not change.
- *
- * Usage: `thin_film_nonlinear CASE.json`
+ * Usage: `thin_film_nonlinear CASE.json`. See `thin_film/nonlinear_driver.hpp`
+ * for the physics and `src/hip/thin_film_nonlinear.cpp` for the device twin.
  */
 
-#include <cmath>
-#include <complex>
-#include <cstdint>
-#include <cstdio>
-#include <filesystem>
-#include <fstream>
-#include <memory>
-#include <vector>
-#include <iomanip>
 #include <iostream>
-#include <locale>
-#include <sstream>
-#include <string>
+#include <stdexcept>
 
 #include <mpi.h>
-#include <nlohmann/json.hpp>
 
-#include <openpfc/kernel/data/domain.hpp>
-#include <openpfc/kernel/data/grid_field.hpp>
-#include <openpfc/kernel/fft/kspace_iterator.hpp>
 #include <openpfc/kernel/simulation/stacks/spectral_cpu_stack.hpp>
-#include <openpfc_apps/spectral_flux.hpp>
-#include <openpfc_apps/structure_factor.hpp>
-
-#include <thin_film/nonlinear.hpp>
-#include <thin_film/thin_film_physics.hpp>
-
-namespace {
-
-using json = nlohmann::json;
-
-/// Deterministic broadband perturbation, identical on any decomposition.
-double hashed_noise(int i, int j, int k, const pfc::Int3 &n, std::uint64_t seed) {
-  std::uint64_t x = seed + std::uint64_t(i) +
-                    std::uint64_t(n[0]) *
-                        (std::uint64_t(j) + std::uint64_t(n[1]) * std::uint64_t(k));
-  x += 0x9e3779b97f4a7c15ULL;
-  x = (x ^ (x >> 30)) * 0xbf58476d1ce4e5b9ULL;
-  x = (x ^ (x >> 27)) * 0x94d049bb133111ebULL;
-  x = x ^ (x >> 31);
-  return 2.0 * (double(x >> 11) / double(1ULL << 53)) - 1.0;
-}
-
-} // namespace
+#include <thin_film/nonlinear_driver.hpp>
 
 int main(int argc, char *argv[]) {
   MPI_Init(&argc, &argv);
@@ -75,147 +26,9 @@ int main(int argc, char *argv[]) {
   try {
     if (argc != 2)
       throw std::invalid_argument("usage: thin_film_nonlinear CASE.json");
-    std::ifstream in(argv[1]);
-    if (!in) throw std::runtime_error(std::string("cannot open ") + argv[1]);
-    json cfg = json::parse(in);
-
-    const auto &d = cfg.at("domain");
-    const int Lx = d.at("Lx"), Ly = d.at("Ly"), Lz = d.value("Lz", 1);
-    const double dx = d.value("dx", 1.0);
-    const auto domain = pfc::domain::create(pfc::GridSize({Lx, Ly, Lz}),
-                                            pfc::PhysicalOrigin({0.0, 0.0, 0.0}),
-                                            pfc::GridSpacing({dx, dx, dx}));
-
-    thin_film::ThinFilmParams p;
-    thin_film::apply_thin_film_json(cfg.at("model").at("params"), p);
-
-    const auto &ts = cfg.at("timestepping");
-    const double t1 = ts.at("t1"), dt = ts.at("dt"), saveat = ts.value("saveat", -1.0);
-
-    const auto &ic = cfg.at("initial_conditions");
-    const double amp = ic.value("amplitude", 0.01);
-    const std::uint64_t seed = ic.value("seed", 1234u);
-    const double defect_amp = ic.value("defect_amplitude", 0.0);
-    const double defect_sigma = ic.value("defect_sigma", 4.0);
-
-    pfc::sim::stacks::SpectralCPUStack stack(domain, rank, nproc, MPI_COMM_WORLD);
-    auto &h = stack.u();
-
-    // One initial condition: mean film + broadband noise + optional defect.
-    const auto defect =
-        thin_film::GaussianDefect::centred(domain, defect_amp, defect_sigma);
-    const auto n = pfc::domain::get_size(domain);
-    const auto box = h.box();
-    h.apply([&](const pfc::Real3 &x) {
-      const int i = int(std::lround(x[0] / dx));
-      const int j = int(std::lround(x[1] / dx));
-      const int k = int(std::lround(x[2] / dx));
-      const double xi = hashed_noise(i, j, k, n, seed);
-      return p.h0 * (1.0 + amp * xi + defect(x[0], x[1]));
-    });
-    (void)box;
-
-    // ETD linear part: the constant-mobility operator about h0. The flux
-    // remainder carries everything the linearisation leaves out, so the
-    // nonlinear solver reduces to the linear one when M is constant.
-    const double gamma = p.gamma, M0 = p.M0, Pip0 = p.Pip0;
-    pfc::apps::FluxETD stepper(domain, stack.fft(), dt, [=](double k_lap) {
-      return -M0 * gamma * k_lap * k_lap - M0 * Pip0 * k_lap;
-    });
-
-    const thin_film::CubicMobility mobility{p.M0, p.h0};
-    const thin_film::ThinFilmPointwise pw{.A = p.A, .h0 = p.h0,
-                                          .h_star = p.h_star, .Pi0 = p.Pi0,
-                                          .Pip0 = p.Pip0};
-
-    // p_hat = -gamma * k_lap * h_hat - FFT(Pi(h))
-    pfc::data::Field<double> pi_real(domain, stack.fft().get_inbox_bounds(), 0);
-    pfc::data::Field<std::complex<double>> pi_hat(
-        domain, stack.fft().get_outbox_bounds(), 0);
-    std::vector<double> k_lap(stack.fft().size_outbox(), 0.0);
-    pfc::fft::kspace::for_each_kpoint(
-        stack.fft().get_outbox_bounds(), domain,
-        [&](std::size_t i, double kx, double ky, double kz, int, int, int) {
-          k_lap[i] = -(kx * kx + ky * ky + kz * kz);
-        });
-
-    auto potential = [&](pfc::data::Field<std::complex<double>> &h_hat,
-                         pfc::data::Field<double> &hh,
-                         pfc::data::Field<std::complex<double>> &out) {
-      hh.with_host_view([&](double *hv, std::size_t cnt) {
-        pi_real.with_host_view([&](double *pv, std::size_t) {
-          for (std::size_t i = 0; i < cnt; ++i) pv[i] = pw.Pi(hv[i]);
-        });
-      });
-      pfc::sim::SpectralETDOps<pfc::HostSpace>::forward(stack.fft(), pi_real,
-                                                        pi_hat);
-      h_hat.with_host_view([&](std::complex<double> *hv, std::size_t m) {
-        pi_hat.with_host_view([&](std::complex<double> *pv, std::size_t) {
-          out.with_host_view([&](std::complex<double> *o, std::size_t) {
-            for (std::size_t i = 0; i < m; ++i)
-              o[i] = -gamma * k_lap[i] * hv[i] - pv[i];
-          });
-        });
-      });
-    };
-
-    // Diagnostics CSV, rank 0, never overwriting.
-    std::unique_ptr<std::FILE, int (*)(std::FILE *)> out(nullptr, std::fclose);
-    if (rank == 0 && cfg.contains("diagnostics")) {
-      const std::filesystem::path path =
-          cfg.at("diagnostics").at("csv").get<std::string>();
-      if (path.has_parent_path())
-        std::filesystem::create_directories(path.parent_path());
-      out.reset(std::fopen(path.string().c_str(), "w"));
-      if (!out) throw std::runtime_error("cannot open diagnostics csv");
-      std::fprintf(out.get(),
-                   "step,time,min_h,max_h,mean_h,volume,hole_area_fraction,"
-                   "dominant_spacing,ruptured\n");
-    }
-
-    double rupture_time = -1.0;
-    const int n_steps = int(std::llround(t1 / dt));
-    const int every =
-        (saveat > 0.0) ? std::max(1, int(std::llround(saveat / dt))) : n_steps;
-
-    auto report = [&](int step, double t) {
-      auto s = thin_film::sample_film(h, domain, p.h0, 0.05, MPI_COMM_WORLD);
-      pfc::data::Field<std::complex<double>> hh(
-          domain, stack.fft().get_outbox_bounds(), 0);
-      pfc::sim::SpectralETDOps<pfc::HostSpace>::forward(stack.fft(), h, hh);
-      hh.with_host_view([&](std::complex<double> *hv, std::size_t) {
-        const auto sf = pfc::apps::shell_average(stack.fft().get_outbox_bounds(),
-                                                 domain, hv, MPI_COMM_WORLD, 64);
-        s.dominant_spacing = sf.dominant_wavelength();
-      });
-      if (s.ruptured && rupture_time < 0.0) rupture_time = t;
-      if (out) {
-        std::ostringstream line;
-        line.imbue(std::locale::classic());
-        line << std::setprecision(17) << step << ',' << t << ',' << s.min_h << ','
-             << s.max_h << ',' << s.mean_h << ',' << s.volume << ','
-             << s.hole_area_fraction << ',' << s.dominant_spacing << ','
-             << (s.ruptured ? 1 : 0) << '\n';
-        std::fputs(line.str().c_str(), out.get());
-        std::fflush(out.get());
-      }
-    };
-
-    report(0, 0.0);
-    double t = 0.0;
-    for (int step = 1; step <= n_steps; ++step) {
-      t = stepper.step(t, h, potential, mobility);
-      if (step % every == 0 || step == n_steps) report(step, t);
-    }
-
-    if (rank == 0) {
-      auto s = thin_film::sample_film(h, domain, p.h0, 0.05, MPI_COMM_WORLD);
-      std::printf("THIN_FILM_NONLINEAR min_h=%.17g volume=%.17g "
-                  "hole_fraction=%.17g rupture_time=%.17g\n",
-                  s.min_h, s.volume, s.hole_area_fraction, rupture_time);
-    } else {
-      (void)thin_film::sample_film(h, domain, p.h0, 0.05, MPI_COMM_WORLD);
-    }
+    status = thin_film::run_thin_film_nonlinear<pfc::HostSpace,
+                                                pfc::sim::stacks::SpectralCPUStack>(
+        rank, nproc, MPI_COMM_WORLD, argv[1]);
   } catch (const std::exception &e) {
     if (rank == 0) std::cerr << "thin_film_nonlinear: " << e.what() << "\n";
     status = 2;

--- a/apps/thin_film/tests/test_thin_film_gpu.cpp
+++ b/apps/thin_film/tests/test_thin_film_gpu.cpp
@@ -9,7 +9,12 @@
 #include "test_helpers.hpp"
 
 #include <algorithm>
+#include <array>
 #include <cmath>
+#include <cstdlib>
+#include <fstream>
+#include <sstream>
+#include <string>
 #include <vector>
 
 #include <catch2/catch_session.hpp>
@@ -17,6 +22,9 @@
 #include <mpi.h>
 #include <nlohmann/json.hpp>
 
+#include <openpfc/kernel/simulation/stacks/spectral_cpu_stack.hpp>
+#include <openpfc/runtime/gpu/gpu_spectral_stack.hpp>
+#include <thin_film/nonlinear_driver.hpp>
 #include <thin_film/thin_film_session.hpp>
 
 using nlohmann::json;
@@ -53,6 +61,44 @@ double max_abs_diff(const std::vector<double> &a, const double *b, std::size_t n
   return m;
 }
 
+std::string tmp_dir() {
+  const char *t = std::getenv("TMPDIR");
+  return (t != nullptr && *t != '\0') ? std::string(t) : std::string("/tmp");
+}
+
+/// Last non-empty row of a `thin_film_nonlinear` diagnostics CSV, as
+/// `{min_h, volume, hole_area_fraction, dominant_spacing}`.
+std::array<double, 4> last_csv_row(const std::string &path) {
+  std::ifstream in(path);
+  REQUIRE(in.good());
+  std::string line, last;
+  while (std::getline(in, line)) {
+    if (!line.empty()) last = line;
+  }
+  REQUIRE(!last.empty());
+  std::stringstream ss(last);
+  std::string cell;
+  std::vector<std::string> cells;
+  while (std::getline(ss, cell, ',')) cells.push_back(cell);
+  REQUIRE(cells.size() == 9);
+  return {std::stod(cells[2]), std::stod(cells[5]), std::stod(cells[6]),
+          std::stod(cells[7])};
+}
+
+nlohmann::json nonlinear_mini_settings(const std::string &csv_path) {
+  return {{"domain", {{"Lx", 32}, {"Ly", 32}, {"Lz", 1}, {"dx", 1.0}}},
+          {"model",
+           {{"params",
+             {{"h0", 1.0},
+              {"gamma", 1.0},
+              {"M0", 1.0},
+              {"A", 0.05},
+              {"h_star", 0.2}}}}},
+          {"timestepping", {{"t1", 0.5}, {"dt", 0.01}, {"saveat", -1.0}}},
+          {"initial_conditions", {{"amplitude", 0.02}, {"seed", 7}}},
+          {"diagnostics", {{"csv", csv_path}}}};
+}
+
 } // namespace
 
 TEST_CASE("ThinFilmHIPSession matches host within 1e-10",
@@ -77,6 +123,53 @@ TEST_CASE("ThinFilmHIPSession matches host within 1e-10",
     REQUIRE(n == h_h.size());
     REQUIRE(max_abs_diff(h_h, d, n) < 1e-10);
   });
+}
+
+TEST_CASE("thin_film_nonlinear HIP matches host dewetting observables",
+          "[thin_film][hip][nonlinear]") {
+  if (!pfc::gpu::test::is_hip_available()) {
+    SKIP("HIP not available");
+  }
+  int rank = 0;
+  int nproc = 1;
+  MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+  MPI_Comm_size(MPI_COMM_WORLD, &nproc);
+
+  const std::string dir = tmp_dir();
+  const std::string json_path = dir + "/thin_film_nonlinear_hip_test.json";
+  const std::string host_csv = dir + "/thin_film_nonlinear_hip_test_host.csv";
+  const std::string dev_csv = dir + "/thin_film_nonlinear_hip_test_dev.csv";
+
+  auto write_case = [&](const std::string &csv) {
+    if (rank == 0) {
+      std::ofstream(json_path) << nonlinear_mini_settings(csv).dump();
+    }
+    MPI_Barrier(MPI_COMM_WORLD);
+  };
+
+  write_case(host_csv);
+  const int rc_host =
+      thin_film::run_thin_film_nonlinear<pfc::HostSpace,
+                                         pfc::sim::stacks::SpectralCPUStack>(
+          rank, nproc, MPI_COMM_WORLD, json_path);
+  REQUIRE(rc_host == 0);
+
+  write_case(dev_csv);
+  const int rc_dev = thin_film::run_thin_film_nonlinear<
+      pfc::HIPSpace, pfc::sim::stacks::GPUSpectralStack<pfc::HIPSpace>>(
+      rank, nproc, MPI_COMM_WORLD, json_path);
+  REQUIRE(rc_dev == 0);
+
+  if (rank == 0) {
+    const auto h = last_csv_row(host_csv);
+    const auto d = last_csv_row(dev_csv);
+    // rocFFT vs FFTW round differently, so this is a tolerance, not the
+    // bit-identical guarantee the framework gives host-vs-host.
+    for (std::size_t i = 0; i < h.size(); ++i) {
+      const double scale = std::max(1.0, std::abs(h[i]));
+      CHECK(std::abs(h[i] - d[i]) < 1.0e-6 * scale);
+    }
+  }
 }
 
 int main(int argc, char *argv[]) {

--- a/apps/thin_film/tests/thin_film_nonlinear_cpu_gpu.json
+++ b/apps/thin_film/tests/thin_film_nonlinear_cpu_gpu.json
@@ -1,0 +1,32 @@
+{
+    "model": {
+        "name": "thin_film",
+        "params": {
+            "h0": 1.0,
+            "gamma": 1.0,
+            "M0": 1.0,
+            "A": 8.6022,
+            "h_star": 0.15
+        }
+    },
+    "domain": {
+        "Lx": 128,
+        "Ly": 128,
+        "Lz": 1,
+        "dx": 0.5
+    },
+    "timestepping": {
+        "t1": 20.0,
+        "dt": 0.002,
+        "saveat": 5.0
+    },
+    "initial_conditions": {
+        "amplitude": 0.01,
+        "seed": 2024,
+        "defect_amplitude": 0.0,
+        "defect_sigma": 3.0
+    },
+    "diagnostics": {
+        "csv": "results/nonlinear_cpu_gpu_check/diagnostics.csv"
+    }
+}

--- a/apps/thin_film/tests/thin_film_nonlinear_cpu_gpu.json.license
+++ b/apps/thin_film/tests/thin_film_nonlinear_cpu_gpu.json.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: 2026 VTT Technical Research Centre of Finland Ltd
+SPDX-License-Identifier: AGPL-3.0-or-later


### PR DESCRIPTION
## Summary

- Templates `pfc::apps::SpectralFlux` and `pfc::apps::FluxETD` (`apps/common/include/openpfc_apps/spectral_flux.hpp`) on `MemorySpace`, routing every elementwise step -- the complex `i*k_d` gradient, the Orszag 2/3 dealias mask, and the ETD1 combine -- through `pfc::sim::SpectralETDOps<MemorySpace>` instead of raw `with_host_view` loops. The device `Ops::combine` already had a **complex**-coefficient overload with real CUDA/HIP kernels behind it (`combine_two_term_{cuda,hip}_impl`); the file's previous "host only, no device kernels exist" claim was wrong and is now corrected.
- The remaining piece -- the real-space mobility `M(u)` -- is evaluated on device with the same `OPENPFC_INSTANTIATE_SPECTRAL_POINTWISE` mechanism physics nonlinearities already use, fused with the gradient multiply into one kernel launch via a new adapter, `pfc::apps::MobilityGradPointwise<Mobility>` (repurposes the pointwise functor's unused mean-field slot to carry the gradient).
- New `thin_film_nonlinear_hip` binary: same JSON schema and observables as `thin_film_nonlinear`, gated on `OpenPFC_ENABLE_HIP AND OpenPFC_HIP_AVAILABLE AND OpenPFC_ENABLE_HIP_SPECTRAL`. The previously CPU-only nonlinear driver (`thin_film_nonlinear.cpp`) is split into a `MemorySpace`-templated `run_thin_film_nonlinear()` (`thin_film/nonlinear_driver.hpp`) shared by the CPU and HIP `main`s.
- `thin_film::CubicMobility` and a new `thin_film::PotentialPointwise` (full `Pi(h)`, as opposed to the existing ETD-remainder `ThinFilmPointwise`) are made device-capable (`OPENPFC_HD`, trivially copyable) and instantiated for device in `apps/thin_film/src/gpu/thin_film_pointwise.inc`.
- New HIP-vs-host parity `ctest` case in `test_thin_film_gpu.cpp` (`[thin_film][hip][nonlinear]`), alongside the existing constant-mobility session-parity case.
- Docs: `spectral_flux.hpp`'s "Scope" section and `apps/thin_film/README.md` now describe the real state (runs on host and device); CMake comment updated.
- CHANGELOG entry with the measured numbers below.

The host arithmetic is unchanged: every `Ops::combine`/`multiply`/`pointwise` call reproduces the exact same operand order as the original raw loops (reasoned through term by term; IEEE-754 multiplication/addition are exactly order-independent for the specific reorderings involved), and the existing CPU tests (`thin-film-all-tests`, `ehd-film-all-tests`, and the rest of the suite) pass unchanged after a full rebuild.

Note: `apps/ehd_film` (landed on `master` concurrently, also using `pfc::apps::FluxETD`/`SpectralFlux` with no explicit `MemorySpace`) keeps compiling: since `MemorySpace` only appears nested inside `Ops::FFT`, class-template-argument deduction cannot deduce it from the constructor arguments in either app, so the class template's default (`pfc::HostSpace`) applies in both -- verified by a full CPU and HIP rebuild after rebasing onto the latest `master`.

## CPU vs GPU agreement (acceptance test)

Small dewetting case (128x128, `dx=0.5`, `A=8.6022`, `h_star=0.15`, `dt=0.002`, `t1=20` -> 10000 steps), run on both:

| Path | min_h | volume |
|---|---|---|
| CPU (FFTW) | `0.96958640466611135` | `2048.0040162697351` |
| GPU (rocFFT, HIP, 1 GCD) | `0.96958640466626422` | `2048.0040162697442` |
| relative difference | `1.6e-13` | `4.4e-15` |

Both at round-off, consistent with FFTW-vs-rocFFT floating-point differences rather than a numerical discrepancy. Also green: the existing `HIP_ThinFilmETD` ctest (constant-mobility session parity, unaffected) and the new nonlinear-flux HIP-vs-host parity case, plus `thin-film-hip-smoke`. LUMI job `21856789` (`dev-g`, 2 GCDs).

## Heroic run

Spontaneous-dewetting preset (`h0=1, gamma=1, M0=1, A=8.6022, h*=0.15`, same physics as the validated 512^2 preset) at **4096x4096** (`dx=0.5`; physical domain 2048x2048, ~128 fastest-growing wavelengths per side -- 64x the validated case's area), on **16 GCDs** (2 `standard-g` nodes, 8 GCDs/node), submitted as a batch job (not the shared interactive allocation): **LUMI job `21857011`**.

`t1=140`, `dt=0.002` (70000 steps), **2333.6 s wall time (33.3 ms/step)**.

- Volume conserved to a relative `1.5e-14` through the physically valid window (`t=0` to `t=125`).
- Precursor reached (`min_h < h* = 0.15`) at `t=115` (`min_h=0.133`) -- earlier than the 512^2 case's `t=140`, consistent with more independent nucleation sites racing to rupture first over 64x the area.
- The run then hits the documented, out-of-scope divergence near `min_h ~ 0.6 h*` around `t=130`-`135` (matches the known limitation: "neither smaller dt nor finer dx moves the breakdown point" -- confirmed here at a resolution/domain size the CPU verifier never exercised). This is the pre-existing physics/scheme limitation described in the `thin_film` README, not a GPU-path defect; it is explicitly out of scope for this PR.

An earlier short calibration run (1000 steps, same mesh/GCD count) measured 80.4 s wall time (dominated by one-time FFT-plan/decomposition setup, which amortizes over the full run above); job `21856816`.

## Deferred / out of scope

- Integrating through rupture (degenerate `h^3` mobility, no positivity preservation) -- a known, separately-tracked limitation, not attempted here.
- `apps/ehd_film`'s own GPU build is untouched by this PR; it inherits the templated `SpectralFlux`/`FluxETD` for free on the host path (see note above) but has no HIP twin yet.

## Test plan

- [x] `ctest -R "thin-film|ehd-film"` (CPU, LUMI login node): all green.
- [x] Full CPU rebuild (`OpenPFC_BUILD_TESTS=ON`) after rebasing onto latest `master`: passes, including `ehd_film` and `higher_order_pfc`.
- [x] Full HIP rebuild (`--with-rocm`) after rebasing: passes.
- [x] `HIP_ThinFilmETD` ctest (session parity + new nonlinear-flux parity) and `thin-film-hip-smoke`: pass on `dev-g` (job `21856789`).
- [x] CPU-vs-GPU small-case agreement measured directly (see table above).
- [x] Heroic run completed on `standard-g`, 16 GCDs (job `21857011`).

GitHub Actions CI is currently red repository-wide at the `apt-get` step (unrelated to this change); verification was done on LUMI directly, as above.

Merge by **rebase**, not squash.
