### PR TITLE
fix(tungsten): make the shipped moving-BC input loadable, and guard the rest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,17 @@ SPDX-License-Identifier: AGPL-3.0-or-later
   both directions so a backend that starts breaking it fails there. No
   measurable cost: 40000 spectral steps time the same either side of the
   change, within run-to-run noise.
+- `tungsten_moving_bc_options.json` can be run at all. It declared
+  `"initial_position": "end"`, a key nothing in the code reads, where
+  `MovingBC` requires a numeric `xpos`; the shipped input aborted on the first
+  line of boundary-condition wiring with `missing or invalid 'xpos' field`.
+  It now carries `xpos = 139.17225402106772`, the end of the domain less the
+  boundary width, the same convention `tungsten_moving_bc.json` uses. Nothing
+  had caught it because no test ever loaded a shipped input -- they all build
+  their JSON inline -- so `tungsten-shipped-inputs` now walks every file in
+  `apps/tungsten/inputs_json/` and constructs what it declares through the
+  same schema and catalog the application uses. The other apps' inputs are
+  still unguarded; the pattern is worth copying.
 
 - `ctest` can be registered in a `--no-heffte` CPU build again (`#105`). The
   Catch2 `-isystem` loop in `tests/CMakeLists.txt` guarded on the unevaluated

--- a/apps/tungsten/CMakeLists.txt
+++ b/apps/tungsten/CMakeLists.txt
@@ -104,11 +104,17 @@ if(TUNGSTEN_ENABLE_TESTS)
   find_package(Catch2 REQUIRED)
   if(TARGET Catch2::Catch2)
     tungsten_cpu_executable(test_tungsten tests/test_tungsten.cpp
-                                          tests/test_tungsten_physics.cpp)
+                                          tests/test_tungsten_physics.cpp
+                                          tests/test_tungsten_inputs.cpp)
     target_link_libraries(test_tungsten PRIVATE Catch2::Catch2)
+    # The shipped inputs are part of the product, so a test loads them from the
+    # source tree rather than from a copy that could drift.
+    target_compile_definitions(test_tungsten PRIVATE
+      TUNGSTEN_INPUTS_JSON_DIR="${CMAKE_CURRENT_SOURCE_DIR}/inputs_json")
     include(CTest)
     # Run all tungsten tests in a single invocation to avoid per-test MPI overhead
     add_test(NAME tungsten-all-tests COMMAND test_tungsten)
+    add_test(NAME tungsten-shipped-inputs COMMAND test_tungsten "[inputs]")
     add_test(NAME tungsten-cpu-golden COMMAND test_tungsten "[etd_cpu_golden]")
     add_test(NAME tungsten-etd-cpu-golden COMMAND test_tungsten "[etd_cpu_golden]")
     if(OpenPFC_RUN_MPI_SUITES AND MPIEXEC_EXECUTABLE)

--- a/apps/tungsten/inputs_json/README.md
+++ b/apps/tungsten/inputs_json/README.md
@@ -43,7 +43,7 @@ Each JSON file follows this structure:
 
 1. `tungsten_fixed_bc.json` - Fixed boundary conditions with seed grid
 2. `tungsten_moving_bc.json` - Moving boundary conditions with seed grid
-3. `tungsten_moving_bc_options.json` - Moving boundary with initial position options
+3. `tungsten_moving_bc_options.json` - Moving boundary, narrow front (`width` 3, `alpha` 10) advancing in larger steps than `tungsten_moving_bc.json`
 4. `tungsten_performance.json` - Performance testing configuration
 5. `tungsten_restart.json` - Restart from checkpoint
 6. `tungsten_single_seed.json` - Single seed initial condition

--- a/apps/tungsten/inputs_json/tungsten_moving_bc_options.json
+++ b/apps/tungsten/inputs_json/tungsten_moving_bc_options.json
@@ -2,8 +2,8 @@
     "model": {
         "name": "tungsten",
         "params": {
-            "n0": -0.10,
-            "alpha": 0.50,
+            "n0": -0.1,
+            "alpha": 0.5,
             "n_sol": -0.047,
             "n_vap": -0.464,
             "T": 3300.0,
@@ -62,12 +62,12 @@
         {
             "target": "psi",
             "type": "moving",
-            "initial_position": "end",
             "rho_low": -0.464,
-            "rho_high": -0.10,
+            "rho_high": -0.1,
             "width": 3.0,
             "alpha": 10.0,
-            "disp": 80
+            "disp": 80,
+            "xpos": 139.17225402106772
         }
     ]
 }

