### PR TITLE
fix(ci): stop a third-party apt repository from failing every workflow

### DIFF
--- a/.github/workflows/asan.yml
+++ b/.github/workflows/asan.yml
@@ -35,7 +35,7 @@ jobs:
 
       - name: Install dependencies (Ubuntu)
         run: |
-          sudo apt-get update
+          bash scripts/ci/apt_update.sh
           sudo apt-get install -y \
             gcc-13 \
             g++-13 \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,7 @@ jobs:
 
       - name: Kernel layering (no frontend includes)
         run: |
-          sudo apt-get update
+          bash scripts/ci/apt_update.sh
           sudo apt-get install -y ripgrep
           bash scripts/check_kernel_no_frontend_includes.sh
 
@@ -82,7 +82,7 @@ jobs:
 
       - name: Install dependencies (Ubuntu)
         run: |
-          sudo apt-get update
+          bash scripts/ci/apt_update.sh
           sudo apt-get install -y \
             ${{ matrix.cc }} \
             ${{ matrix.cxx }} \
@@ -180,7 +180,7 @@ jobs:
           submodules: true
       - name: Install dependencies (Ubuntu)
         run: |
-          sudo apt-get update
+          bash scripts/ci/apt_update.sh
           sudo apt-get install -y gcc-11 g++-11 cmake ninja-build \
             libopenmpi-dev openmpi-bin libfftw3-dev libfftw3-mpi-dev \
             nlohmann-json3-dev
@@ -238,7 +238,7 @@ jobs:
 
       - name: Install dependencies (Ubuntu)
         run: |
-          sudo apt-get update
+          bash scripts/ci/apt_update.sh
           sudo apt-get install -y gcc-13 g++-13 cmake ninja-build \
             libopenmpi-dev openmpi-bin libfftw3-dev libfftw3-mpi-dev nlohmann-json3-dev
 

--- a/.github/workflows/clang-tidy.yml
+++ b/.github/workflows/clang-tidy.yml
@@ -28,7 +28,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          sudo apt-get update
+          bash scripts/ci/apt_update.sh
           sudo apt-get install -y \
             cmake \
             ninja-build \

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -26,7 +26,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          sudo apt-get update
+          bash scripts/ci/apt_update.sh
           sudo apt-get install -y \
             gcc-11 \
             g++-11 \

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -93,7 +93,7 @@ jobs:
 
       - name: Install Doxygen and Ninja
         run: |
-          sudo apt-get update
+          bash scripts/ci/apt_update.sh
           sudo apt-get install -y doxygen ninja-build
 
       - name: Install uv and Python

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 
 ### Fixed
 
+- CI no longer fails on a third-party apt repository it does not use. The
+  GitHub runner images carry apt sources for Google Chrome and Microsoft
+  prod; on 2026-09-09 Chrome served a `Packages.gz` whose hash disagreed with
+  its own `Release` file, `apt-get update` exited 100, and every workflow that
+  installs a package died on its first line. Because the build matrix is gated
+  on the Code Quality job, healthy branches reported a red pipeline. All
+  runner-image installs now go through `scripts/ci/apt_update.sh`, which drops
+  the unused sources before refreshing the index, so only an outage of the
+  Ubuntu archives we actually install from can fail the step.
 - `ctest` can be registered in a `--no-heffte` CPU build again (`#105`). The
   Catch2 `-isystem` loop in `tests/CMakeLists.txt` guarded on the unevaluated
   string, so `$<INSTALL_INTERFACE:include>` passed the check and expanded to

--- a/scripts/ci/apt_update.sh
+++ b/scripts/ci/apt_update.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: 2026 VTT Technical Research Centre of Finland Ltd
+# SPDX-License-Identifier: AGPL-3.0-or-later
+#
+# Refresh the apt index without letting a third-party repository fail the job.
+#
+# The GitHub-hosted Ubuntu images ship extra apt sources for software this
+# repository never installs -- Google Chrome, Microsoft prod, and friends.
+# Those repositories are published continuously and occasionally serve a
+# Packages index whose hash does not match the Release file that was fetched
+# moments earlier:
+#
+#   E: Failed to fetch .../google-chrome/.../Packages.gz  Hash Sum mismatch
+#   E: Some index files failed to download.
+#
+# `apt-get update` then exits 100. Every workflow here runs it as the first
+# line of an install step, so a transient inconsistency in Chrome's apt
+# repository takes down Code Quality -- and because the build matrix is gated
+# on Code Quality, the entire pipeline reports failure on branches that have
+# nothing wrong with them. That happened across this repository on
+# 2026-09-09 and is what this script exists to prevent.
+#
+# Dropping the unused sources first means the update only has to succeed for
+# the Ubuntu archives we actually install from, and a real archive outage
+# still fails loudly instead of being swallowed.
+
+set -euo pipefail
+
+for list in google-chrome microsoft-prod; do
+  sudo rm -f "/etc/apt/sources.list.d/${list}.list" \
+             "/etc/apt/sources.list.d/${list}.sources"
+done
+
+sudo apt-get update


### PR DESCRIPTION
## What is broken

Every workflow in this repository begins its install step with `sudo apt-get update`. The GitHub-hosted Ubuntu images ship apt sources for software we never install — Google Chrome, Microsoft prod. On 2026-09-09 the Chrome repository served a `Packages.gz` whose hash disagreed with the `Release` file fetched seconds earlier:

```
Err:29 https://dl.google.com/linux/chrome-stable/deb stable/main amd64 Packages
  Hash Sum mismatch
E: Some index files failed to download.
##[error]Process completed with exit code 100.
```

`apt-get update` exits 100, the step dies, and because `build-and-test` is `needs: [code-quality]`, **the whole matrix is skipped and the pipeline reports failure**. This hit `master` and every open branch simultaneously. It is what is currently red on #129 and #130, whose diffs contain no C++ at all.

## The fix

`scripts/ci/apt_update.sh` removes the unused third-party sources, then runs `apt-get update`. The seven runner-image sites across `ci.yml`, `docs.yml`, `asan.yml`, `clang-tidy.yml` and `coverage.yml` call it instead of `apt-get update` directly.

Deliberately **not** `|| true`: a real outage of the Ubuntu archives we do install from must still fail loudly. Only the repositories nothing here depends on are removed.

The two container jobs (`nvidia/cuda`, `rocm`) are left alone — those images have no third-party sources and no `sudo`.

## Verification

The check is that CI on this PR goes green where the same commit range is red elsewhere; there is nothing to run locally, since the failure is a property of the runner image.