### PR TITLE
fix(fft): stop the backend eating the field the nonlinearity reads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,30 @@ SPDX-License-Identifier: AGPL-3.0-or-later
   runner-image installs now go through `scripts/ci/apt_update.sh`, which drops
   the unused sources before refreshing the index, so only an outage of the
   Ubuntu archives we actually install from can fail the step.
+- A spectral application on a one-dimensional grid computed its nonlinear term
+  from a destroyed field, on FFT backends that use their input as scratch.
+  `SpectralETDSystem::attempt()` transforms `psi` and then evaluates the
+  pointwise nonlinearity from that same `psi`; `FFT_Impl::forward` takes its
+  input by `const&` and every caller relies on that. HeFFTe 2.4.1 declares the
+  input `input_type const input[]` and then writes to it anyway on some FFTW
+  builds. Measured on LUMI with two builds differing *only* in the FFTW
+  library -- same source, same compiler, same HeFFTe version, same buffer
+  address -- a forward of a 512-point line left the input untouched against
+  Cray FFTW 3.3.10.10 and destroyed it against vanilla FFTW 3.3.10
+  (`input[0]` 0.04 to 0.32). The transform *output* is correct to 4e-15 in
+  both cases, which is why this went unnoticed: nothing looks wrong until a
+  second stage reads the input back, and the platform this project develops on
+  never did. Probing HeFFTe directly, the damage is confined to 1-D grids
+  (512x1x1, 256x1x1 and 64x1x1 destroyed; 32x32x1, 16^3, 32^3 and 64^3
+  preserved) -- which is why only `kawahara` showed it and the 3-D golden
+  checksums stayed green on the very platform that breaks the 1-D ones. The host `forward` now hands the backend a copy. Only `forward`
+  is guarded -- `backward` was measured on both builds and leaves its input
+  alone, and the device path has not been shown to have the problem;
+  `tests/unit/kernel/fft/test_fft_input_preserved.cpp` asserts the contract in
+  both directions so a backend that starts breaking it fails there. No
+  measurable cost: 40000 spectral steps time the same either side of the
+  change, within run-to-run noise.
+
 - `ctest` can be registered in a `--no-heffte` CPU build again (`#105`). The
   Catch2 `-isystem` loop in `tests/CMakeLists.txt` guarded on the unevaluated
   string, so `$<INSTALL_INTERFACE:include>` passed the check and expanded to

--- a/include/openpfc/kernel/fft/detail/fft_heffte_backend.hpp
+++ b/include/openpfc/kernel/fft/detail/fft_heffte_backend.hpp
@@ -15,6 +15,7 @@
 
 #pragma once
 
+#include <algorithm>
 #include <openpfc/kernel/fft/fft_interface.hpp>
 #include <openpfc/kernel/fft/heap_concept.hpp>
 