--- a/apps/tungsten/tests/test_tungsten_inputs.cpp
+++ b/apps/tungsten/tests/test_tungsten_inputs.cpp
@@ -1,0 +1,95 @@
+// SPDX-FileCopyrightText: 2026 VTT Technical Research Centre of Finland Ltd
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+/**
+ * @file test_tungsten_inputs.cpp
+ * @brief Every shipped JSON input must actually load.
+ *
+ * @details
+ * `tungsten_moving_bc_options.json` sat in the tree with
+ * `"initial_position": "end"` where `MovingBC` requires a numeric `xpos`.
+ * Running it aborted on the first line of boundary-condition wiring:
+ *
+ *     Invalid JSON input: missing or invalid 'xpos' field.
+ *
+ * Nothing caught it, because nothing here ever loaded the shipped inputs --
+ * the tests build their JSON inline. A file a reader is invited to run is part
+ * of the product, so this walks every input in `inputs_json/` and constructs
+ * what it declares: the model parameters through the tungsten schema, and each
+ * initial and boundary condition through the same catalog the application
+ * uses.
+ *
+ * It stops short of stepping a simulation. The point is to catch a key that
+ * was renamed, dropped, or never read, which is cheap to check and is what
+ * actually rots; a physics regression is a different test's job.
+ */
+
+#define CATCH_CONFIG_ENABLE_ALL_STRINGMAKERS
+#include <catch2/catch_test_macros.hpp>
+
+#include <filesystem>
+#include <fstream>
+#include <string>
+#include <vector>
+
+#include <nlohmann/json.hpp>
+
+#include <openpfc/frontend/ui/field_modifier_registry.hpp>
+#include <tungsten/tungsten_physics.hpp>
+#include <tungsten/tungsten_session.hpp>
+
+namespace {
+
+using json = nlohmann::json;
+
+/// Shipped inputs, sorted so a failure names the same file on every machine.
+std::vector<std::filesystem::path> shipped_inputs() {
+  std::vector<std::filesystem::path> out;
+  const std::filesystem::path dir{TUNGSTEN_INPUTS_JSON_DIR};
+  for (const auto &entry : std::filesystem::directory_iterator(dir)) {
+    if (entry.is_regular_file() && entry.path().extension() == ".json") {
+      out.push_back(entry.path());
+    }
+  }
+  std::sort(out.begin(), out.end());
+  return out;
+}
+
+} // namespace
+
+TEST_CASE("Every shipped tungsten JSON input loads", "[tungsten][inputs]") {
+  tungsten::register_catalog();
+
+  const auto inputs = shipped_inputs();
+  INFO("inputs directory: " << TUNGSTEN_INPUTS_JSON_DIR);
+  REQUIRE_FALSE(inputs.empty());
+
+  for (const auto &path : inputs) {
+    const std::string name = path.filename().string();
+    INFO("input file: " << name);
+
+    std::ifstream in(path);
+    REQUIRE(in.good());
+    json cfg;
+    REQUIRE_NOTHROW(in >> cfg);
+
+    // Model parameters, through the schema the application parses them with.
+    if (cfg.contains("model") && cfg["model"].contains("params")) {
+      const json &params = cfg["model"]["params"];
+      INFO("section: model.params");
+      REQUIRE_NOTHROW(tungsten::make_tungsten_schema().parse(params));
+    }
+
+    // Initial and boundary conditions, through the same catalog the session
+    // uses -- this is where a renamed or missing key shows up.
+    for (const char *section : {"initial_conditions", "boundary_conditions"}) {
+      if (!cfg.contains(section)) continue;
+      for (const json &entry : cfg[section]) {
+        REQUIRE(entry.contains("type"));
+        const std::string type = entry["type"].get<std::string>();
+        INFO("section: " << section << ", type: " << type);
+        REQUIRE_NOTHROW(pfc::ui::create_field_modifier(type, entry));
+      }
+    }
+  }
+}


### PR DESCRIPTION
## A shipped input that cannot be run

`apps/tungsten/inputs_json/tungsten_moving_bc_options.json` declares

```json
{ "type": "moving", "initial_position": "end", ... }
```

`initial_position` appears nowhere in the codebase. `MovingBC::from_json` requires a numeric `xpos`, so the file aborts on the first line of boundary-condition wiring:

```
[INFO] Creating boundary condition from data {"alpha":10.0,"disp":80,"initial_position":"end",...}
(rank 0): Invalid JSON input: missing or invalid 'xpos' field.
application called MPI_Abort(MPI_COMM_WORLD, 1)
```

The inputs README lists it as *"Moving boundary with initial position options"* — described by the key that never worked.

Found while verifying the report-audit findings in #134.

## Fix

`xpos = 139.17225402106772`: the end of the domain (`128 × 1.1107207345395915 = 142.17225402106772`) less the boundary `width` of 3. That is exactly the convention the two working inputs use — `tungsten_moving_bc.json` and `tungsten_restart.json` both set `xpos = 127.17225402106772`, which is the same domain length less their `width` of 15. README line corrected to describe what actually distinguishes the file: a narrower, faster-advancing front.

## Why it survived

**No test has ever loaded a shipped input.** Every test builds its JSON inline, so all ~40 input files across the apps are unverified. `tungsten-shipped-inputs` closes that for tungsten: it walks `inputs_json/`, parses `model.params` through the tungsten schema, and constructs every `initial_conditions` and `boundary_conditions` entry through the same catalog the session uses.

It deliberately stops short of stepping a simulation. The point is to catch a key that was renamed, dropped, or never read — cheap to check, and what actually rots. Physics regressions are other tests' job.

Removing `xpos` again makes it fail with the file, the section and the key named:

```
input file: tungsten_moving_bc_options.json
section: boundary_conditions, type: moving
Invalid JSON input: missing or invalid 'xpos' field.
```

**The other apps' inputs are still unguarded.** The pattern is worth copying; I have not done it here to keep this reviewable.

## Verification (LUMI)

- `test_tungsten "[inputs]"`: 47 assertions, green.
- The fixed input runs on 4 ranks, boundary advancing `139.172 → 139.979 → 141.09`.
- Full `test_tungsten`: green.