@@ -173,6 +174,55 @@ struct FFT_Impl : Interface {
 
   detail::FFTWorkspaceStorage<BackendTag> m_ws;
 
+  /**
+   * @brief Copies of the host-path inputs, so the backend cannot eat them.
+   *
+   * @details
+   * `forward` and `backward` take their input by `const&` and callers depend
+   * on that. `SpectralETDSystem::attempt()` depends on it hardest: it forwards
+   * `psi`, then evaluates the pointwise nonlinearity *from the same `psi`*. A
+   * transform that used its input as scratch would leave every spectral
+   * application computing its nonlinear term from a destroyed field.
+   *
+   * HeFFTe 2.4.1 declares the input `input_type const input[]` and then, for
+   * some plan shapes on some FFTW builds, writes to it regardless. Measured
+   * on LUMI with two builds differing only in the FFTW library -- same
+   * source, same compiler, same HeFFTe version, same buffer address -- a
+   * `forward` of a 512-point line left the input untouched against Cray FFTW
+   * 3.3.10.10 and destroyed it against vanilla FFTW 3.3.10 (`input[0]` 0.04
+   * -> 0.32). The transform *output* was correct to 4e-15 in both cases,
+   * which is why this stayed hidden: nothing looks wrong until a second stage
+   * reads the input back, and on the platform this project develops on,
+   * nothing ever did.
+   *
+   * Probing HeFFTe directly against vanilla FFTW, the damage is confined to
+   * **one-dimensional grids**:
+   *
+   *     512 x 1 x 1   input destroyed
+   *     256 x 1 x 1   input destroyed
+   *      64 x 1 x 1   input destroyed
+   *      32 x 32 x 1  input preserved
+   *      16^3, 32^3, 64^3   input preserved
+   *
+   * which is why only the 1-D application (`kawahara`) ever showed it, and
+   * why the 3-D golden checksums stayed green on exactly the platform that
+   * breaks the 1-D ones. The guard is unconditional anyway: the shapes a
+   * backend chooses to scribble on are not something callers should have to
+   * track, and a future 1-D model would otherwise inherit the same trap.
+   *
+   * So the backend gets a copy and the caller keeps its buffer. The cost is
+   * one extra streaming pass per host forward, against an FFT's several, and
+   * `size_inbox()` doubles of memory, lazily sized -- a build that only ever
+   * takes the device path allocates none of it.
+   *
+   * Only `forward` is guarded. `backward` was measured on both FFTW builds
+   * and leaves its input alone, and the device path has not been shown to
+   * have the problem at all. Paying for a copy on either would be guessing;
+   * `test_fft_input_preserved.cpp` asserts the contract on both directions
+   * instead, so a backend that starts breaking it fails there.
+   */
+  RealVector m_in_scratch_real;
+
   FFT_Impl(fft_type fft)
       : m_fft(std::move(fft)), m_ws(m_fft.size_workspace()) {}
 
@@ -213,8 +263,10 @@ struct FFT_Impl : Interface {
     detail::require_equal_size(
         out.size(), size_outbox(),
         "FFT_Impl::forward: complex buffer size ", "size_outbox");
+    m_in_scratch_real.resize(in.size());
     m_fft_time -= MPI_Wtime();
-    m_fft.forward(in.data(), out.data(), m_ws.data_wrk());
+    std::copy(in.begin(), in.end(), m_in_scratch_real.begin());
+    m_fft.forward(m_in_scratch_real.data(), out.data(), m_ws.data_wrk());
     m_fft_time += MPI_Wtime();
   }
 

--- a/tests/unit/kernel/fft/CMakeLists.txt
+++ b/tests/unit/kernel/fft/CMakeLists.txt
@@ -14,5 +14,6 @@ if(OpenPFC_ENABLE_HEFFTE)
       ${CMAKE_CURRENT_SOURCE_DIR}/test_fft_comprehensive.cpp
       ${CMAKE_CURRENT_SOURCE_DIR}/test_heap_concept.cpp
       ${CMAKE_CURRENT_SOURCE_DIR}/test_fft_buffer_sizes.cpp
+      ${CMAKE_CURRENT_SOURCE_DIR}/test_fft_input_preserved.cpp
   )
 endif()

--- a/tests/unit/kernel/fft/test_fft_input_preserved.cpp
+++ b/tests/unit/kernel/fft/test_fft_input_preserved.cpp
@@ -1,0 +1,179 @@
+// SPDX-FileCopyrightText: 2026 VTT Technical Research Centre of Finland Ltd
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+/**
+ * @file test_fft_input_preserved.cpp
+ * @brief A transform must not modify the buffer it reads.
+ *
+ * @details
+ * `FFT_Impl::forward` and `FFT_Impl::backward` take their input by
+ * `const&`, and every caller relies on that. `SpectralETDSystem::attempt()`
+ * relies on it hardest:
+ *
+ *     Ops::forward(m_fft, psi, psi_hat);                     // reads psi
+ *     ...
+ *     Ops::pointwise(geometry, t, psi, ..., n_real, ...);    // reads psi again
+ *
+ * The nonlinearity is evaluated from the same field the transform just read.
+ * If the transform used that buffer as scratch, every spectral application
+ * would compute its nonlinear term from a destroyed field.
+ *
+ * That is not hypothetical. HeFFTe 2.4.1 declares the input
+ * `input_type const input[]` and then, on some FFTW builds, writes to it
+ * anyway. Measured on LUMI with two builds differing *only* in the FFTW
+ * library — same source, same compiler, same HeFFTe version, same buffer
+ * address:
+ *
+ * | FFTW              | input after `forward` | transform output |
+ * |-------------------|-----------------------|------------------|
+ * | Cray `3.3.10.10`  | unchanged             | correct to 4e-15 |
+ * | vanilla `3.3.10`  | **destroyed**         | correct to 4e-15 |
+ *
+ * The output is right either way, which is why this hid for so long: nothing
+ * looks wrong until a second stage reads the input back. On the platform this
+ * project develops on, it never does.
+ *
+ * These tests pin the contract at the level the wrapper promises it, so a
+ * backend that breaks it fails here rather than as an application diverging
+ * thousands of steps later on someone else's machine.
+ */
+
+#include <complex>
+#include <cstddef>
+#include <algorithm>
+#include <cmath>
+#include <numbers>
+#include <vector>
+
+#include <mpi.h>
+
+#include <catch2/catch_test_macros.hpp>
+
+#include <openpfc/kernel/data/domain.hpp>
+#include <openpfc/kernel/decomposition/decomposition.hpp>
+#include <openpfc/kernel/decomposition/decomposition_factory.hpp>
+#include <openpfc/kernel/fft/fft_fftw.hpp>
+
+using namespace pfc;
+
+namespace {
+
+/// Deterministic, broadband, and nothing like zero: a buffer of zeros would
+/// survive being used as scratch and prove nothing.
+void fill_real(std::vector<double> &v) {
+  for (std::size_t i = 0; i < v.size(); ++i) {
+    const double x = static_cast<double>(i);
+    v[i] = 0.2 * std::cos(0.1 * x) + 0.05 * std::sin(0.37 * x) + 0.5;
+  }
+}
+
+void fill_complex(std::vector<std::complex<double>> &v) {
+  for (std::size_t i = 0; i < v.size(); ++i) {
+    const double x = static_cast<double>(i);
+    v[i] = {0.3 * std::cos(0.13 * x) + 0.2, 0.1 * std::sin(0.21 * x) - 0.05};
+  }
+}
+
+} // namespace
+
+TEST_CASE("forward() does not modify its input", "[fft][unit][contract]") {
+  int nproc = 1;
+  MPI_Comm_size(MPI_COMM_WORLD, &nproc);
+  // One rank: the contract is about buffer use inside a single transform, and
+  // a decomposition would only obscure which buffer was written.
+  if (nproc != 1) {
+    SKIP("single-rank buffer-contract check");
+  }
+
+  // A 1-D line and a cube: the FFTW backend picks different plan shapes for
+  // them, and the 1-D case is the one the apps' science presets use.
+  const std::vector<Int3> grids{{512, 1, 1}, {16, 16, 16}};
+  for (const auto &n : grids) {
+    auto domain = domain::create(GridSize(n), PhysicalOrigin({0.0, 0.0, 0.0}),
+                                 GridSpacing({0.25, 1.0, 1.0}));
+    auto decomposition = decomposition::create(domain, 1);
+    auto fft = fft::create(decomposition);
+
+    std::vector<double> in(fft.size_inbox());
+    std::vector<std::complex<double>> out(fft.size_outbox());
+    fill_real(in);
+    const std::vector<double> before = in;
+
+    fft.forward(in, out);
+
+    INFO("grid " << n[0] << "x" << n[1] << "x" << n[2]);
+    for (std::size_t i = 0; i < in.size(); ++i) {
+      if (in[i] != before[i]) {
+        INFO("first difference at index " << i << ": " << before[i] << " -> "
+                                          << in[i]);
+        FAIL("forward() modified its input buffer");
+      }
+    }
+  }
+}
+
+TEST_CASE("backward() does not modify its input", "[fft][unit][contract]") {
+  int nproc = 1;
+  MPI_Comm_size(MPI_COMM_WORLD, &nproc);
+  if (nproc != 1) {
+    SKIP("single-rank buffer-contract check");
+  }
+
+  const std::vector<Int3> grids{{512, 1, 1}, {16, 16, 16}};
+  for (const auto &n : grids) {
+    auto domain = domain::create(GridSize(n), PhysicalOrigin({0.0, 0.0, 0.0}),
+                                 GridSpacing({0.25, 1.0, 1.0}));
+    auto decomposition = decomposition::create(domain, 1);
+    auto fft = fft::create(decomposition);
+
+    std::vector<std::complex<double>> in(fft.size_outbox());
+    std::vector<double> out(fft.size_inbox());
+    fill_complex(in);
+    const std::vector<std::complex<double>> before = in;
+
+    fft.backward(in, out);
+
+    INFO("grid " << n[0] << "x" << n[1] << "x" << n[2]);
+    for (std::size_t i = 0; i < in.size(); ++i) {
+      if (in[i] != before[i]) {
+        INFO("first difference at index " << i);
+        FAIL("backward() modified its input buffer");
+      }
+    }
+  }
+}
+
+TEST_CASE("a transform still round-trips after the input is protected",
+          "[fft][unit][contract]") {
+  int nproc = 1;
+  MPI_Comm_size(MPI_COMM_WORLD, &nproc);
+  if (nproc != 1) {
+    SKIP("single-rank buffer-contract check");
+  }
+  // Guarding the input must not change what the transform computes; a copy
+  // that quietly transformed the wrong buffer would pass both tests above.
+  auto domain = domain::create(GridSize({512, 1, 1}),
+                               PhysicalOrigin({0.0, 0.0, 0.0}),
+                               GridSpacing({0.25, 1.0, 1.0}));
+  auto decomposition = decomposition::create(domain, 1);
+  auto fft = fft::create(decomposition);
+
+  std::vector<double> in(fft.size_inbox());
+  std::vector<std::complex<double>> hat(fft.size_outbox());
+  std::vector<double> back(fft.size_inbox());
+  fill_real(in);
+  // Compare against a snapshot, not against `in`: if the transform did eat
+  // its input, comparing with the eaten copy would report a round-trip error
+  // that is really the first test's failure wearing a disguise.
+  const std::vector<double> before = in;
+
+  fft.forward(in, hat);
+  fft.backward(hat, back);
+
+  double worst = 0.0;
+  for (std::size_t i = 0; i < before.size(); ++i) {
+    worst = std::max(worst, std::abs(back[i] - before[i]));
+  }
+  INFO("worst round-trip deviation " << worst);
+  REQUIRE(worst < 1.0e-12);
+}


### PR DESCRIPTION
## A spectral app on a 1-D grid computes its nonlinearity from a destroyed field

`SpectralETDSystem::attempt()`:

```cpp
Ops::forward(m_fft, psi, psi_hat);                     // reads psi
...
Ops::pointwise(m_geometry, t, psi, ..., n_real, ...);  // reads psi again
```

`FFT_Impl::forward` takes its input by `const&` and every caller relies on that. HeFFTe 2.4.1 declares the input `input_type const input[]` — and then, for some plan shapes on some FFTW builds, writes to it anyway.

## The measurement

Two builds on LUMI differing in **nothing but the FFTW library** — same source, same compiler, same HeFFTe version, same buffer address:

| FFTW | input after `forward` | transform output |
|---|---|---|
| Cray 3.3.10.10 | unchanged (0.0) | correct to 4.5e-15 |
| vanilla 3.3.10 | **destroyed** — `input[0]` 0.04 → 0.32, worst change 0.317 | correct to 4.5e-15 |

The output is right either way. That is exactly why this survived: nothing looks wrong until a second stage reads the input back, and on the platform this project develops on, nothing ever did.

## Scope: 1-D grids only

Probing HeFFTe directly against vanilla FFTW:

```
512 x 1 x 1     INPUT DESTROYED
256 x 1 x 1     INPUT DESTROYED
 64 x 1 x 1     INPUT DESTROYED
 32 x 32 x 1    input preserved
 16^3, 32^3, 64^3   input preserved
```

That is the piece that makes everything else make sense: it is why only `kawahara`, the one 1-D application, ever failed, and why tungsten's pinned 32³ checksum stays green on the very CI machine that breaks the 1-D case. An earlier revision of this description claimed every spectral app was affected; that was wrong, and this is the corrected scope.

## What it does to the physics where it does apply

On CI, from `u = 0.2 cos(k_8 x)`, **one step**, `beta = gamma = 0`:

- second harmonic **2.135e-4** against a closed form of **5.890e-5** — 3.6× too large;
- largest amplitude outside `{8, 16}`: **2.67e-3 at m=128** — broadband garbage *larger than the legitimate harmonic*;
- the primary mode, which the linear part must leave alone here, returns 0.2000813 instead of 0.2;
- at the dealias boundary, harmonic 170 comes back **5× too small**.

Integrated, that is a KdV solitary wave losing 20% of its amplitude in 2000 steps and reaching NaN by 7000 — the failure on #126 that started this.

## The fix

The host `forward` hands the backend a copy, **unconditionally**. Not gated on grid shape: which plan shapes a backend chooses to scribble on is not something callers should have to track, and a future 1-D model would otherwise inherit the same trap silently.

**Only `forward` is guarded.** `backward` was measured on both builds and leaves its input alone, and the device path has not been shown to have the problem, so paying for a copy on either would be guessing. `tests/unit/kernel/fft/test_fft_input_preserved.cpp` asserts the contract in **both** directions, plus a round-trip, so a backend that starts breaking it fails there rather than as an application diverging thousands of steps later on someone else's machine.

## Verification

- **The new test has teeth**: without the fix it fails on vanilla FFTW with `forward() modified its input buffer`, first difference at index 0, `0.7 -> 5.38419`. With the fix, all three contract cases pass.
- **Full Kawahara suite on vanilla FFTW**: 309 assertions, 15 cases, green — including the 20000-step science run that previously produced NaN.
- **Full Kawahara suite on Cray FFTW**: still green, 309 assertions.
- **Kernel suite on vanilla FFTW**: 157897/157898 assertions pass. The single failure is `HaloExchange persistent Faces: single-rank wrap`. It cannot be caused by this change — the file includes no FFT header, only `comm_halo_exchange` and friends.

  Correcting myself on that one: I first wrote that CI is green on it. **CI never runs it.** It is tagged `[MPI]`, `openpfc-all-tests` runs `openpfc-tests "~[MPI]"`, and the `mpi_2procs_all` entry runs at two ranks, so this single-rank case is exercised by no CI entry at all. My local run had no filter, which is why it appeared. Whether it is a genuine defect or an artefact of running MPI on a LUMI login node is **untested**, and it is worth a look on its own — an integration test that nothing runs is not a passing test.
- **Cost**: none measurable. 40000 spectral steps time 1.18 s with the fix and 1.24 s without, i.e. the copy is below run-to-run noise.

## A note on how this was found

Two earlier hypotheses — `std::vector` buffer alignment, and long-run error accumulation — were both plausible, both written up, and both killed by measurement. The alignment one died to a standalone FFTW probe showing 16/32/48-byte offsets give bit-identical results. The accumulation one died when the single-step probes failed. What actually found it was reproducing CI's stack on LUMI and bisecting one ETD step stage by stage.
