### PR TITLE
docs(report): field figures for the thin-film and surface chapters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,31 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 
 ### Added
 
+- Field figures for the two application chapters that had none, rendered from
+  real single-rank runs of the shipped science presets: `07_surface_diffusion`
+  gets the isotropic-against-anisotropic nanosurface anneal (the same crossed
+  corrugation after the same anneal, one keeping its egg-crate and the other
+  reduced to stripes — `energy_kx_frac`/`energy_ky_frac` = 0.249/0.751 drawn as
+  a surface), and `09_ehd_film` gets the compliant-against-stiff plate at the
+  instant the load lifts (the deepest either dent gets: `h_centre` 0.659 with
+  radius 12.3 against 0.747 with radius 14.2, on one shared scale). Both runs
+  are in `docs/report/figures/run_field_demos.sh` and neither extends the
+  shipped preset's `t1`.
+
+  Getting them needed a real change to the two applications, not just to the
+  report: `surface_diffusion_anisotropic` and `ehd_film_nonlinear` are the two
+  science drivers that own their `main()` rather than running on
+  `SpectralETDSession`, and neither had ever had a field writer — their science
+  presets could only be read through the diagnostics CSV. Both now honour the
+  session's own `fields[]` spelling through the new
+  `apps/common/include/openpfc_apps/field_snapshots.hpp`, and the four presets
+  `nanosurface_isotropic.json`, `nanosurface_anisotropic.json`,
+  `load_relaxation_compliant.json` and `load_relaxation_stiff.json` set it.
+  Omitting the key keeps the previous CSV-only behaviour, which is what the
+  test presets rely on; a malformed one is rejected rather than silently
+  ignored, since a preset that believes it is writing output and is not stays
+  invisible until a figure is missing. Covered by `ctest -R field_snapshots`.
+
 - `tungsten_dealias_study` and `tungsten/resolution.hpp`: what running the
   cubic PFC nonlinearity undealiased actually costs. The crystal sits at
   `k0 = 1` and carries real content at `2k0` and `3k0`, so a grid must both

--- a/apps/common/include/openpfc_apps/field_snapshots.hpp
+++ b/apps/common/include/openpfc_apps/field_snapshots.hpp
@@ -1,0 +1,147 @@
+// SPDX-FileCopyrightText: 2026 VTT Technical Research Centre of Finland Ltd
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+#pragma once
+
+/**
+ * @file field_snapshots.hpp
+ * @brief Optional `fields[]` snapshot output for the standalone science drivers.
+ *
+ * Shared by the science drivers that do *not* run on
+ * `SpectralETDSession`: `surface_diffusion_anisotropic` and
+ * `ehd_film_nonlinear`. Both own their own `main()` because their physics is
+ * not expressible as a reciprocal-space symbol, and both consequently missed
+ * out on the one thing the session gives every other application for free —
+ * a field writer.
+ *
+ * @details
+ * That gap had a concrete cost: the science presets of those two apps could
+ * only ever be read through their diagnostics CSV. A CSV can say that the
+ * anisotropic anneal ends up with three quarters of its spectral energy in
+ * \f$k_y\f$, or that a compliant plate dents four times deeper than a stiff
+ * one, but it cannot show *what the surface looks like* while doing so. The
+ * report's field figures need the field.
+ *
+ * The JSON spelling is deliberately the same one the session-based presets of
+ * the same two applications already use, so a reader moving between
+ * `smoothing.json` and `nanosurface_isotropic.json` does not meet a second
+ * convention:
+ *
+ * ```json
+ * "fields": [ { "name": "h", "data": "results/<app>/<case>_%04d.vti" } ]
+ * ```
+ *
+ * Only the subset these drivers can honour is supported: one entry, naming
+ * the driver's single evolving field, written to a `.vti` path. Anything else
+ * (a second entry, an unknown field name) is rejected loudly rather than
+ * silently ignored — a preset that believes it is writing output and is not
+ * is worse than one that fails.
+ *
+ * Omitting `fields[]` entirely keeps the previous behaviour: diagnostics
+ * only, no file-system traffic. That matters because these presets are also
+ * run from the test suite, where the CSV is the assertion and the snapshots
+ * would be dead weight.
+ *
+ * Snapshot indices count saves, not steps, exactly as
+ * `SpectralETDSession::write_results` does: the file written at \f$t = 0\f$ is
+ * `_0000`, the one written after the first `saveat` interval is `_0001`, and
+ * so on. A figure script can therefore recover the time of frame \f$i\f$ as
+ * \f$i \times \mathtt{saveat}\f$ without parsing anything.
+ */
+
+#include <filesystem>
+#include <memory>
+#include <stdexcept>
+#include <string>
+
+#include <mpi.h>
+#include <nlohmann/json.hpp>
+
+#include <openpfc/frontend/io/vtk_writer.hpp>
+#include <openpfc/kernel/data/grid_field.hpp>
+#include <openpfc/kernel/field/state_access.hpp>
+#include <openpfc/kernel/simulation/results_writer_domain.hpp>
+
+namespace pfc::apps {
+
+/**
+ * @brief Build a `.vti` snapshot writer from an optional `fields[]` entry.
+ *
+ * Collective on @p comm: rank 0 creates the output directory and every rank
+ * waits for it, so a preset may name a `results/...` path that does not exist
+ * yet (the diagnostics CSV in the same drivers behaves the same way).
+ *
+ * @param cfg         the parsed case JSON; `fields` is optional
+ * @param field_name  the name of the driver's evolving field, e.g. `"h"`
+ * @param field       that field, used only for its geometry
+ * @param comm        communicator the writer is collective over
+ * @return the writer, or `nullptr` when the case asks for no field output
+ *
+ * @throws std::invalid_argument if `fields[]` is malformed, holds more than
+ *         one entry, or names a field this driver does not own
+ */
+inline std::unique_ptr<pfc::VTKWriter>
+make_field_snapshot_writer(const nlohmann::json &cfg, const std::string &field_name,
+                           const pfc::data::Field<double> &field,
+                           MPI_Comm comm = MPI_COMM_WORLD) {
+  if (!cfg.contains("fields")) return nullptr;
+  const auto &fields = cfg.at("fields");
+  if (!fields.is_array())
+    throw std::invalid_argument("fields: must be an array of {name, data} objects");
+  if (fields.empty()) return nullptr;
+  if (fields.size() > 1)
+    throw std::invalid_argument(
+        "fields: this driver evolves a single field, so at most one entry is "
+        "meaningful");
+
+  const auto &entry = fields.front();
+  if (!entry.is_object() || !entry.contains("data"))
+    throw std::invalid_argument("fields[0]: expected an object with a `data` path");
+  const std::string name = entry.value("name", field_name);
+  if (name != field_name)
+    throw std::invalid_argument("fields[0].name: this driver owns only '" +
+                                field_name + "', got '" + name + "'");
+
+  const std::filesystem::path path = entry.at("data").get<std::string>();
+  if (path.extension() != ".vti")
+    throw std::invalid_argument(
+        "fields[0].data: only `.vti` output is implemented here, got '" +
+        path.string() + "'");
+
+  int rank = 0;
+  MPI_Comm_rank(comm, &rank);
+  if (rank == 0 && path.has_parent_path())
+    std::filesystem::create_directories(path.parent_path());
+  MPI_Barrier(comm);
+
+  auto writer = std::make_unique<pfc::VTKWriter>(path.string(), comm);
+  writer->set_field_name(name);
+  // Origin and spacing must be set before `set_domain`, which validates the
+  // three against each other.
+  const auto &origin = field.origin();
+  const auto &spacing = field.spacing();
+  writer->set_origin({origin[0], origin[1], origin[2]});
+  writer->set_spacing({spacing[0], spacing[1], spacing[2]});
+  pfc::apply_writer_domain(*writer, field);
+  return writer;
+}
+
+/**
+ * @brief Write one snapshot of @p field, or do nothing if @p writer is null.
+ *
+ * The null case is the point: a driver can call this unconditionally at every
+ * save without wrapping it in a test for whether the case requested output.
+ *
+ * @param writer     may be `nullptr`
+ * @param increment  save index, not step index (see the file-level notes)
+ */
+inline void write_field_snapshot(pfc::VTKWriter *writer, int increment,
+                                 const pfc::data::Field<double> &field) {
+  if (writer == nullptr) return;
+  const pfc::field::FieldView<double> view(field.data(), field.size(),
+                                           field.box().size, field.spacing(),
+                                           field.origin());
+  writer->write(increment, view);
+}
+
+} // namespace pfc::apps

--- a/apps/ehd_film/README.md
+++ b/apps/ehd_film/README.md
@@ -159,7 +159,14 @@ stiff plate; VTK of `h` goes to `results/ehd_film/`. JSON `model.params`:
 `load.p0` / `load.a` / `load.t_load` (Gaussian load, centred, see above)
 and `diagnostics.csv` (one row per `saveat` with `time`, `h_center`,
 `deflection_center`, `p_max`, `p_min`, `spreading_radius`,
-`displaced_volume`, `volume`, `volume_rel_drift`).
+`displaced_volume`, `volume`, `volume_rel_drift`). It also accepts the
+session's `fields` key —
+`fields: [{"name": "h", "data": "results/ehd_film_nonlinear/<case>_%04d.vti"}]`
+— which writes a VTK snapshot of the gap at every `saveat`, indexed by save
+and not by step (`_0000` is `t=0`). Both `load_relaxation_*.json` presets set
+it; `docs/report/09_ehd_film.qmd` renders the compliant-against-stiff
+comparison from those snapshots. Omit the key and the driver writes
+diagnostics only, as it did before.
 
 ## Tests
 

--- a/apps/ehd_film/inputs_json/load_relaxation_compliant.json
+++ b/apps/ehd_film/inputs_json/load_relaxation_compliant.json
@@ -25,6 +25,12 @@
         "a": 8.0,
         "t_load": 60.0
     },
+    "fields": [
+        {
+            "name": "h",
+            "data": "results/ehd_film_nonlinear/load_relaxation_compliant_%04d.vti"
+        }
+    ],
     "diagnostics": {
         "csv": "results/ehd_film_nonlinear/load_relaxation_compliant.csv"
     }

--- a/apps/ehd_film/inputs_json/load_relaxation_stiff.json
+++ b/apps/ehd_film/inputs_json/load_relaxation_stiff.json
@@ -25,6 +25,12 @@
         "a": 8.0,
         "t_load": 60.0
     },
+    "fields": [
+        {
+            "name": "h",
+            "data": "results/ehd_film_nonlinear/load_relaxation_stiff_%04d.vti"
+        }
+    ],
     "diagnostics": {
         "csv": "results/ehd_film_nonlinear/load_relaxation_stiff.csv"
     }

--- a/apps/ehd_film/src/ehd_film_nonlinear.cpp
+++ b/apps/ehd_film/src/ehd_film_nonlinear.cpp
@@ -48,6 +48,7 @@
 #include <openpfc/kernel/data/grid_field.hpp>
 #include <openpfc/kernel/fft/kspace_iterator.hpp>
 #include <openpfc/kernel/simulation/stacks/spectral_cpu_stack.hpp>
+#include <openpfc_apps/field_snapshots.hpp>
 #include <openpfc_apps/spectral_flux.hpp>
 
 #include <ehd_film/ehd_film_physics.hpp>
@@ -193,6 +194,15 @@ int main(int argc, char *argv[]) {
       });
     };
 
+    // Optional `.vti` snapshots of the gap itself (`fields[]`). The
+    // diagnostics CSV reduces the dent to a handful of scalars; the
+    // snapshots are what show its shape, and how far the disturbance has
+    // spread relative to the periodic box. See
+    // openpfc_apps/field_snapshots.hpp.
+    auto snapshots =
+        pfc::apps::make_field_snapshot_writer(cfg, "h", h, MPI_COMM_WORLD);
+    int snapshot_index = 0;
+
     // Diagnostics CSV, rank 0, never overwriting.
     std::unique_ptr<std::FILE, int (*)(std::FILE *)> out(nullptr, std::fclose);
     if (rank == 0 && cfg.contains("diagnostics")) {
@@ -228,6 +238,7 @@ int main(int argc, char *argv[]) {
                                                           p_real_diag);
       auto s = ehd_film::sample_ehd_film(h, p_real_diag, domain, p.h0,
                                          MPI_COMM_WORLD);
+      pfc::apps::write_field_snapshot(snapshots.get(), snapshot_index++, h);
       if (volume0 < 0.0) volume0 = s.volume;
       const double drift = (volume0 != 0.0) ? (s.volume - volume0) / volume0 : 0.0;
       h_center_min = std::min(h_center_min, s.h_center);

--- a/apps/surface_diffusion/README.md
+++ b/apps/surface_diffusion/README.md
@@ -145,6 +145,14 @@ a standalone driver, not a `SpectralETDSession`): `model.params` is `B0`,
 modes:[{nx,ny,amplitude}, ...]}` (each mode a plane cosine, summed); optional
 `diagnostics.csv` writes the observables table below every `saveat`.
 
+One key is shared with the session shape: an optional
+`fields: [{"name": "h", "data": "results/surface_diffusion/<case>_%04d.vti"}]`
+writes a VTK snapshot of the surface at every `saveat`, indexed by save and
+not by step (`_0000` is `t=0`). Both `nanosurface_*.json` presets set it, so
+the orientation split in the CSV can also be looked at as a surface —
+`docs/report/07_surface_diffusion.qmd` renders exactly that. Omit the key and
+the driver writes diagnostics only, as it did before.
+
 ## Measured orientation selection (LUMI, CPU, 2026-09-09)
 
 Both presets start from the identical crossed corrugation (\(n_x=n_y=16\),

--- a/apps/surface_diffusion/inputs_json/nanosurface_anisotropic.json
+++ b/apps/surface_diffusion/inputs_json/nanosurface_anisotropic.json
@@ -25,6 +25,12 @@
             {"nx": 0, "ny": 16, "amplitude": 0.05}
         ]
     },
+    "fields": [
+        {
+            "name": "h",
+            "data": "results/surface_diffusion/nanosurface_anisotropic_%04d.vti"
+        }
+    ],
     "diagnostics": {
         "csv": "results/surface_diffusion/nanosurface_anisotropic.csv"
     }

--- a/apps/surface_diffusion/inputs_json/nanosurface_isotropic.json
+++ b/apps/surface_diffusion/inputs_json/nanosurface_isotropic.json
@@ -25,6 +25,12 @@
             {"nx": 0, "ny": 16, "amplitude": 0.05}
         ]
     },
+    "fields": [
+        {
+            "name": "h",
+            "data": "results/surface_diffusion/nanosurface_isotropic_%04d.vti"
+        }
+    ],
     "diagnostics": {
         "csv": "results/surface_diffusion/nanosurface_isotropic.csv"
     }

--- a/apps/surface_diffusion/src/surface_diffusion_anisotropic.cpp
+++ b/apps/surface_diffusion/src/surface_diffusion_anisotropic.cpp
@@ -59,6 +59,7 @@
 #include <openpfc/kernel/data/grid_field.hpp>
 #include <openpfc/kernel/fft/kspace_iterator.hpp>
 #include <openpfc/kernel/simulation/stacks/spectral_cpu_stack.hpp>
+#include <openpfc_apps/field_snapshots.hpp>
 #include <openpfc_apps/structure_factor.hpp>
 
 #include <surface_diffusion/anisotropic_flux.hpp>
@@ -258,6 +259,14 @@ int main(int argc, char *argv[]) {
         domain, stack.fft(), dt,
         surface_diffusion::SurfaceStiffness::from_params(params));
 
+    // Optional `.vti` snapshots of the surface itself (`fields[]`). The
+    // diagnostics CSV carries the orientation split as a number; the
+    // snapshots are what let a reader see *which* ridge set the anisotropic
+    // anneal is erasing. See openpfc_apps/field_snapshots.hpp.
+    auto snapshots =
+        pfc::apps::make_field_snapshot_writer(cfg, "h", h, MPI_COMM_WORLD);
+    int snapshot_index = 0;
+
     std::unique_ptr<std::FILE, int (*)(std::FILE *)> out(nullptr, std::fclose);
     if (rank == 0 && cfg.contains("diagnostics")) {
       const std::filesystem::path path =
@@ -274,6 +283,7 @@ int main(int argc, char *argv[]) {
 
     auto report = [&](int step, double t) {
       auto s = sample_surface(h, domain, stack.fft(), MPI_COMM_WORLD);
+      pfc::apps::write_field_snapshot(snapshots.get(), snapshot_index++, h);
       if (out) {
         std::ostringstream line;
         line.imbue(std::locale::classic());

--- a/docs/report/07_surface_diffusion.qmd
+++ b/docs/report/07_surface_diffusion.qmd
@@ -145,7 +145,9 @@ statement (in a linear model $\lvert\mathbf{k}\rvert$ sets the rate and
 orientation does not) and a useful internal check. The anisotropic run's split
 moves monotonically away from 1:1 at every sample: the softer $\theta = \pi/2$
 orientation increasingly dominates the surviving spectral content as the
-stiffer $\theta = 0$ orientation is preferentially damped. The dominant
+stiffer $\theta = 0$ orientation is preferentially damped. @fig-sd-nanosurface
+shows what that 3:1 number looks like as a surface — an egg-crate that stays an
+egg-crate against one that has become a set of stripes. The dominant
 wavelength from the orientation-blind structure factor is 7.758 in *both* runs,
 which is exactly why the directional split, and not the structure factor alone,
 is the observable that shows the anisotropy.
@@ -197,7 +199,32 @@ and `surface_diffusion_anisotropic` (CPU science driver). Presets:
 initial surface and differ only in $\epsilon_a$. The anisotropic driver reads a
 simpler standalone JSON shape than the session-based verifier: `model.params`
 is $B_0$, $\epsilon_a$, $m$; `domain` requires `Lz: 1`; `initial_conditions` is
-a single object with `h0` and a `modes` array.
+a single object with `h0` and a `modes` array. It accepts one key from the
+session shape unchanged: an optional `fields[]` entry naming a `.vti` path,
+which writes a snapshot of $h$ at every `saveat` alongside the diagnostics CSV.
+Both `nanosurface_*.json` presets use it; omitting it restores the previous
+CSV-only behaviour.
+
+## Visualisation
+
+![Both panels are the same surface annealed for the same time, from the same
+crossed corrugation (16 periods per axis, amplitude $0.05$ each): the only
+difference between the runs is $\epsilon_a$. Isotropically
+($\epsilon_a = 0$, left) the symbol depends on $\lvert\mathbf{k}\rvert$
+alone, so both ridge sets decay at one rate and the egg-crate pattern
+survives, merely fainter. With sixfold anisotropy ($\epsilon_a = 0.5$,
+$m = 6$, right) the surface has instead turned into stripes: the
+$x$-varying ridges, whose gradient points along $x$ and so samples the
+stiff end of $B(\theta)$ near $\theta = 0$, have been erased, while the
+$y$-varying ridges near the soft $\theta = \pi/2$ remain. This is the
+`energy_kx_frac`/`energy_ky_frac` = 0.249/0.751 of the table above, drawn.
+The shared diverging scale, centred on the conserved mean height $h = 0$,
+also carries the amplitude difference — the anisotropic surface is the
+flatter of the two, RMS $0.00155$ against $0.00238$. Neither number follows
+from the isolated single-orientation rates, for the reason given above:
+$\theta$ here is the orientation of the *combined* gradient of both ridge
+sets, so the two orientations do not decay
+independently.](figures/surface_diffusion_nanosurface_comparison.svg){#fig-sd-nanosurface}
 
 ## Scalability
 

--- a/docs/report/09_ehd_film.qmd
+++ b/docs/report/09_ehd_film.qmd
@@ -50,7 +50,9 @@ periodicity removes. Periodicity also means the disturbance must stay small
 compared with the box, or the measured spreading radius is measuring the box.
 That was checked directly rather than assumed: over the full $t \in [0,600]$
 run the RMS spreading radius peaks at $27.4$ (stiff) and $23.1$ (compliant),
-under 22 % of the $128$-unit domain half-width in both cases.
+under 22 % of the $128$-unit domain half-width in both cases — and
+@fig-ehd-load shows the same thing without a number, as a dent that occupies a
+small patch of an otherwise undisturbed box.
 
 ## Governing equations
 
@@ -115,7 +117,31 @@ ETD1 as in @eq-etd1, dealiased.
 
 ## Binaries and inputs
 
-`ehd_film` (CPU), `ehd_film_hip`. Preset `relaxation.json`.
+`ehd_film` (CPU) and `ehd_film_hip` run the verification preset,
+`relaxation.json`. `ehd_film_nonlinear` (CPU) runs the science presets, the
+pair `load_relaxation_compliant.json` / `load_relaxation_stiff.json`, which
+share a load and differ only in $B$. Like the verifier's input, theirs may
+carry an optional `fields[]` entry naming a `.vti` path; both presets use
+it, and the snapshots are written at the same `saveat` cadence as the
+diagnostics CSV rows.
+
+## Visualisation
+
+![The same Gaussian press ($p_0=0.5$, width $a=8$) held on both plates over
+$0 \le t < 60$ and sampled at $t=60$, the instant it lifts — which is also
+where both runs' CSV records their minimum central gap, so this is the
+deepest either dent ever gets. The only difference between the two runs is
+the bending stiffness. The compliant plate ($B=100$) yields into a deeper,
+tighter well ($h_{\mathrm{centre}} = 0.659$, RMS spreading radius $12.3$);
+the stiff plate ($B=640$) distributes almost the same displaced volume
+($106$ against $111$) into a shallower, wider depression
+($h_{\mathrm{centre}} = 0.747$, radius $14.2$). Both are ringed by the
+bulge where the displaced liquid has gone: @eq-ehd-pde evolves $h$ as a
+divergence, so whatever leaves the centre has to appear somewhere. The
+colour map is sequential because a gap thickness is one-sided, and the
+scale is shared, so
+"deeper" and "wider" are read off the same
+ruler.](figures/ehd_film_load_comparison.svg){#fig-ehd-load}
 
 ## Scalability
 

--- a/docs/report/README.md
+++ b/docs/report/README.md
@@ -50,7 +50,8 @@ Python but not matplotlib, so use a virtual environment.
 
 ## Field-visualisation figures
 
-Chapters `03_tungsten.qmd`, `05_cahn_hilliard.qmd`, and `06_thin_film.qmd`
+Chapters `03_tungsten.qmd`, `05_cahn_hilliard.qmd`, `06_thin_film.qmd`,
+`07_surface_diffusion.qmd`, and `09_ehd_film.qmd`
 show real simulation output — a "Visualisation" section near the end of
 each — rendered by `figures/field_io.py` (readers) and `figures/field_plots.py`
 (panels, montages, comparisons) from real runs, not synthesised data. As with
@@ -69,9 +70,9 @@ field_data_dir=/flash/project_462001519/juaho/tmp-shared/report-figures
 ./scripts/build.sh --machine=lumi --cpu --no-submit --no-test \
     --build-dir="$build_dir"
 
-# 2. Run the three demo applications (cahn_hilliard, thin_film, tungsten)
-#    and write their .vti/.bin output somewhere. On the shared LUMI
-#    allocation:
+# 2. Run the demo applications (cahn_hilliard, thin_film, tungsten,
+#    surface_diffusion, ehd_film) and write their .vti/.bin output
+#    somewhere. On the shared LUMI allocation:
 SLURM_JOB_ID=$(cat /flash/project_462001519/juaho/shared_job_id.txt) \
 TMPDIR=/flash/project_462001519/juaho/tmp-shared \
 RUNNER="srun --overlap -n 1" \
@@ -86,8 +87,9 @@ FIELD_DATA_DIR="$field_data_dir" \
 ```
 
 `run_field_demos.sh` documents, next to each run, why its parameters were
-chosen (in particular: two of the three runs deliberately extend the
+chosen (in particular: the two `thin_film` runs deliberately extend the
 shipped preset's `t1`/`saveat` past what the default JSON input uses,
+while the `surface_diffusion` and `ehd_film` pairs deliberately do not,
 and the tungsten run uses the 256³ preset rather than the 32³ one because
 `SingleSeed`'s seed radius does not fit inside the smaller domain). Read
 those comments before changing a parameter — the values are not arbitrary,
@@ -115,6 +117,11 @@ To add a field figure for another application:
    this for free — an extension of `.vti`/`.vtk` selects the VTK writer) or
    read the raw `.bin` dump it already writes; add the run to
    `run_field_demos.sh` (or a similar recipe) so the figure is reproducible.
+   An application with its own `main()` rather than a session — the science
+   drivers of `surface_diffusion` and `ehd_film` — reads the same `fields[]`
+   key through `apps/common/include/openpfc_apps/field_snapshots.hpp`, which
+   is two calls: build the writer after the field exists, then write a
+   snapshot wherever the driver already samples its diagnostics.
 2. **Read it.** `field_io.read_vti(path)` returns a `Field2D` directly. For a
    `.bin` dump, build a `field_io.GridSpec` from the run's JSON `domain`
    (`nx`/`ny`/`nz` are grid *point counts* — `domain.Lx` etc., not physical

--- a/docs/report/figures/ehd_film_load_comparison.svg
+++ b/docs/report/figures/ehd_film_load_comparison.svg
@@ -1,0 +1,1626 @@
+<?xml version="1.0" encoding="utf-8" standalone="no"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN"
+  "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="608.629203pt" height="289.111321pt" viewBox="0 0 608.629203 289.111321" xmlns="http://www.w3.org/2000/svg" version="1.1">
+ <metadata>
+  <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+   <cc:Work>
+    <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
+    <dc:date>2026-09-10T11:53:01.880040</dc:date>
+    <dc:format>image/svg+xml</dc:format>
+    <dc:creator>
+     <cc:Agent>
+      <dc:title>Matplotlib v3.11.1, https://matplotlib.org/</dc:title>
+     </cc:Agent>
+    </dc:creator>
+   </cc:Work>
+  </rdf:RDF>
+ </metadata>
+ <defs>
+  <style type="text/css">*{stroke-linejoin: round; stroke-linecap: butt}</style>
+ </defs>
+ <g id="figure_1">
+  <g id="patch_1">
+   <path d="M 0 289.111321 
+L 608.629203 289.111321 
+L 608.629203 0 
+L 0 0 
+z
+" style="fill: #ffffff"/>
+  </g>
+  <g id="axes_1">
+   <g id="patch_2">
+    <path d="M 60.133642 253.910618 
+L 269.716988 253.910618 
+L 269.716988 44.327273 
+L 60.133642 44.327273 
+z
+" style="fill: #ffffff"/>
+   </g>
+   <g clip-path="url(#pd7c3492578)">
+    <image xlink:href="data:image/png;base64,
+iVBORw0KGgoAAAANSUhEUgAAASMAAAEjCAYAAAB5IGctAAAiy0lEQVR4nO2d63YbuZJmPwCZZIqyXT5VfXrmWeZd+8HmCaZP11R1lS1RZGYC0T8CQCKTpETKuoDyt9fysi3xkqTNrYhAIGD+4//+HwEhhLwz9r0vgBBCAMqIEFIJlBEhpAooI0JIFVBGhJAqoIwIIVVAGRFCqoAyIoRUAWVECKkCyogQUgWUESGkCigjQkgVUEaEkCqgjAghVUAZEUKqgDIihFQBZUQIqQLKiBBSBZQRIaQKKCNCSBVQRoSQKqCMCCFVQBkRQqqAMiKEVAFlRAipAsqIEFIFlBEhpAooI0JIFVBGhJAqoIwIIVVAGRFCqoAyIoRUAWVECKkCyogQUgWUESGkCigjQkgVUEaEkCqgjAghVUAZEUKqgDIihFQBZUQIqQLKiBBSBZQRIaQKKCNCSBVQRoSQKqCMCCFVQBkRQqqAMiKEVAFlRAipAsqIEFIFlBEhpAooI0JIFVBGhJAqoIwIIVVAGRFCqoAyIoRUAWVECKkCyogQUgWUESGkCigjQkgVUEaEkCqgjAghVUAZEUKqgDIihFQBZUQIqQLKiBBSBZQRIaQKKCNCSBVQRoSQKqCMCCFVQBkRQqqAMiKEVAFlRAipAsqIEFIFlBEhpAooI0JIFVBGhJAqoIwIIVVAGRFCqoAyIoRUAWVECKkCyogQUgWUESGkCigjQkgVUEaEkCqgjAghVdC89wWQuvHycj+vnAkv9ljk48HIiBBSBYyMSOYlo6BzH5/REklQRj8xry2f51wD5fTzQhn9RNQgn6egnH5eKKOfgOdKyL9CSdHhMrmka6eUPj6U0QfmEgm9hnjOfZ5zBEUpfXwoow/IuRJ6KwE9RXkdT4mpfG0U08eCMvognCOg58oniHnW/UqskbNut7zGx+TEaOljUcePRkLITw8jow/AU1HRuRHRS0RAlz72UxFTuvanIiRGR9cPZXTFvISEXlNA51A+/2NiekpKTNmuH6ZpV8qPiiiIeXcRLUnX9Nh1PfW6rqGXihyHkdEVcuoDd46AXgNr5MUfOz3esWjpqdU3RknXCWV0ZTxHRD8iinNXwc653XOu4zEpAfq6H0vdKKTrgTK6Et5CQk8J5dLuaWB+fcce/9xrPCdSOhUlUUjXAWVUOY/VQE6J6BIJnRLQsQ/2sz7UJ/yWrr18/nOu+7GC96koiWnbdUAZVcylIvoRCT0lH/uMqEifJyAU15rFUDzej4jpXCGl56aQ6oVLD4SQKmBkdIU8Nyo6lpKlKGIZMdj8dTm47SVopOL1z2Jg4/OU0VJK5Y7Vl556Xaeio+deL3k/KKNKObdg/VISKtOwJKB0myQQd6oA9Nhzx8cIYuFMKQoPn649vYTi4Zep22Ov81Rx+1jKxlStXiijCjkmopeIhtxMOJOEnpLPcWGdt7vexev28bFmjwGbIycvZpIScBAtndPLdG4NiQXtOqGMKuOlRHRMQsuCtDMyE1ApH1vcxx0RyfLxltffGk3NUjrmjYEXizZdPyw8BBahiJrkZLTkYc+Oki5ZZaOQ6oEyqoRL+oieK6KyDrSU0DEBqbCmKMkuPrhHP+BmmUZaeBi08bVkOSHAwsboSOBhAAGcSa9bcrTkRWVybup2LG2jkOqHMqqAlxLRseX6U+lYKaHWjFk+QCEjE/QxUmRkyhTrqd32ep2TfAy8sQhS/D3KyRuDQZpJSoBGRMYCEmZR0rLIfUmURCHVDWVUKZcWqh+LhlIkVNaClhLSv/t8/0lGEv9cPn5K2450VBeFHw8DGI8gJsrHHMhpEAcrFs5IlpJ+P15XipxSTWlR5H4pIZH3h31GhJAqYGT0zrzEyAu7WA0DjkdFqxj5WOif8+8xHZsioykaamd1phQRzXEG8EeytgDkiAgABi1X6+uOX3cIOX3rxeVUsoeDg0UPHKRsZRf3OdHROTBVe38oo3fkJXqJnhJRSsVSWqa31a+3xmcJrRCKxxK0uYitsimvyOXnKa4rFZ6lTIkAQBCMwAuwQoCP9xliYXuFgB4WAxysCRjEFfdP4kr1rGZWQyoL248J6ViqtnzP8uNRSO8GZVQZPyKiZbE6iag1o8oo6mFlfCEjFU9bFLhbSBaQg0pH/1xuUj1xXSZdt8TXIzFCEngAAek5PIYYHdkYiaVISV+ToBcHGMDCAtIAZkQWUnyu5wpJr431o5qgjN6Jc9KzS0WUVsOm1EtFVMoHAFbwaI3P0Y/KSPKyeou5gKwx+ns51OyUjNLri9IJCFFIksWUvu/i19xMRlN0Zk2Ak4Ah/TeNQkqNlL3gh4V0cN2Mjt4NyqgSLjlG6GAJv0jL9PvzmlAS0SpGRklEXY6MVEBtFMxSQCqm+fVZnLu65wohhUJSghaCIcvIT8v6iSib2WtNdaT452UdqXzuc+pIjI7qgTJ6B5ZR0XO3eqQ+ojIt06/LgYg6M2AVP3StCTkaag2wMgZtFBAAtHAzASXxOHO+MFPlx0vQ1kYjSGLS1ywY4KdiOQSDCLAsoi9E0cu0xWSWtsVl/3NG7z6VrnG7yPtAGV0ZZXp2rFANYJaadWbIBep1StNMmEVDrbFZQIDWaJ4joGOk+ztMYkqvw8HE4rSPPUVSpGle+5gEgBmORy/LOtJCSK8xm5u8HuwzIoRUASOjN+a5Kdrp3feSO6ZTmlamZ2VUtIppx7pIzVqjcVBr3MXRkJfDaOWx+5bf00gppkyiBfHZ1hMIkF5nKlQf+9kpjaZ+xiLI/P05VdA+d+8ai9lvC2V0peQULe0zM9M+tGWdaG08upiaAXMRqYQ0LXtMJF5CXpYHkGs/S0ZJjZVTvenU47rYyNgaN20jKZbtUdaMYro2uyaYWBQ3MT0zB8Vscj1QRm/Ej4wGWUZFZa0orZy1Zsx9RGnlrIyIUqEaANZFjaiBOymLJKCAAC8yKz6XfUTTtc37kPJqXPz9mJicsTlKyj1FAGzsSgKm54UAAX7W9Jj+3GO+upZu/9hy/zn71hgdvR2U0ZVSpmep+Ls60ke0MiGnZesoghYup2XHRFRKaBCvK18SdLULyJrwgtlH1xa9SlY0FWuNQRuF1BqXJbZ8bo2SCvHmZf0Q/xIQYODh82bZELeR+LihdpmukeuCMqqEU6s+p5oby/RsqhFpzSiJqC0iohYGbVzJOiWiVAMa4eFFsJcRAwS9CPYC9DG6G2Dzdo4w6++Zaj6pq1tl6PUaJGBtmvg60vyipZBSquliJCSAQWyaDLNepHLfmw5rK9I1YLa6dm50RN4PyugNODdFO5dpLpEWrW3cX5Y6rFNDYwvR5ftYH5qW7g9FNIjP6dBORuwlYCeCnRjspMFOHHaicxp3ocUApzOIpJTJtP+thUdnB3RmQGd8/BUwQOs+a1h0RreNtMYVjxEfTwJcjKogIW4nmfqQ9D308LA6QdKM8KIVJpebHi9/b5mqvR+UUQWcExXN9p2VReuYnpUrUalfpzVFH5FxaGJkdExEg3jsRUWyk4CtAPfSYBtafAsdtrLGLqiM7sMaO2kxiDuIjJIQOzPg1u7R2QEbs8cXu8PGDriNsvLGIxjJkVIppHyNRQd2klEQWbxOjQxDFEaKjvQ+htHRFcFlB0JIFTAyujKOpWgpImnz0n5RK4p9RLrH7PBnTxkV3cd6zfdgsZUGf4UbfA83+OY7fA83uPMdAGAbVtj6FQZxGMMU0TR2ShU3rsfG9vjkdvhsH7B1a3yWBwz2AQDQmxGfbQAw5vsfi46C6FaR1mhBPdWOgFQz0lTNSpilaum9YjH7eqCM3oFL6kXlUn6iTNFcHIy2QsiD0Ga1omLlbMlSRN+DXtffYY2/wgZ/+Q3+8J/w3+Mt/h5v8G1UGT34FttxhT40CGJymmONYGVVLpumx40b8KXZ4ZfmAf9o7vGbazE4/S/31W4B7IEnhGTjKlwqZufaEXTeUYDBEN+jWaoGrfVYnL9vLcFDIN8HyuiVeaoB76l60ZJyOb8sXFsjU9QUa0XWmLjh9fjKWUCYiejvsAYA/BFu8fv4BX+On/D/h0/4Y7jF38MNvvUxMhpW2I0NBm8Rgp1kZANapx/grhmxaXt8We3wre2wbVfYt20ugvsmve5JSM6YfFRR3tMWV9jS62hhMJRjRiBoi0J2mpsNpPElC7k9s27EIvbrQxldCeV4EFf+KjaYtnlwmTYgtnBH0zMvASM8djJiV4joj3ALAPh9/IJ/Db/gv/rP+L3/hD/3t/hrd4P7/QoAsB8aDH2D4A3ET49tXIB18RpWI9btiG/rDnfdGg/rFvvQzCY5Tv/79nA2wMqIrmhYLIUURNDC5dEjQNr5L7mQnd6PcrStA/uOrgXKqGLy2WaLdKHc4T6tnIXccOgWUdGSAIl9RLpqpvWhDX4fvwAA/jX8gv/X/4L/3H3BH7tb/Lm9wXa3Rr/T/y5h1wCDgRksTOpJNIBYYGxjr1LbYt+N2HUtHoYGe9+gD81BquQa0Y5x6eEkZNHorv7yNRdRXtpDB53RPYidvRd+qhrl9yst2f9ISwV5XSijN+bSD8N0iOL8yOlUuNZfafYP4vdwMJkRmJoaU3q2E8F9LFT/5Tf4c/wEAPiv/jP+c/cF/9p+xl/bG9zddxi3DcxDbA3YWbgesIPRCR5JRg0Q4gY4vwJCZ7G7cRgHhxAsxlBulA15/5w2bAa0MqKN9aOUspVR3bS1pHydWqtKaauVgCQhlwe6Oa0lXbhnjYPX3hbK6BV57obNw0mOh5MdyxStRUCaVw3MRVR+mNNG10E8BmhD4za0+B5u8IfX+hAA/N5/wh+7W/y1vcH3uxv4uwb23qHZqmiarYHtAddrD6IJArEG4gC/ih3RK2DcWIyDwegNvsc6TWPjaFw7Ym1HrO2Azg64NX1sjJyu0Ro7vSZjEcRHIRWn3AIaHcWvp/dFH2N6/8pU7ZJJkCWsG70ulNE7csmHIR/AaA6bG/Xr01zqUylaudG1F8FOGnwLHb75Dv893uKPQWtGf+41Nbu77+DvGrjvDu2dRXOvj9NsgeZB4HqBzZGRIDSTjMYbAzsY2NFgCLqf7c50sFFGazfixg3YuB6f7QM2Zo+NHdDHxsu1SRtkp2StTNX09ceZ2bJ4L/J7oitr5/5QYPPj+8IEmhBSBYyMKmdZvE64stBrNF2x+XvH60XpTLNBAvYC7MRhK2t8Dzf4e7zB38MNAOCvnRasx62mZ+2dRfsdaL/HlbJ7QfsgcLsAO4puArMGoTHwXdxMu9fIyAQDwGpx2wm2rbYP/NWO+NTu8aXZ4Xtzgy+yw062eUtKF4vZHuFo3Qjx9eq5bpJH1DoI5lOPpveRxeu6oYwqpdyPNp+AGGbFa/1+Sk+mGdbAYb0o5FqKoBeLnbTYhRZ3vsO3sct9RPf7FfqdFqybrUFzryJaf4syugto70fYnYcdPCACGIPQOoQurmD1DWxc9pcoqqF16Nf6X+5+tcK3dYdvbYc732HntAeplyFeY0Aw2nF9rG6U3hcU6Zk1ZRE7rTraWRH7kuZH8rZQRldOPvX1jNtOncs6BmQXWtyHNbZhpV3Vw9RHFHYN3M6qjLYxGrqLxefvA9xdD7vtgWGE8QHiLGzbIGz0MUwQAC2CswitQWgN/NrCx/aA/U2D7RCfN6x0821oMVgbr3E61ujx1z+tqpHrhjK6MsrVnOUHMB01dKp4nQabBejx0gN0LMjWr7AdtasaAIZe+4hcD9hei9Xtg6C9j8vudz3stweYhz1k30NEh5qZ9Qp2nEZ8tNYgrFr4tWC80cfzg8nPsRsbbEfd57aTNJbE5msMIgjmeBE7/bl8C5bvhzMhr6iR+qGMrpBy+drmlaPTK3PLwfk+DiAbRDuiB3Hog27vAIDgtaHRRiG5PtaHdnG+9bZXEd1vIX0PeA84B4xjVqBtHOyqgds5uN7A9bGGNEzPMXirzxuvYZCm2FeGYrzsvG40fy8MEDfTAvP0dtbtTaqHMvqJmE5zhY5rFR3bOganG15jU6J47aw2o/YR2RGwo2h9CACGUSOivofs9xDvYVz84Dfxv1S3gh283i8+jhmBFNhJsa9Nn3+6nnSN56Rp5ONAGVXGc/pc3GW9e0dJu+8zor9MiAcpBtFCNaA1IgmA9xCvBWzxHsb7PDbW+KC3j/fXx5mnVQfP+Uxc3JV/KTzksS64rEAIqQLKqDKe85Pav0A2k+YR5cjMIG5+jaNbrQGM/hJnAWMB5zQ9M0Z/d06/bmy8jYn3Kx4n/Sqe80d57utnVFQXTNN+IqY+JMmjSKwJaKzP84gAHQUiVje+igNCA4RG+4gAwLYNzHoFjLq6ZmIB26xW+nUA0jbad9QYhPg40ujO/vQc1uomX33+6Xr0GufnsJGPD2V0hXix8CYVetPqk+DUZ9cZm0961b9PY2vzEdh2zIPRrBOMbdDeoFX81dnc0Bg2uoRvAC1YF0v7crPOtwmdg+9sfAwgtAKJI0acE7Qu6POadM7bONtrV17/6fciFeXj+xCHrJHrgzK6MvRYHhWLX/YSFae8Hs4DsrkPyUo610xHeGxcj03To2viMUOrEWPbqkBWuul12BvYXv+7mLgF3jYO6Fa56VGKpkf/aYXhtsFwYzDeGISVjhVBOw1f65oRm6bHxvU6SgTTHG8L7ZtabmtJs5jK15vfm8X7QSldF5TRlaPnzQP+yVtOaY+Djt3orB4ntLE6r3rT9gCAdTti340IncW40X4jO5i8vQNo0VoDu2pObgcZbhsMnyyGW4NxA4wbQegCbDfm59i08Xltn481SnO8Hc5L0/Lptkzprh7KqFI80nHPusHT5g9p3J0m+juMjx9EKfqItGu5bBa0xebZ1hisTNADFu2AT26HL80OX1Y7AMC3dYdd18bBaDoGRDe8KsFZhFULt3OnN8reGAy3BsNng/FWZSQ3Husoo9u1zsf+0uzwye3ygY+rfMKJiWeaFCfIFsPh9D1KkWCcoSTF+4LplNm0F82L5b60iqGMKifAwh2Je6YPoB7xHIzk/f0+boq1RaLmzLTbvYXFOp7yujF7fLYP+KV5wLdWN8redWs8DA3GwWH0Oo9Id97H52wN/Fq0q7qY9LicZzRugPEWGD4FhFuPZjNi0+0BAF+7B/zS6vOmeUad8VhH96QTcJf1olDsWQvxly/6lU5FSIESqh7+CxFCqoCR0TtySQdw2ibhIfDGoEU6xHDayzVFDHKyiA1oLWZlDDrj8cXusHVr/KO5x7bV4vPDusXeNwjB4rsYeOiSfGimyEg3vpojY2fj9a40NRs3gnDr4T6N+HS7w68bPcTx1/U9fmvv8Y/mHl/cDl/sDp3xWKXNvkdmMqXidS7Ui+Qeo9l7UZybFi4oYnPK4/tCGb0izxkCDxyOP9XB9Cj+rrUPb7QmMsBihZCTuZSmHasbAXpQYisBnQnY2AGf5QG/uRb7Vs802wc9ySMN0L8zHUYnGGKfkV8vB/KbYiB/FMUKCF2A3Gh69ul2h6+bB/zW6ezaf67u8G/tHX5zd5qm2QGdEbS5ruVO1ovKUSgBOg4l1Ya8HC7te1muOj6v2M35168LZfTGXHpcjhebi9iADgxrgVkROyDAG5MH7qdNpsfqRoAuia9NgwEDbs2IwT5gcE0+YHEQl5+vsdqcuG3XeTCa3zXwJ44qSn1EaAW2G7HutE70axTR/+6+AQD+ffUdvzZ3+Oq2+GofcGtGdMZgbZr4Og/Pe0siCvnvcTVRzEHxGsBB8fpSeDLI20IZVUw6KmdZxNZVopBTEx0HYtEi9R/JyVQNmGYCrWHhjUdvRny12+KUV8VBmxLXbsRf7Yj7VRy+dnP6EEe3OMTxdt3ja/eAX9f3+OfqDv+++g4A+F/t3/hn8w1f7RYbM2JjgHUsWqdrLClTNJ/TNJ3LVL4P2uqwlFhKcVkirRnK6ErIxz7DqmQwT9U0XSsPNxQM8HA4PH9Mj4wGOgMEI/hsA4D99GTxf0VrPNZWT/H41O7xbf28461/aR/wW3uPf2vv8GtzBwD4Z/MNv9l7/GL3+GwDOmPRmQZNOvOsuN50FPcAH0+RVYaZhKYULUVBOpaE/UfXAmX0yjxVN7r07PfUc5T6jQZxGsHESElvMx37nKIjLAaUpSOjNS0a43n3k5BcI+jMgLXVDu0vzS4v/T/4FttxhT40eQxI2vS6stpHtGm0ofFLs8MvzQP+0dzjN6dpGQB8tdssoltjsTbN0dRMRTRFRUNZtI7PnYazxQnYxftw+L6fqhc9Vbxmvej1oYzegUvqRqn5MWUtDl5/4sdVNRv3qfWwxbTD6ahnCw+IFoSX6Vpryq8kIQHAPu8V6+yAz/YB35sb3PkYGQUdFTuIwximx2isz1tVNq7Hxvb45Hb4bB/wJf7+1epq2saMMxG1xi2uRwmQeOikHjw5ADkCHKCvO0dF8Yy0cgUt5O+dn6KxVvQ+UEZXRlpZS2Nj9bRUnWc9P9zR6+58BDhjEGK6BsxToAMhAXA2YCU9WhNwa3pszF6PEnJa4L4Pa51ZLW72wbcmZBl1ZshbPDZmjy92h43VgjkAbAzQPSGilJ4FBAwS0ItgiHUiIM7xjtegUeI0tja9V+R6YEWPEFIFjIwq4Km6UU7VAMDE5kaZGiB7cXH5f2r608gppWsh3xeAHnZ4JDrKK1kywklAK6NuGbEDdrLNS/+7kE7yaGb1MGcC2hj5tPB5v1kXt550RtDF51jHgrWFPRkVjfCaoknAEKOiZXOjh0UvbpaipZRsmaI9t15E3gbK6A04VsS+tN+o5FiqlgrZ+thpWqOfzqCXkDuajxW0W+NyWtMZoIWgxYjOCHoZsZdxOmDR2rykvkzT0nPriJKAlQlYG2BlTNwT18T3xKCBO1qwBqal/EHCrFa0E1ekaVPhen6yyPPTs2P1Ihav3wbKqBLST+flT+9ZdATkYnYZHfVpObyoGaXfU+0IBlrMjo/RGnd0hS19X4/NNhjEY20EnWjdBtADFnWDKmYfXT1quvgzdPd9Gzfpalf11A1+auUMwKxoXdaKUp1Ib9NgkEYjoyIqyn1FjIquCsroSvFiADMt83sE9PFDauMxzrqaJgBSm3SRrkk6c+xwkqLu8NfnsEY7vFukAxVjU2WcLFkeJ1TOH7LG5P1lrhgHcmpqY0rLUkPjAI99LFrvBegLESX5pvSsHBXCovX1Qhm9ESnUn9VYjqRqx+pHZc/RbKlfVER9umFa/pcQI6GQa002CwnQjRVxH5jR7SHHRJGkFBsKctQCIIvpFI9FQCUpGtIVM5+jrzIi6sViLw49LHq4KTKKdateXG5wTHWi/F7h/KiIKdr7QhldKV7sQbqWBDCU/6xmyA4K+cMmWWaADuhPaRtwfOb0JKb8lYOTak/d9/RrCLmPKC3fD/Fiy4goiSi1EwzS5PdgmZ5x1Oz1Qhm9Mcti9iXRUfpe2rMGzNM1yOE/p0PIaVnxaHnvmoegNTKlbZgiJb3e0x/uS8Sj1zrJK0VDXnTbSl4xi99fRkTlEdh9UTM6lp6V7+exqOhYnYhR0fvDHyOEkCpgZHRlHPQe5XSr0cPsgYMIycMu0jUTd/1LHjUSMEVDLVwuOgfxZ0VJpyiX6vX3FNFpRBRE5itmaatHLFgv07O+TNNia0NZK3oqKiL1Qhm9A89N1ZYcFRIAmFEL24tsJI1f84hD/I3KIKVsbZqrHcW0XA0LxdlryxEfS2bF7piOzeZXiz5nSs1SQ+Mup2DTylkponIj7GMiOsU5KRrTs/eBMqqEXAM64wN1OAnSzgrSaYXNLR+r6MCenldylJSKxy0kikivqxRTvp95QpQyRUKpFaAcjOajhHyMhlITZdnQuBRRqhHlEbyL1bPy/TkXboqtB8ronThnJO1j0VGZrjmESUgAeokiMmNO2dJ2CQAIeQaSjzLStC01S/q84z81Tk5iytf2VGRUHCipDZKCNCYWmCTkRcfmTjKaitO9OAzQhsYkohQNAcAly/jp/XwKRkXvB2VUGcuU7WIhAYd1JGm0VmPS/aYmQX0+jwCTR5AMELRRTklI+sipsxuz1beSFBEB08GSZbe2L2pCaWRsWi3zmHdXT/KxWNaH9Ll+TESMiuqCMnpHTkVHPyIkYJm2NTFVKpe+p9utjFcJIOSxtQ6CQSysUSmpeCRHTvnKonicQR54Nrs2pIhsmj9Unm+WIiEP7RVKNSEA+c+5oRGHTY36OJeL6JSEGBW9L5TRO/PcE0RKlvvXZmmbBCCOmU2d2mlKZGtGBLGwEvQ6ivu7OAtpgC22laT7JynFrxWf9TCT3vygyVm9J0ZmQ9pXhin6AZCjoR8V0blQRO8P+4wIIVXAyKhSjqVqwOko4GD/GjAdOx2XzdPqWkrbvNg8gygUg+ydmSKjFCXpTv4penB4vBg8RUXzSGj290VElKKhdL8yIgLmu/DL1/0Y56Zo5P2hjCrg3NoR8HT9KN0GKPqQgNnSf0rbppqOSsnmeUhRRjF9069J/n55fUsOZVEMyC/ONZvJ6MhspGOp2WuJiClaHVBGlXBsVz/wvIbIZZS0XPrPkVLck5akNI+c9ETaJKYBgF1sjD32IT7o+VnIp/z6UkLlHrNTK2bp9T3GJStnFFE9UEaVce5UyHOElG43S9sSZi4ljVJS46UB4oD/QaYPbBkZORPyMvwxck/TgVSmay5HxJbp2Pz2l23voIiuF8qoQk4JCZh/OM/ZMnK0lgTM0rcgKhqfpxdNEZLez8y+Duj2jXM4rB2VwjkeBR1cK15WRJRQnVBGlXJJDxLw+Id1WUsCcBgtmfL2k5xS1ASU85DO55h89LEej4KW1/4YpzqrKaLrgjK6Qp67sbb8/tGVtwIPLWqHYlJkipwu5Zh4ls/12LU+BjurPw7sMyKEVAEjo4p5rDv7VHQEnBdVHG0DWD7+oobznBTn1PX/SDSUuDQqYopWN5RR5Zxa8gdOn732HCmV9wNOjDJ5xqk+T41EeQkBJbhqdt1QRlfCY31IwPEP/SVSOnW7JwV1AT+yh+w5EgIoomuCMroyLunWTlwqpZJzV7Nea8TrUzOIKKKPA2V0hTwmpMRjkRLwsvOhX0NEz42EAEroWuFq2pXy1AfuqQ+sNVLd0c7pmiiinxNGRlfMY8Vt4Ly52q8VLZ3LuUKkhD4+lNEH4KkBbecO+z8lhpeQ1HOjsHMaGCmijwHTNEJIFTAy+iCU0cFTaVu+3Zk/i96ytnTJVg5GRB8LyugD8lQtKd/uidW3t4ICIgBl9KE5V0rAeVMbX+SanrmJlRL6+FBGPwGXSGl2vwp2v1NCPw+U0U/E8oP9o0ckvQaUz88LZfQTU4OcKB+SoIxI5pwB+y/9+IQk6ovTCSE/JYyMyKMwmiFvBSMjQkgVUEaEkCqgjAghVUAZEUKqgDIihFQBZUQIqQLKiBBSBZQRIaQKKCNCSBVQRoSQKqCMCCFVQBkRQqqAMiKEVAFlRAipAsqIEFIFlBEhpAooI0JIFVBGhJAqoIwIIVVAGRFCqoAyIoRUAWVECKkCyogQUgWUESGkCigjQkgVUEaEkCqgjAghVUAZEUKqgDIihFQBZUQIqQLKiBBSBZQRIaQKKCNCSBVQRoSQKqCMCCFVQBkRQqqAMiKEVAFlRAipAsqIEFIFlBEhpAooI0JIFVBGhJAqoIwIIVVAGRFCqoAyIoRUAWVECKkCyogQUgWUESGkCigjQkgVUEaEkCqgjAghVUAZEUKqgDIihFQBZUQIqQLKiBBSBZQRIaQKKCNCSBVQRoSQKqCMCCFVQBkRQqqAMiKEVAFlRAipAsqIEFIFlBEhpAooI0JIFVBGhJAqoIwIIVVAGRFCqoAyIoRUAWVECKkCyogQUgWUESGkCigjQkgVUEaEkCqgjAghVUAZEUKqgDIihFQBZUQIqQLKiBBSBZQRIaQKKCNCSBVQRoSQKqCMCCFVQBkRQqqAMiKEVMH/ADCJmGiB/tQnAAAAAElFTkSuQmCC" id="image3fe74a7942" transform="scale(1 -1) translate(0 -209.52)" x="60.48" y="-44.311321" width="209.52" height="209.52"/>
+   </g>
+   <g id="matplotlib.axis_1">
+    <g id="xtick_1">
+     <g id="line2d_1">
+      <defs>
+       <path id="mdb07662f7b" d="M 0 0 
+L 0 3.5 
+" style="stroke: #000000; stroke-width: 0.8"/>
+      </defs>
+      <g>
+       <use xlink:href="#mdb07662f7b" x="60.133642" y="253.910618" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_1">
+      <!-- 0 -->
+      <g transform="translate(57.588642 266.988743) scale(0.08 -0.08)">
+       <defs>
+        <path id="DejaVuSans-13" d="M 2034 4250 
+Q 1547 4250 1301 3770 
+Q 1056 3291 1056 2328 
+Q 1056 1369 1301 889 
+Q 1547 409 2034 409 
+Q 2525 409 2770 889 
+Q 3016 1369 3016 2328 
+Q 3016 3291 2770 3770 
+Q 2525 4250 2034 4250 
+z
+M 2034 4750 
+Q 2819 4750 3233 4129 
+Q 3647 3509 3647 2328 
+Q 3647 1150 3233 529 
+Q 2819 -91 2034 -91 
+Q 1250 -91 836 529 
+Q 422 1150 422 2328 
+Q 422 3509 836 4129 
+Q 1250 4750 2034 4750 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-13"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_2">
+     <g id="line2d_2">
+      <g>
+       <use xlink:href="#mdb07662f7b" x="101.06789" y="253.910618" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_2">
+      <!-- 50 -->
+      <g transform="translate(95.97789 266.988743) scale(0.08 -0.08)">
+       <defs>
+        <path id="DejaVuSans-18" d="M 691 4666 
+L 3169 4666 
+L 3169 4134 
+L 1269 4134 
+L 1269 2991 
+Q 1406 3038 1543 3061 
+Q 1681 3084 1819 3084 
+Q 2600 3084 3056 2656 
+Q 3513 2228 3513 1497 
+Q 3513 744 3044 326 
+Q 2575 -91 1722 -91 
+Q 1428 -91 1123 -41 
+Q 819 9 494 109 
+L 494 744 
+Q 775 591 1075 516 
+Q 1375 441 1709 441 
+Q 2250 441 2565 725 
+Q 2881 1009 2881 1497 
+Q 2881 1984 2565 2268 
+Q 2250 2553 1709 2553 
+Q 1456 2553 1204 2497 
+Q 953 2441 691 2322 
+L 691 4666 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-18"/>
+       <use xlink:href="#DejaVuSans-13" transform="translate(63.625 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_3">
+     <g id="line2d_3">
+      <g>
+       <use xlink:href="#mdb07662f7b" x="142.002137" y="253.910618" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_3">
+      <!-- 100 -->
+      <g transform="translate(134.367137 266.988743) scale(0.08 -0.08)">
+       <defs>
+        <path id="DejaVuSans-14" d="M 794 531 
+L 1825 531 
+L 1825 4091 
+L 703 3866 
+L 703 4441 
+L 1819 4666 
+L 2450 4666 
+L 2450 531 
+L 3481 531 
+L 3481 0 
+L 794 0 
+L 794 531 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-14"/>
+       <use xlink:href="#DejaVuSans-13" transform="translate(63.625 0)"/>
+       <use xlink:href="#DejaVuSans-13" transform="translate(127.25 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_4">
+     <g id="line2d_4">
+      <g>
+       <use xlink:href="#mdb07662f7b" x="182.936384" y="253.910618" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_4">
+      <!-- 150 -->
+      <g transform="translate(175.301384 266.988743) scale(0.08 -0.08)">
+       <use xlink:href="#DejaVuSans-14"/>
+       <use xlink:href="#DejaVuSans-18" transform="translate(63.625 0)"/>
+       <use xlink:href="#DejaVuSans-13" transform="translate(127.25 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_5">
+     <g id="line2d_5">
+      <g>
+       <use xlink:href="#mdb07662f7b" x="223.870631" y="253.910618" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_5">
+      <!-- 200 -->
+      <g transform="translate(216.235631 266.988743) scale(0.08 -0.08)">
+       <defs>
+        <path id="DejaVuSans-15" d="M 1228 531 
+L 3431 531 
+L 3431 0 
+L 469 0 
+L 469 531 
+Q 828 903 1448 1529 
+Q 2069 2156 2228 2338 
+Q 2531 2678 2651 2914 
+Q 2772 3150 2772 3378 
+Q 2772 3750 2511 3984 
+Q 2250 4219 1831 4219 
+Q 1534 4219 1204 4116 
+Q 875 4013 500 3803 
+L 500 4441 
+Q 881 4594 1212 4672 
+Q 1544 4750 1819 4750 
+Q 2544 4750 2975 4387 
+Q 3406 4025 3406 3419 
+Q 3406 3131 3298 2873 
+Q 3191 2616 2906 2266 
+Q 2828 2175 2409 1742 
+Q 1991 1309 1228 531 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-15"/>
+       <use xlink:href="#DejaVuSans-13" transform="translate(63.625 0)"/>
+       <use xlink:href="#DejaVuSans-13" transform="translate(127.25 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_6">
+     <g id="line2d_6">
+      <g>
+       <use xlink:href="#mdb07662f7b" x="264.804878" y="253.910618" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_6">
+      <!-- 250 -->
+      <g transform="translate(257.169878 266.988743) scale(0.08 -0.08)">
+       <use xlink:href="#DejaVuSans-15"/>
+       <use xlink:href="#DejaVuSans-18" transform="translate(63.625 0)"/>
+       <use xlink:href="#DejaVuSans-13" transform="translate(127.25 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="text_7">
+     <!-- x (grid units) -->
+     <g transform="translate(136.014221 279.749212) scale(0.09 -0.09)">
+      <defs>
+       <path id="DejaVuSans-5b" d="M 3513 3500 
+L 2247 1797 
+L 3578 0 
+L 2900 0 
+L 1881 1375 
+L 863 0 
+L 184 0 
+L 1544 1831 
+L 300 3500 
+L 978 3500 
+L 1906 2253 
+L 2834 3500 
+L 3513 3500 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-3" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-b" d="M 1984 4856 
+Q 1566 4138 1362 3434 
+Q 1159 2731 1159 2009 
+Q 1159 1288 1364 580 
+Q 1569 -128 1984 -844 
+L 1484 -844 
+Q 1016 -109 783 600 
+Q 550 1309 550 2009 
+Q 550 2706 781 3412 
+Q 1013 4119 1484 4856 
+L 1984 4856 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-4a" d="M 2906 1791 
+Q 2906 2416 2648 2759 
+Q 2391 3103 1925 3103 
+Q 1463 3103 1205 2759 
+Q 947 2416 947 1791 
+Q 947 1169 1205 825 
+Q 1463 481 1925 481 
+Q 2391 481 2648 825 
+Q 2906 1169 2906 1791 
+z
+M 3481 434 
+Q 3481 -459 3084 -895 
+Q 2688 -1331 1869 -1331 
+Q 1566 -1331 1297 -1286 
+Q 1028 -1241 775 -1147 
+L 775 -588 
+Q 1028 -725 1275 -790 
+Q 1522 -856 1778 -856 
+Q 2344 -856 2625 -561 
+Q 2906 -266 2906 331 
+L 2906 616 
+Q 2728 306 2450 153 
+Q 2172 0 1784 0 
+Q 1141 0 747 490 
+Q 353 981 353 1791 
+Q 353 2603 747 3093 
+Q 1141 3584 1784 3584 
+Q 2172 3584 2450 3431 
+Q 2728 3278 2906 2969 
+L 2906 3500 
+L 3481 3500 
+L 3481 434 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-55" d="M 2631 2963 
+Q 2534 3019 2420 3045 
+Q 2306 3072 2169 3072 
+Q 1681 3072 1420 2755 
+Q 1159 2438 1159 1844 
+L 1159 0 
+L 581 0 
+L 581 3500 
+L 1159 3500 
+L 1159 2956 
+Q 1341 3275 1631 3429 
+Q 1922 3584 2338 3584 
+Q 2397 3584 2469 3576 
+Q 2541 3569 2628 3553 
+L 2631 2963 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-4c" d="M 603 3500 
+L 1178 3500 
+L 1178 0 
+L 603 0 
+L 603 3500 
+z
+M 603 4863 
+L 1178 4863 
+L 1178 4134 
+L 603 4134 
+L 603 4863 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-47" d="M 2906 2969 
+L 2906 4863 
+L 3481 4863 
+L 3481 0 
+L 2906 0 
+L 2906 525 
+Q 2725 213 2448 61 
+Q 2172 -91 1784 -91 
+Q 1150 -91 751 415 
+Q 353 922 353 1747 
+Q 353 2572 751 3078 
+Q 1150 3584 1784 3584 
+Q 2172 3584 2448 3432 
+Q 2725 3281 2906 2969 
+z
+M 947 1747 
+Q 947 1113 1208 752 
+Q 1469 391 1925 391 
+Q 2381 391 2643 752 
+Q 2906 1113 2906 1747 
+Q 2906 2381 2643 2742 
+Q 2381 3103 1925 3103 
+Q 1469 3103 1208 2742 
+Q 947 2381 947 1747 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-58" d="M 544 1381 
+L 544 3500 
+L 1119 3500 
+L 1119 1403 
+Q 1119 906 1312 657 
+Q 1506 409 1894 409 
+Q 2359 409 2629 706 
+Q 2900 1003 2900 1516 
+L 2900 3500 
+L 3475 3500 
+L 3475 0 
+L 2900 0 
+L 2900 538 
+Q 2691 219 2414 64 
+Q 2138 -91 1772 -91 
+Q 1169 -91 856 284 
+Q 544 659 544 1381 
+z
+M 1991 3584 
+L 1991 3584 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-51" d="M 3513 2113 
+L 3513 0 
+L 2938 0 
+L 2938 2094 
+Q 2938 2591 2744 2837 
+Q 2550 3084 2163 3084 
+Q 1697 3084 1428 2787 
+Q 1159 2491 1159 1978 
+L 1159 0 
+L 581 0 
+L 581 3500 
+L 1159 3500 
+L 1159 2956 
+Q 1366 3272 1645 3428 
+Q 1925 3584 2291 3584 
+Q 2894 3584 3203 3211 
+Q 3513 2838 3513 2113 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-57" d="M 1172 4494 
+L 1172 3500 
+L 2356 3500 
+L 2356 3053 
+L 1172 3053 
+L 1172 1153 
+Q 1172 725 1289 603 
+Q 1406 481 1766 481 
+L 2356 481 
+L 2356 0 
+L 1766 0 
+Q 1100 0 847 248 
+Q 594 497 594 1153 
+L 594 3053 
+L 172 3053 
+L 172 3500 
+L 594 3500 
+L 594 4494 
+L 1172 4494 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-56" d="M 2834 3397 
+L 2834 2853 
+Q 2591 2978 2328 3040 
+Q 2066 3103 1784 3103 
+Q 1356 3103 1142 2972 
+Q 928 2841 928 2578 
+Q 928 2378 1081 2264 
+Q 1234 2150 1697 2047 
+L 1894 2003 
+Q 2506 1872 2764 1633 
+Q 3022 1394 3022 966 
+Q 3022 478 2636 193 
+Q 2250 -91 1575 -91 
+Q 1294 -91 989 -36 
+Q 684 19 347 128 
+L 347 722 
+Q 666 556 975 473 
+Q 1284 391 1588 391 
+Q 1994 391 2212 530 
+Q 2431 669 2431 922 
+Q 2431 1156 2273 1281 
+Q 2116 1406 1581 1522 
+L 1381 1569 
+Q 847 1681 609 1914 
+Q 372 2147 372 2553 
+Q 372 3047 722 3315 
+Q 1072 3584 1716 3584 
+Q 2034 3584 2315 3537 
+Q 2597 3491 2834 3397 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-c" d="M 513 4856 
+L 1013 4856 
+Q 1481 4119 1714 3412 
+Q 1947 2706 1947 2009 
+Q 1947 1309 1714 600 
+Q 1481 -109 1013 -844 
+L 513 -844 
+Q 928 -128 1133 580 
+Q 1338 1288 1338 2009 
+Q 1338 2731 1133 3434 
+Q 928 4138 513 4856 
+z
+" transform="scale(0.015625)"/>
+      </defs>
+      <use xlink:href="#DejaVuSans-5b"/>
+      <use xlink:href="#DejaVuSans-3" transform="translate(59.1875 0)"/>
+      <use xlink:href="#DejaVuSans-b" transform="translate(90.96875 0)"/>
+      <use xlink:href="#DejaVuSans-4a" transform="translate(129.984375 0)"/>
+      <use xlink:href="#DejaVuSans-55" transform="translate(193.46875 0)"/>
+      <use xlink:href="#DejaVuSans-4c" transform="translate(234.578125 0)"/>
+      <use xlink:href="#DejaVuSans-47" transform="translate(262.359375 0)"/>
+      <use xlink:href="#DejaVuSans-3" transform="translate(325.84375 0)"/>
+      <use xlink:href="#DejaVuSans-58" transform="translate(357.625 0)"/>
+      <use xlink:href="#DejaVuSans-51" transform="translate(421 0)"/>
+      <use xlink:href="#DejaVuSans-4c" transform="translate(484.375 0)"/>
+      <use xlink:href="#DejaVuSans-57" transform="translate(512.15625 0)"/>
+      <use xlink:href="#DejaVuSans-56" transform="translate(551.359375 0)"/>
+      <use xlink:href="#DejaVuSans-c" transform="translate(603.453125 0)"/>
+     </g>
+    </g>
+   </g>
+   <g id="matplotlib.axis_2">
+    <g id="ytick_1">
+     <g id="line2d_7">
+      <defs>
+       <path id="me365e4cf9e" d="M 0 0 
+L -3.5 0 
+" style="stroke: #000000; stroke-width: 0.8"/>
+      </defs>
+      <g>
+       <use xlink:href="#me365e4cf9e" x="60.133642" y="253.910618" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_8">
+      <!-- 0 -->
+      <g transform="translate(48.043642 256.94968) scale(0.08 -0.08)">
+       <use xlink:href="#DejaVuSans-13"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_2">
+     <g id="line2d_8">
+      <g>
+       <use xlink:href="#me365e4cf9e" x="60.133642" y="212.976371" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_9">
+      <!-- 50 -->
+      <g transform="translate(42.953642 216.015433) scale(0.08 -0.08)">
+       <use xlink:href="#DejaVuSans-18"/>
+       <use xlink:href="#DejaVuSans-13" transform="translate(63.625 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_3">
+     <g id="line2d_9">
+      <g>
+       <use xlink:href="#me365e4cf9e" x="60.133642" y="172.042124" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_10">
+      <!-- 100 -->
+      <g transform="translate(37.863642 175.081186) scale(0.08 -0.08)">
+       <use xlink:href="#DejaVuSans-14"/>
+       <use xlink:href="#DejaVuSans-13" transform="translate(63.625 0)"/>
+       <use xlink:href="#DejaVuSans-13" transform="translate(127.25 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_4">
+     <g id="line2d_10">
+      <g>
+       <use xlink:href="#me365e4cf9e" x="60.133642" y="131.107877" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_11">
+      <!-- 150 -->
+      <g transform="translate(37.863642 134.146939) scale(0.08 -0.08)">
+       <use xlink:href="#DejaVuSans-14"/>
+       <use xlink:href="#DejaVuSans-18" transform="translate(63.625 0)"/>
+       <use xlink:href="#DejaVuSans-13" transform="translate(127.25 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_5">
+     <g id="line2d_11">
+      <g>
+       <use xlink:href="#me365e4cf9e" x="60.133642" y="90.173629" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_12">
+      <!-- 200 -->
+      <g transform="translate(37.863642 93.212692) scale(0.08 -0.08)">
+       <use xlink:href="#DejaVuSans-15"/>
+       <use xlink:href="#DejaVuSans-13" transform="translate(63.625 0)"/>
+       <use xlink:href="#DejaVuSans-13" transform="translate(127.25 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_6">
+     <g id="line2d_12">
+      <g>
+       <use xlink:href="#me365e4cf9e" x="60.133642" y="49.239382" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_13">
+      <!-- 250 -->
+      <g transform="translate(37.863642 52.278445) scale(0.08 -0.08)">
+       <use xlink:href="#DejaVuSans-15"/>
+       <use xlink:href="#DejaVuSans-18" transform="translate(63.625 0)"/>
+       <use xlink:href="#DejaVuSans-13" transform="translate(127.25 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="text_14">
+     <!-- y (grid units) -->
+     <g transform="translate(31.701533 178.030039) rotate(-90) scale(0.09 -0.09)">
+      <defs>
+       <path id="DejaVuSans-5c" d="M 2059 -325 
+Q 1816 -950 1584 -1140 
+Q 1353 -1331 966 -1331 
+L 506 -1331 
+L 506 -850 
+L 844 -850 
+Q 1081 -850 1212 -737 
+Q 1344 -625 1503 -206 
+L 1606 56 
+L 191 3500 
+L 800 3500 
+L 1894 763 
+L 2988 3500 
+L 3597 3500 
+L 2059 -325 
+z
+" transform="scale(0.015625)"/>
+      </defs>
+      <use xlink:href="#DejaVuSans-5c"/>
+      <use xlink:href="#DejaVuSans-3" transform="translate(59.1875 0)"/>
+      <use xlink:href="#DejaVuSans-b" transform="translate(90.96875 0)"/>
+      <use xlink:href="#DejaVuSans-4a" transform="translate(129.984375 0)"/>
+      <use xlink:href="#DejaVuSans-55" transform="translate(193.46875 0)"/>
+      <use xlink:href="#DejaVuSans-4c" transform="translate(234.578125 0)"/>
+      <use xlink:href="#DejaVuSans-47" transform="translate(262.359375 0)"/>
+      <use xlink:href="#DejaVuSans-3" transform="translate(325.84375 0)"/>
+      <use xlink:href="#DejaVuSans-58" transform="translate(357.625 0)"/>
+      <use xlink:href="#DejaVuSans-51" transform="translate(421 0)"/>
+      <use xlink:href="#DejaVuSans-4c" transform="translate(484.375 0)"/>
+      <use xlink:href="#DejaVuSans-57" transform="translate(512.15625 0)"/>
+      <use xlink:href="#DejaVuSans-56" transform="translate(551.359375 0)"/>
+      <use xlink:href="#DejaVuSans-c" transform="translate(603.453125 0)"/>
+     </g>
+    </g>
+   </g>
+   <g id="patch_3">
+    <path d="M 60.133642 253.910618 
+L 60.133642 44.327273 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_4">
+    <path d="M 60.133642 253.910618 
+L 269.716988 253.910618 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="text_15">
+    <!-- compliant plate ($B=100$) -->
+    <g transform="translate(60.133642 38.327273) scale(0.105 -0.105)">
+     <defs>
+      <path id="DejaVuSans-46" d="M 3122 3366 
+L 3122 2828 
+Q 2878 2963 2633 3030 
+Q 2388 3097 2138 3097 
+Q 1578 3097 1268 2742 
+Q 959 2388 959 1747 
+Q 959 1106 1268 751 
+Q 1578 397 2138 397 
+Q 2388 397 2633 464 
+Q 2878 531 3122 666 
+L 3122 134 
+Q 2881 22 2623 -34 
+Q 2366 -91 2075 -91 
+Q 1284 -91 818 406 
+Q 353 903 353 1747 
+Q 353 2603 823 3093 
+Q 1294 3584 2113 3584 
+Q 2378 3584 2631 3529 
+Q 2884 3475 3122 3366 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-52" d="M 1959 3097 
+Q 1497 3097 1228 2736 
+Q 959 2375 959 1747 
+Q 959 1119 1226 758 
+Q 1494 397 1959 397 
+Q 2419 397 2687 759 
+Q 2956 1122 2956 1747 
+Q 2956 2369 2687 2733 
+Q 2419 3097 1959 3097 
+z
+M 1959 3584 
+Q 2709 3584 3137 3096 
+Q 3566 2609 3566 1747 
+Q 3566 888 3137 398 
+Q 2709 -91 1959 -91 
+Q 1206 -91 779 398 
+Q 353 888 353 1747 
+Q 353 2609 779 3096 
+Q 1206 3584 1959 3584 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-50" d="M 3328 2828 
+Q 3544 3216 3844 3400 
+Q 4144 3584 4550 3584 
+Q 5097 3584 5394 3201 
+Q 5691 2819 5691 2113 
+L 5691 0 
+L 5113 0 
+L 5113 2094 
+Q 5113 2597 4934 2840 
+Q 4756 3084 4391 3084 
+Q 3944 3084 3684 2787 
+Q 3425 2491 3425 1978 
+L 3425 0 
+L 2847 0 
+L 2847 2094 
+Q 2847 2600 2669 2842 
+Q 2491 3084 2119 3084 
+Q 1678 3084 1418 2786 
+Q 1159 2488 1159 1978 
+L 1159 0 
+L 581 0 
+L 581 3500 
+L 1159 3500 
+L 1159 2956 
+Q 1356 3278 1631 3431 
+Q 1906 3584 2284 3584 
+Q 2666 3584 2933 3390 
+Q 3200 3197 3328 2828 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-53" d="M 1159 525 
+L 1159 -1331 
+L 581 -1331 
+L 581 3500 
+L 1159 3500 
+L 1159 2969 
+Q 1341 3281 1617 3432 
+Q 1894 3584 2278 3584 
+Q 2916 3584 3314 3078 
+Q 3713 2572 3713 1747 
+Q 3713 922 3314 415 
+Q 2916 -91 2278 -91 
+Q 1894 -91 1617 61 
+Q 1341 213 1159 525 
+z
+M 3116 1747 
+Q 3116 2381 2855 2742 
+Q 2594 3103 2138 3103 
+Q 1681 3103 1420 2742 
+Q 1159 2381 1159 1747 
+Q 1159 1113 1420 752 
+Q 1681 391 2138 391 
+Q 2594 391 2855 752 
+Q 3116 1113 3116 1747 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-4f" d="M 603 4863 
+L 1178 4863 
+L 1178 0 
+L 603 0 
+L 603 4863 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-44" d="M 2194 1759 
+Q 1497 1759 1228 1600 
+Q 959 1441 959 1056 
+Q 959 750 1161 570 
+Q 1363 391 1709 391 
+Q 2188 391 2477 730 
+Q 2766 1069 2766 1631 
+L 2766 1759 
+L 2194 1759 
+z
+M 3341 1997 
+L 3341 0 
+L 2766 0 
+L 2766 531 
+Q 2569 213 2275 61 
+Q 1981 -91 1556 -91 
+Q 1019 -91 701 211 
+Q 384 513 384 1019 
+Q 384 1609 779 1909 
+Q 1175 2209 1959 2209 
+L 2766 2209 
+L 2766 2266 
+Q 2766 2663 2505 2880 
+Q 2244 3097 1772 3097 
+Q 1472 3097 1187 3025 
+Q 903 2953 641 2809 
+L 641 3341 
+Q 956 3463 1253 3523 
+Q 1550 3584 1831 3584 
+Q 2591 3584 2966 3190 
+Q 3341 2797 3341 1997 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-48" d="M 3597 1894 
+L 3597 1613 
+L 953 1613 
+Q 991 1019 1311 708 
+Q 1631 397 2203 397 
+Q 2534 397 2845 478 
+Q 3156 559 3463 722 
+L 3463 178 
+Q 3153 47 2828 -22 
+Q 2503 -91 2169 -91 
+Q 1331 -91 842 396 
+Q 353 884 353 1716 
+Q 353 2575 817 3079 
+Q 1281 3584 2069 3584 
+Q 2775 3584 3186 3129 
+Q 3597 2675 3597 1894 
+z
+M 3022 2063 
+Q 3016 2534 2758 2815 
+Q 2500 3097 2075 3097 
+Q 1594 3097 1305 2825 
+Q 1016 2553 972 2059 
+L 3022 2063 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Oblique-25" d="M 1081 4666 
+L 2694 4666 
+Q 3350 4666 3675 4422 
+Q 4000 4178 4000 3688 
+Q 4000 3238 3720 2911 
+Q 3441 2584 2988 2516 
+Q 3375 2428 3569 2181 
+Q 3763 1934 3763 1522 
+Q 3763 819 3242 409 
+Q 2722 0 1819 0 
+L 172 0 
+L 1081 4666 
+z
+M 1234 2228 
+L 903 519 
+L 1919 519 
+Q 2491 519 2800 781 
+Q 3109 1044 3109 1522 
+Q 3109 1891 2904 2059 
+Q 2700 2228 2247 2228 
+L 1234 2228 
+z
+M 1606 4147 
+L 1331 2741 
+L 2272 2741 
+Q 2775 2741 3058 2959 
+Q 3341 3178 3341 3566 
+Q 3341 3869 3150 4008 
+Q 2959 4147 2541 4147 
+L 1606 4147 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-20" d="M 678 2906 
+L 4684 2906 
+L 4684 2381 
+L 678 2381 
+L 678 2906 
+z
+M 678 1631 
+L 4684 1631 
+L 4684 1100 
+L 678 1100 
+L 678 1631 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-46" transform="translate(0 0.015625)"/>
+     <use xlink:href="#DejaVuSans-52" transform="translate(54.980469 0.015625)"/>
+     <use xlink:href="#DejaVuSans-50" transform="translate(116.162109 0.015625)"/>
+     <use xlink:href="#DejaVuSans-53" transform="translate(213.574219 0.015625)"/>
+     <use xlink:href="#DejaVuSans-4f" transform="translate(277.050781 0.015625)"/>
+     <use xlink:href="#DejaVuSans-4c" transform="translate(304.833984 0.015625)"/>
+     <use xlink:href="#DejaVuSans-44" transform="translate(332.617188 0.015625)"/>
+     <use xlink:href="#DejaVuSans-51" transform="translate(393.896484 0.015625)"/>
+     <use xlink:href="#DejaVuSans-57" transform="translate(457.275391 0.015625)"/>
+     <use xlink:href="#DejaVuSans-3" transform="translate(496.484375 0.015625)"/>
+     <use xlink:href="#DejaVuSans-53" transform="translate(528.271484 0.015625)"/>
+     <use xlink:href="#DejaVuSans-4f" transform="translate(591.748047 0.015625)"/>
+     <use xlink:href="#DejaVuSans-44" transform="translate(619.53125 0.015625)"/>
+     <use xlink:href="#DejaVuSans-57" transform="translate(680.810547 0.015625)"/>
+     <use xlink:href="#DejaVuSans-48" transform="translate(720.019531 0.015625)"/>
+     <use xlink:href="#DejaVuSans-3" transform="translate(781.542969 0.015625)"/>
+     <use xlink:href="#DejaVuSans-b" transform="translate(813.330078 0.015625)"/>
+     <use xlink:href="#DejaVuSans-Oblique-25" transform="translate(852.34375 0.015625)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(940.429688 0.015625)"/>
+     <use xlink:href="#DejaVuSans-14" transform="translate(1043.701172 0.015625)"/>
+     <use xlink:href="#DejaVuSans-13" transform="translate(1107.324219 0.015625)"/>
+     <use xlink:href="#DejaVuSans-13" transform="translate(1170.947266 0.015625)"/>
+     <use xlink:href="#DejaVuSans-c" transform="translate(1234.570312 0.015625)"/>
+    </g>
+   </g>
+  </g>
+  <g id="axes_2">
+   <g id="patch_5">
+    <path d="M 310.542588 253.910618 
+L 520.125933 253.910618 
+L 520.125933 44.327273 
+L 310.542588 44.327273 
+z
+" style="fill: #ffffff"/>
+   </g>
+   <g clip-path="url(#pe62b927044)">
+    <image xlink:href="data:image/png;base64,
+iVBORw0KGgoAAAANSUhEUgAAASMAAAEjCAYAAAB5IGctAAAjZUlEQVR4nO2d7XbjNrBlDwCSkrs7yX2e+67zYPMUk6Q7bYkkgPkBFAhCpL5MybB99lq9bEsyRSrhdlWhAKj/83//14MQQt4Z/d4nQAghAGVECKkEyogQUgWUESGkCigjQkgVUEaEkCqgjAghVUAZEUKqgDIihFQBZUQIqQLKiBBSBZQRIaQKKCNCSBVQRoSQKqCMCCFVQBkRQqqAMiKEVAFlRAipAsqIEFIFlBEhpAooI0JIFVBGhJAqoIwIIVVAGRFCqoAyIoRUAWVECKkCyogQUgWUESGkCigjQkgVUEaEkCqgjAghVUAZEUKqgDIihFQBZUQIqQLKiBBSBZQRIaQKKCNCSBVQRoSQKqCMCCFVQBkRQqqAMiKEVAFlRAipAsqIEFIFlBEhpAooI0JIFVBGhJAqoIwIIVVAGRFCqoAyIoRUAWVECKkCyogQUgWUESGkCigjQkgVUEaEkCqgjAghVUAZEUKqgDIihFQBZUQIqQLKiBBSBZQRIaQKKCNCSBVQRoSQKqCMCCFVQBkRQqqAMiKEVAFlRAipAsqIEFIFlBEhpAooI0JIFVBGhJAqoIwIIVVAGRFCqoAyIoRUAWVECKkCyogQUgWUESGkCigjQkgVUEaEkCpo3vsESP1Yv93fLKPcZscinwtGRoSQKmBkRBJbRkC3vgcjJkIZfWGeIZ9rKc+Fcvp6UEZfiJrkcwnK6etBGX0B7pGQfXA50eA2ucg1UEqfF8roE1KjfK55v2sElV8bxfS5oIw+EbdK6NkCukR+PhTT14My+iRcI6J75eO8uuv3ltDKX/W68lwvycl6TSF9cOr600gI+bIwMvrgbBkRbRkB3foelyImuYZzERKL3B8byugDcm1t6BoJPUNA15CfxzkxUUqfF8rog3FJRJcEVIt8zlGe45Kcril2U0ofC8rog/AVJLSGnPtaxHQpWqKUPgaU0QfgnIg+s4RKtpAShVQvHE2rnHtE5LxK/z4jl67tnKA/0pSYrwYjo4pZu3HOSegrca7obaEZIX0w+GeCEFIFjIwqZSkqOpd+PDIqurZr+hoedZ7Oq8XoSCijJEZH9UEZVcZ7p2aXxHPrbHtgfu5Lx9/qGs4VuJfSNgqpLiijingvES3dvOekc8sNbP1y7WZNUFtc01KUJO+5JCSAw/41QBlVwi0ieusNuxb9LEmjvEn1jZGRVg6uuIYlQcl1biWmW4SUzolCelcoowq4VkSPkFB+Y+Y345J0zJ21IwMLOxv5OhUUskNvJaa10TYKqU4oo3fmPURU3ohyA+qZmNZfr2+4YV1Kg8LP6bp8cQx5PouaylRuy0iJQqoPyugduXbE7C034ZKE1iIgEVB+k+biMViIrBZu3PmiZzY8Fm2j4eC8hlHFtUY5zaKmIlqSa7n386CQ6oYyeiceKaIyHSsldE5AWrkT6Sz9Xvnc7P0Xl5QNj4Ub3c6OdyIniZryS4+n9FYpLQkpnB9H2t4bNj0SQqqAkdGTefSo2bmoSKfv56mbpGIGfiV6mp5P73NmVK1V9nQETSKv+LiDhknPeViolMJBLdSV1FRPKgvct35Oaw2SjI7eF8qoArYW0dIImYY7m5KJrM6JZ+m5dYpaUSpk+/h4XrfSMNAphTuREhDEJB9JlrLJdT9KSOR5UEZP5JEzxtdElEdDEgXlMsklZOBXxTNFT7fdrC3CTd4qG0fWbIiCZkVujxBL6RBRZVICMIkpqyWVo25vHW1bg02Rz4MyehKPGsI/N1om0VAZCc2fnyRkMlGV8jHwi0P6S1GSxfwaWgQRWTWlavnvWThorxelBABQDvCYitwxSkqiiKnbrWnbLdERU7bHQxm9I1uLqKz3lNHQUio2E5Jy4Th5ipancklU59O0duGarPIxSlIw3gPKZsP9QU5LUgrvq1NdCR5TlFSMtt2Tti3NZ2O69j5QRk/gmmH8W0S0VKReqw3lImrVeJKKlRJKr58Jqfj5qppRvC4VrmsSkQKUiwXr8JzxHla5RSkBUl9qQqQUo6Q8bXOIUcudQgKu60FidPRYKKMPjoiojIaAMKpV1oRESABWJZTLR8QzCe72KSFTEVsBCnBRRCaLmnSMmEopAQB8A6hxKnTDT0IC5n1J/lT05GPA/2qEkCpgZPRgyhTtrcP4S3WiPCrKIx95rosjU3l0FH5/OSLS8CeRUH7W5obSlvWn0VUYTVMphZMoqYyQ4OP/nmpMaVvvkWpFU69TA+tDn1IeHb21oM1U7blQRg/kmqH8e0S0NMcsF1FePxIRdcqmtKyN0zHWJBS+R3bs+P4r52Wy7+3JOcfrjK8TOYUi9ZS+OaVOpJSOEdO23gOdwiSkNNo2QoSUPpc3FLQv7m5LIT0EyuiJvKWWsdRHBEwF61xEs8gnE1EH+erSMZcklEc+csYG17H2OoMgKq0mMWk/RUx5tJTqSfE8jPfoFdABSUipqA3EwnYQEvw00XaLPqRrdrAl20AZPYgto6K1iCjvIypHzACk76evNn6V3z+V0Dn5GHV/U6H1Ph0zFxMQ5KS9P5FS6rRWoWAtfUoWLhW1A2GkzcHNhv2X+pCu+cwZHb0PlNGT2GqEZ2nkbDZqVtSEWjXOJCSREAB0yl2U0JqArL+wVnbxe/nPuZgEiZhESr3XmTTV7GsSUawpWakVAYt9SFt0vrP36PFQRu/EPVHRNExf9BGVheosMipFJF8BzESUy2FJQKV8ytrQCQuykuPKVznmTEyxAN3FXqRwLOkv0kCsd8E3aeg/ryOdNEZmx9w6OiLbQhltzK1bDF3DycqMxfSOslAtkdGaiFIUVIiojF7m1xAoYwO7cL8aNX9duvrsmEap9WgpyiPlaUlEhZAieWHbYGqMtEX8lc/4v4cyOmKqti3sMyKEVAEjoydzd09RkaIB0/pDszStmEtWRkXtQn3oUkTkMEVADvOJsHbhemarAmSRmMsiMbsWJcUISefRlfcn0ZGDTwVtGWUzSoUitg9VtfRZFQVtpmp1QhltyJYp2lqtaLYYWjZ6ZpRLw/fSR7QmorX6kAhCBBQemwRkvYKDgoWaJsBiQUbeZ+c/tQ44H8TkivOw3s/qSWWBu1U4FRKQsrheAQYqLjUSe46kdgTMC9o31o5KllK1cN5M194KZfREtlhvR88K0PP5ZuV6RdeKqJSQCAgAeq/hoDB4DQuFwZsgpihZtyBgrRyMn1YGaJWF8eFcNDy62Ank8mbK1HOkrhJSHhkZr8IR4wibhZtqR3jbaNq5XWrJtlBGlbE23aPsJwKy1C0bwu/g5n1EMU26VKgWEQ0+CGiIshm8xuANepggIq8xwKQb3EEXu4HMlylpYWMEZ9H5ELUNcGgxNV+20tyIKUoSIcnjgKSXHlZ6pVLkE7+KiLJ0LZyj2zQ6Io+BMtqIR4yilegkmSnqkPQsn9qx1Ed0SUSDB4YYAQ1eo4/nfvAtDq7FAIOD64KYvEldztbr2XWW8+XC6J7FXvdoYbHXA/YY4BBSvvD+Di08oE6FJOdpECOpOOzf+2numfE+RUqSrlnka2W7TVfZ5Jy1x0AZPYlb/wKn4fuFqGjWgV2kZyab5HrS0FikZQAwIKRlIqKDNzj4BgcflkgLMurwn+swxMcHH6IkABhc+F8oLAsS+5v0mNWtLPZqQOs6fNc9BhgMymCvBuwxpvMI6ZeHU3Hto4U6kgZSZCM1qPDeUUQxXZtFR8BJd7bI5JY/FixmPx7KqCJOFk3L/tLqQkDy/FJUND0/pWdLIrKYRBQkZHDwLX67Hf5zOwBBRv+5HX67DkfX4rfrMLhMRt6cbCPdqqyIri2+6R47PeDge3z3R+zVgO/6CKuP8TwG7GFD/5D30FmEBGSjbXLuCnA+pGvynmvRUTi+nkVHJvv+rRtDku1gnxEhpAoYGT2ILetF+QTZ2dy0lRRN3rkcPZvOLTAUUdFvt8N/vsN/boef9gUA8Nvt8NPu8dt1eLUtXl2Ho21wlPTMK4xZPaZRDlp57HRIwXZmxIvu8WIGfNM9jqbFN32MI3IhGnFKAzFKkugIavnc82K2SVGNX03VgFDAtt7E1Oza9QfOw7lq20MZbcCl4ugtKUC56aKZ9esUu3uspGjl4md5ipb3EOV1IhHRT/uCf90Lftk9AOAf+4Jf4w6/7A7/jTscbIPeNeit1IwW0jRt0ZmgvE6P2JsR35sjfpgjjr7BX8bAQk9tASaelD6GFDNrTwAQGiHLEbaYqgGAlTWZFlK18HwY6k+NkMWo2rVcqhuxiP02KKNKOPc/uUyGzYfyAaxGRUsz8G0q9oaICEBWsG5nIvrHvuCf8RsA4N9xj5/jHj+HHX4NOxxtg8PYYIwysk7BulC6VgCMdjDao4ky2jcjdmbEoW3Qt01qDzhpljSA9vm12cUh//y6psK8X42OwvOhmB0aN5flw2H+94cyqpxy66D5c9dHRcBUsO791EN08E0qWIuI/t/wHX9HGf3dh8joZ7/D69DiODToR4NxDEpwNo6heQUoDwVAG4emCTI6NBa7dsQxRlRH22Asit5AFuXpaZkTSUd1lrKV0REwFbPz6GhY+bzchqka2RbKaGPeUivKaxDlPLQ8Rcs3U1yqFZW3Wh4VOSA1NPbQabTspw2p2T/jN/w9fsPffagZ/d2/4N/jHr/7Foe+xdA3sKOGH+O72TiJLMooFHM8hiacY984HLsRfWcwWINxN30++ZQRka40b0qntpz3UnQkn4LUj1wmIh1TNQAnfUeSquV1n3v+u7FutC2UUWWUNYdyF1e5cfPn8uH8+drVy1HR4LOGxvjvt9vhH/uCf8c9/u5fkoz+Oe7x67DD4dhi7A3c0QCDhhrDsdWokJ+i14BvPHwT3mNsHZxVsFandE5oZC3u2KG91wMOvkXrw9In0nip4RajI7lWGz+Xaah/StUAzKKktSF+8v5QRm9ki+L1Wr1obRRtet5jPrP/zHmkfyr1CB2cNDSGEbNf4w4/x/D132MoYP867PB6aDEeWviDgeoVdK+gk4ziFLAYGQUZKbgmRmOdghs1BqvzNiE02mFnpnWXdmrETg+hQRIWnbZwUVZy7qvrayvA+emzNH6epumsCfLcqNo1dSMWsR8HZfTB0MVI0zUpmkRFNo6e9fFVAwz+cx1+x3+/7A4/h1Af+t3HDuzjJCL9qqGPCqYHdB9lZIOMlAe8UkFGBnBdfP9RwVkPB2AEcFChyN2aHbo4/N/pES9mwG/XYa867HUf58KFq2qVg47NkFgoZDvMU7Uhfi4ykRaeNaKPAGNUQkgVMDKqlEv9RfJcTjkHrcR6lZYBARAnvjY4uhavtsV/Yxi+fx1CsRoAxt6kqMgcFMxBQfeA6cMx1QhoC8jYvjNhnXxrp8gpLMwWkszROBxMi66x+GXClJO9GUMPkmkx6AYH12GvBtjUH6XQnkyVmUbVNOZrcqeoKF6nUS4VsfN+I7eebZF3gDKqhHxi7DWvmz92/q4q60U2De3LXLQOr67DwYah9+PQYOhjh/Ux1omOKsoIMEdARxmZwc+WpPYGsK1Kj1kHAApeAd4ouMZgMB7HtsGxDe9xsA1eY6ooE3FtXLoEAJyyF+tG8jkMs5/DZzWs/JbOR9hunDhLtocyqohrRtLmz0/LhVzaclqmX1iodHP2cfb94EzqAzqMoY/IytD9oKF7qRMFEZmDT5GRHgBtfRYZKSjro4QAINSRjAmFbdtq2FGjHw0OY/jfT/qPZAJu701YMyktMRLOuz0jXSliaynqZy8tJVWOqAHbbGdE3gZl9EG4FDEtIcVrwfmwQmO+MJosB3KMUzxGGxoapY9IjWHkbCakHjDHKMEBUNbHAjagzRQNAZhEZBR0B7hRwY8a42hSF3dvw/vLuciCbdNqkmraAw2YFbFv+/xYyK4Zyqhy8vWL0mMX0rIS66d6kfN6tjDaECXgvMLgDKxTcFaHZkbEPqIxjpqNIS3TQ5AQAOjBQ49ZZNQAEg0BgDEeLqZtagzH8za8h43rzsr8thClNbDxHNPcMqXi+fu0C+3Fz22hC9sol4b3SX1QRp+Ia28xiYzyyGP0OkRO0pgo+x+66Z+OSw5p66HidiF6jN9HGWmEaEjHkMxZFX4vOw7iirHWnb6/nNctaVPejU0+LpTRF8cVE1bTPLO8+c8rKI+pDuNDX1H6hfizz5/Lg7f0WJwqH4+/FN+V50O+DqzaEUKqgJHRF0cX8YkCQhiT9/UoD6+mIjLywEnFn/PvFTALcNJjPh1PZvhfOh/ydaCMPhFhwuhl0lZHacKtTys0Gh0TpRgzez39cyZO9TAKOr6Ra2TfM8QCtgr9RLHXILx+fhzoae2j8v3lvG6Z32Uvv4R8ACijyrFeQ0OnBe6BaRfX9spjhK2KfNzpNVu2Vrm0k4es0Gi0hzYOMEEMYQa+gpfO6na5j0iG9r1RsC3g4snZVsE3SL/vGw+Y8B5Gy24idlrIX49pUnDeaW7U6VpNZz+3hbjL+tsK4+S5UEYfBHcy6eEysqNGWvdHeRg/3+pIdvLY6RGdsWiMRdPYtB6RbzRc4+G6MMVD2dM+ovl0EAXXAjZOlHVd+N51Hq7x8I2HasLia7IaZGfC+8u5yCaQeeSWrkmu667Pj9QMZVQR1utZ17XzGqaIiPJoyHkFl+Zv4WwPTlqEDR5tlJpssNhqi50Zw3rVzYhDY9FHGY2tg+sU7DgX0ayPyE5vLNNB0qz93VxIaB1M49A1FvtmmrW/MyNaHc6nUzbsRJtt032ptyp2GoTNIYtlQMooKd+Sm5FSPVBGlSCrBro0V2o5CrLQSSbTY+ps4Venf3Hfe9l6Om6w+E33eNE99iZIYdeOOHZBFM6G9Yic9fGGn6Z3AIBr1fJE2Twy2nu4nYfvPPTOou3Ce8h6Rvu4g8g33Yf1jNS0JTbieedre69/hqWELqw1lT3PeWnvD2VUKdYrGBVuMBMXl9c+1I6mzmQ/j5RwuvlhjokLj8lNvtc9Wtdhpwe8mAHfmyMObZgn1ndxwX0bFkZLa0qqaXoHUK5nhGw9o7hzRwe4nYd7cVB7i6az2HcDXtoBP9qwPdH35ogXM2CnB7RqDOelsshoYTGzfDPKstQtnebTa8MGAGGR/mklAFIX/HNACKkCRkYfDOd1WsGwRUzRvApRD06H91MRO+4z1iqHzsetp2HxXfc4+JAi/TBH9G2YvT+krYjCcrEj4rr7RsE3YdIrsLbsLLJlZ0N6pvYWzX7AfjfgWzfgj+6IP2Jk9MMc8S2mad91H5adhUU7G007LV7PJgFjmn8HnEZHpH4oozdyaVH3t6yrbKHDmjtxeD+kK/OCtslntJ8pYpd1IwDY6wEDDL77sLDZ0YdJs0fbpF085KwOKiyM5hoD22q4kwX5YytAWpA//mbroHcxPdsN+LE/4s/dAT+aI/5oDgAQvjcHfNdH7HWPvR7SDiH5ua9hs4/OZUJKj8kqAMWcvJK3rFcucP3r+6GMKkNuGBlVWxpR01Lk9mH3VRfX+9Hws4UyTrb2UUAHhyFWWfYYMCgTi9jHsNOr1xiLWe3SoHgwLQbjZ1sV+ZWtilQcjTONQ9uN2HchIvpzd8D/dK/4n+4Vf0YZ/WVe8U0fsVdD+tcqh04io2Kr63zrpfxzkXltLi4/stRrxJG0eqGMNmarfbgcNODdtFFhVsROw9zKRgmdpmrhXOLXbGsfDaBN76GwVwO+62NcwCwWeosIoZEF9BuLY3vbJo5d3MTxpQ2p2Y/mGGTU/MZfzW8AwA9zwB/mNURGakAHhzYb61paTnctRbO5kFIkpOYjZ9k2Rlvtc0feDmVUOZKqLU3zEBGZ2G8U6kfzNX/WoiMgyggjbJRRHjVIOtKoqQfpl9nh2N63vfWPNtSI/mgO+LM54K/mN/4yrwCAP3UQUYiOxhQViYiXoqLw/fQ5SH9RLqSlz4tD+PVCGVXCuf24QtrhU93IpoF2DeM9rPKz6Cj/e70UHcke9jZFcQOc0rO7fhpWD/0+nR6xNyMOcXnaPspIFkYTZFpJJ93V8fe+N0f8MCEy+su84oc54E8dZPSHecV31ccULRSuW3V+Q0pZExuYR0V5ipYvIme9PlvQvqZeRB4LZbQBWxSxhfSXW0KNmKqV/UbAtAvGUnQU3jceM0ZHMrImtAg1pz0soI+pUUlnUzFkg8UXM+CHOeLVdWHRfhcX7I8Lowky4XUX90TbxYbGFxOaK/8wB3zTx5SWAcB31ceoKIooNjnmIpXrSJ+Tn5ocy6hIUrTp+Xl/Ubms7bWweP1YKKMHseVuE8ujaiGyWYuOgClyKFO89HPcFDFt5aGP0N7Npl/sdWhG/O06HE3YSUQWzgeQlqwV0oTXeMxWW3zTPXZ6iEP3x1Sn+hZlJBHRXlm08GjV6TlPn8UUFUnj4lpUlGpGF0bR7oH1ou1hAk0IqQJGRhVR1o3yibMyxC+jagDSyNpSqhae99MiZ1mqlqaLIBS0JTpKk2m1Q6tCmnXwbYxcurDBYtzXLEVGkq5l8+NkWRJgmv/WqhHfdR/6iNIQfpyblqVn+TD+rE4UdzoJEVE5lL+couUjaGtD+qwV1QNl9CRuqRsBxcRZ7wAVUjXEVA1AKmYvpWryvNSeZM5aqh3Fn1sg7WGPrOM5ycSHGfR73ccdaMO+ZrPicHbTy8JoMptNVgbYx87qvR6m4fs0YdedpGeliIBJRGvd1mWKlg/th0X+7x/Sv1QvIm+HMtqIpSL21ruU5tERgFnfURkdAUDvdWgcjJ3ZuZDCOYcoyQBRWB4GNs6Sn5bv6LRFj9Acab0OGyxme6/l1y0iSisDYJqBH6Z4SBQ0NTXKyNnZgjUmEfVez5YKuSUq2oLFXX1ZvH4zlFFlyA2mlQ8iy0bV8ugIwHyo38f/lHEDDiBEHDY+kBez81n9MyFBxOBSL1IPDacsBq9hVdweO+vXWbrR89E4ibLCVwcNj04FVUgf0TUiSkXrmJ4NXqPHtE334JuTqGiKnKao6GRzSFINlNETuTVVW8J5naVTehKRGmfpGgBoxDU9lAO8T/1F5XSRlBJFKWk1jcRpODhEsXkFF7u+U1SysOqikS2m5XtZNlaG7ItICFhOy6TL2gEYYp1oiJLJmzQlPZsJaaOJskzPngdltCFbpmpSzF6KjiTysfAAoohiutZnkRGAKKJTIYVzW0/bRBQiJu092thQaZFPzl2Q0WyZWJ9N5ziVkLyvkItIhFiKaPBhW+4+HilPzwbfpAZH+dy3jIrKFI3p2XZQRk9G/tJeczPko2vW61kTJBClkPUe9R7ogLTEyDwymoQkcnDS5VykbeH9phE3iZaAIIgWeQp1GjmUC+cnGc1eU6zKWEhI6kNynbmIyshICuon6ZnPmh7vGEFjVPRc2GdECKkCRkYbI2H7bITpjaNq+Wx++RlATN8cDHSIihTQl3/MlT2NjiSakfQPy4XtGVmkFM4hsLZ+0lIH9Vo0NF1XMXwfT66MiqRg3cdeJwc9RUfZMH/JW0c2maI9Fsronbi2mL1aOwJS/cgiNDeKkKQpchphmwtJUisZ9sdCHSn9nNWTZvjzKcy57YSWJATMRSTD9+H5UxHlw/d5mpb6jXwxUfbGWhFTtOdDGT2JrXqOUu0IOCloQ0SUJDSm7x18+irNhr0PtSbnp1Gu6Xzl/U7FVH5/3XkvCyic0zwaCiIJAgKQJJSPmMnX8PtBROE182H8reBctMdDGT2ISzP5gfuiI4PsuIv9R2F0DQDgm2mZkBgFydfp/T1sHHrPpTQN7cfrwalQbiWPgIBpPaJSQtI60KdoRqOHCV+zdGyIorWpqL0sokdERUzRtocyeiJviY5KIaXHZbqISEiEhBAlSR2pA9ArzNbMNt7DxZ6gJSmFY0xyWjvz2eJna+cvzxcCCo/NJSSjZTL/zULPRJSnZQCmSMnPO6/zz3qroXzyOCijB7JldAQU9SMA8HnBXGEuJMzqSL0HTDlNIk4jWZMSEPqEXFzaOi1nW5zuudt1tli+PJZFQfLzyWTXPPKBCvWgQkRTgbuZ9TuV8+VuERGjoveDMnowpZCW1si+R0jpGLEAHdY7CkJyuR5ERCr25WR1pCAitSql8B7zjRRFTrdw2vczRUHyfC4hiYRmssmElNeH5sd9W2NjKSLOQXsu7DMihFQBI6MPzmzIH5hG2IA47B+Wq3VwKSqSorakbWsRkpBHSgOQZvRfg0OWPi1EQwAWIyKJguS1Ms1jtlxIFhEBp+kZ+VhQRk/gmjlrt6Zq8jvAJCSjsvWPgGnYX00jbRYuDcuHm9otSmlI5xXkNGBapP+WHpxcPvLVZYVnOf9SQvI9gFmNaKmPCHhbnWjpmpiiPR/K6B15i5CAlfoRsNiHJKNXKUoCkphKKQ2YNpE0XiURyZy3PDAyC1HS2uaJpXzy15cSKkfLZjP0zwzfy+dyLUti5Qja+0AZPYm1kbUlIQHX31Dl+kdLfUgWJlv1cVoPyUYxlVIK51WkQMoB3pzcqAMuU659lEc98h5rEpLfK9Oyt/QRCbeIiFHR46GMnsg1Q/33stSHtNStHW74OKs/TQ+ZSykcLy5cBsSGSgOjHAaYxWhojWkkbUq58sfluaVIyM7SsPn0jvC6t/cRXYISeh6UUQUsNUPesxDbSR8SME/d8loSkMSklYP15iSFS+e3Jqhz51Jcz5qU5LEyCgqPT9c/l9X82PeIiOlZfVBGT2ZpVj+wvZCEWeqWR0lCjJZM1FCoK82FtiQo6bteihyWor8yqgHmaZica3jNPEXMf2+LaOhaETEqei4cByWEVAEjo3fi2iVq742O8t+frX8EzJYMkShJitx5TSn8fkjhwvktRTzXRUZ5jaiMhMLvzFOy8jhb1YeuGcIHGBW9B5TRO7ImJOD+6SIlJ7uNALOheQs93XiFmACkFA7IZvJnN6qIav39y9rRaT0oHPu8gPJruReKqG4oo3fmliH/t9yMJz1J+fvkrQBCVleyqT6Urcd9I2vymZ5fl5Cc/1ugiOqHMqqAR/UglZSd2wCWR96yx/ObM8zev/1mPSeexfMozvde1jrFKaI6oYwq4VohAdtJqTxeGTEBp+KYpXVXsBZFrc0h26pfiCL6eFBGFXGLkIBtNoUETgvewLosZmndlVyavLp1w+ItIqKE6oEyqoxb+pCAt0dJJUvHWU3rNjr+VpybwEsR1Q9lVCnXjrQJW0VJS3yEPelv7aimiOqDTY+EkCpgZFQx52pIwGmEtHXKVju3pmXpOUZFVcLIqHLO3ThrN5xWPv37jFy6NoroY8LI6ANwbumRc3Uk4HNFS5fkemnWPUVUN5TRB2FtlC09/4mlRAl9DSijD8alBdryG/NcK4BQo5yu2rvsik5wSuhjQRl9QMxsouplMZ3rDcpv/PcU07X1LUro80IZfXAupW/AdVIC1oWwpaTuLapTQp8fjqYRQqqAkdEn4ZrF/svo4tqpHe/RInDretSMij4+lNEn4pqUbfb6C8XuZ0MBfW0oo09IeZNeI6d7o6Z7uXcnDgro80IZfQFujZiA+rbtoYQ+P5TRF+KeiOm9oHy+HpTRF6YmOVE+hDIiiTUhbCkpSoesUW+cTgj5UjAyIhdhNEOeASMjQkgVUEaEkCqgjAghVUAZEUKqgDIihFQBZUQIqQLKiBBSBZQRIaQKKCNCSBVQRoSQKqCMCCFVQBkRQqqAMiKEVAFlRAipAsqIEFIFlBEhpAooI0JIFVBGhJAqoIwIIVVAGRFCqoAyIoRUAWVECKkCyogQUgWUESGkCigjQkgVUEaEkCqgjAghVUAZEUKqgDIihFQBZUQIqQLKiBBSBZQRIaQKKCNCSBVQRoSQKqCMCCFVQBkRQqqAMiKEVAFlRAipAsqIEFIFlBEhpAooI0JIFVBGhJAqoIwIIVVAGRFCqoAyIoRUAWVECKkCyogQUgWUESGkCigjQkgVUEaEkCqgjAghVUAZEUKqgDIihFQBZUQIqQLKiBBSBZQRIaQKKCNCSBVQRoSQKqCMCCFVQBkRQqqAMiKEVAFlRAipAsqIEFIFlBEhpAooI0JIFVBGhJAqoIwIIVVAGRFCqoAyIoRUAWVECKkCyogQUgWUESGkCigjQkgVUEaEkCqgjAghVUAZEUKqgDIihFTB/weJbeLyAWzTqgAAAABJRU5ErkJggg==" id="image5e0871f660" transform="scale(1 -1) translate(0 -209.52)" x="310.32" y="-44.311321" width="209.52" height="209.52"/>
+   </g>
+   <g id="matplotlib.axis_3">
+    <g id="xtick_7">
+     <g id="line2d_13">
+      <g>
+       <use xlink:href="#mdb07662f7b" x="310.542588" y="253.910618" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_16">
+      <!-- 0 -->
+      <g transform="translate(307.997588 266.988743) scale(0.08 -0.08)">
+       <use xlink:href="#DejaVuSans-13"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_8">
+     <g id="line2d_14">
+      <g>
+       <use xlink:href="#mdb07662f7b" x="351.476835" y="253.910618" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_17">
+      <!-- 50 -->
+      <g transform="translate(346.386835 266.988743) scale(0.08 -0.08)">
+       <use xlink:href="#DejaVuSans-18"/>
+       <use xlink:href="#DejaVuSans-13" transform="translate(63.625 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_9">
+     <g id="line2d_15">
+      <g>
+       <use xlink:href="#mdb07662f7b" x="392.411082" y="253.910618" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_18">
+      <!-- 100 -->
+      <g transform="translate(384.776082 266.988743) scale(0.08 -0.08)">
+       <use xlink:href="#DejaVuSans-14"/>
+       <use xlink:href="#DejaVuSans-13" transform="translate(63.625 0)"/>
+       <use xlink:href="#DejaVuSans-13" transform="translate(127.25 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_10">
+     <g id="line2d_16">
+      <g>
+       <use xlink:href="#mdb07662f7b" x="433.345329" y="253.910618" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_19">
+      <!-- 150 -->
+      <g transform="translate(425.710329 266.988743) scale(0.08 -0.08)">
+       <use xlink:href="#DejaVuSans-14"/>
+       <use xlink:href="#DejaVuSans-18" transform="translate(63.625 0)"/>
+       <use xlink:href="#DejaVuSans-13" transform="translate(127.25 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_11">
+     <g id="line2d_17">
+      <g>
+       <use xlink:href="#mdb07662f7b" x="474.279576" y="253.910618" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_20">
+      <!-- 200 -->
+      <g transform="translate(466.644576 266.988743) scale(0.08 -0.08)">
+       <use xlink:href="#DejaVuSans-15"/>
+       <use xlink:href="#DejaVuSans-13" transform="translate(63.625 0)"/>
+       <use xlink:href="#DejaVuSans-13" transform="translate(127.25 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_12">
+     <g id="line2d_18">
+      <g>
+       <use xlink:href="#mdb07662f7b" x="515.213823" y="253.910618" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_21">
+      <!-- 250 -->
+      <g transform="translate(507.578823 266.988743) scale(0.08 -0.08)">
+       <use xlink:href="#DejaVuSans-15"/>
+       <use xlink:href="#DejaVuSans-18" transform="translate(63.625 0)"/>
+       <use xlink:href="#DejaVuSans-13" transform="translate(127.25 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="text_22">
+     <!-- x (grid units) -->
+     <g transform="translate(386.423167 279.749212) scale(0.09 -0.09)">
+      <use xlink:href="#DejaVuSans-5b"/>
+      <use xlink:href="#DejaVuSans-3" transform="translate(59.1875 0)"/>
+      <use xlink:href="#DejaVuSans-b" transform="translate(90.96875 0)"/>
+      <use xlink:href="#DejaVuSans-4a" transform="translate(129.984375 0)"/>
+      <use xlink:href="#DejaVuSans-55" transform="translate(193.46875 0)"/>
+      <use xlink:href="#DejaVuSans-4c" transform="translate(234.578125 0)"/>
+      <use xlink:href="#DejaVuSans-47" transform="translate(262.359375 0)"/>
+      <use xlink:href="#DejaVuSans-3" transform="translate(325.84375 0)"/>
+      <use xlink:href="#DejaVuSans-58" transform="translate(357.625 0)"/>
+      <use xlink:href="#DejaVuSans-51" transform="translate(421 0)"/>
+      <use xlink:href="#DejaVuSans-4c" transform="translate(484.375 0)"/>
+      <use xlink:href="#DejaVuSans-57" transform="translate(512.15625 0)"/>
+      <use xlink:href="#DejaVuSans-56" transform="translate(551.359375 0)"/>
+      <use xlink:href="#DejaVuSans-c" transform="translate(603.453125 0)"/>
+     </g>
+    </g>
+   </g>
+   <g id="matplotlib.axis_4">
+    <g id="ytick_7">
+     <g id="line2d_19">
+      <g>
+       <use xlink:href="#me365e4cf9e" x="310.542588" y="253.910618" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_8">
+     <g id="line2d_20">
+      <g>
+       <use xlink:href="#me365e4cf9e" x="310.542588" y="212.976371" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_9">
+     <g id="line2d_21">
+      <g>
+       <use xlink:href="#me365e4cf9e" x="310.542588" y="172.042124" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_10">
+     <g id="line2d_22">
+      <g>
+       <use xlink:href="#me365e4cf9e" x="310.542588" y="131.107877" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_11">
+     <g id="line2d_23">
+      <g>
+       <use xlink:href="#me365e4cf9e" x="310.542588" y="90.173629" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_12">
+     <g id="line2d_24">
+      <g>
+       <use xlink:href="#me365e4cf9e" x="310.542588" y="49.239382" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+    </g>
+   </g>
+   <g id="patch_6">
+    <path d="M 310.542588 253.910618 
+L 310.542588 44.327273 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_7">
+    <path d="M 310.542588 253.910618 
+L 520.125933 253.910618 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="text_23">
+    <!-- stiff plate ($B=640$) -->
+    <g transform="translate(310.542588 38.327273) scale(0.105 -0.105)">
+     <defs>
+      <path id="DejaVuSans-49" d="M 2375 4863 
+L 2375 4384 
+L 1825 4384 
+Q 1516 4384 1395 4259 
+Q 1275 4134 1275 3809 
+L 1275 3500 
+L 2222 3500 
+L 2222 3053 
+L 1275 3053 
+L 1275 0 
+L 697 0 
+L 697 3053 
+L 147 3053 
+L 147 3500 
+L 697 3500 
+L 697 3744 
+Q 697 4328 969 4595 
+Q 1241 4863 1831 4863 
+L 2375 4863 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-19" d="M 2113 2584 
+Q 1688 2584 1439 2293 
+Q 1191 2003 1191 1497 
+Q 1191 994 1439 701 
+Q 1688 409 2113 409 
+Q 2538 409 2786 701 
+Q 3034 994 3034 1497 
+Q 3034 2003 2786 2293 
+Q 2538 2584 2113 2584 
+z
+M 3366 4563 
+L 3366 3988 
+Q 3128 4100 2886 4159 
+Q 2644 4219 2406 4219 
+Q 1781 4219 1451 3797 
+Q 1122 3375 1075 2522 
+Q 1259 2794 1537 2939 
+Q 1816 3084 2150 3084 
+Q 2853 3084 3261 2657 
+Q 3669 2231 3669 1497 
+Q 3669 778 3244 343 
+Q 2819 -91 2113 -91 
+Q 1303 -91 875 529 
+Q 447 1150 447 2328 
+Q 447 3434 972 4092 
+Q 1497 4750 2381 4750 
+Q 2619 4750 2861 4703 
+Q 3103 4656 3366 4563 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-17" d="M 2419 4116 
+L 825 1625 
+L 2419 1625 
+L 2419 4116 
+z
+M 2253 4666 
+L 3047 4666 
+L 3047 1625 
+L 3713 1625 
+L 3713 1100 
+L 3047 1100 
+L 3047 0 
+L 2419 0 
+L 2419 1100 
+L 313 1100 
+L 313 1709 
+L 2253 4666 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-56" transform="translate(0 0.015625)"/>
+     <use xlink:href="#DejaVuSans-57" transform="translate(52.099609 0.015625)"/>
+     <use xlink:href="#DejaVuSans-4c" transform="translate(91.308594 0.015625)"/>
+     <use xlink:href="#DejaVuSans-49" transform="translate(119.091797 0.015625)"/>
+     <use xlink:href="#DejaVuSans-49" transform="translate(154.296875 0.015625)"/>
+     <use xlink:href="#DejaVuSans-3" transform="translate(189.501953 0.015625)"/>
+     <use xlink:href="#DejaVuSans-53" transform="translate(221.289062 0.015625)"/>
+     <use xlink:href="#DejaVuSans-4f" transform="translate(284.765625 0.015625)"/>
+     <use xlink:href="#DejaVuSans-44" transform="translate(312.548828 0.015625)"/>
+     <use xlink:href="#DejaVuSans-57" transform="translate(373.828125 0.015625)"/>
+     <use xlink:href="#DejaVuSans-48" transform="translate(413.037109 0.015625)"/>
+     <use xlink:href="#DejaVuSans-3" transform="translate(474.560547 0.015625)"/>
+     <use xlink:href="#DejaVuSans-b" transform="translate(506.347656 0.015625)"/>
+     <use xlink:href="#DejaVuSans-Oblique-25" transform="translate(545.361328 0.015625)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(633.447266 0.015625)"/>
+     <use xlink:href="#DejaVuSans-19" transform="translate(736.71875 0.015625)"/>
+     <use xlink:href="#DejaVuSans-17" transform="translate(800.341797 0.015625)"/>
+     <use xlink:href="#DejaVuSans-13" transform="translate(863.964844 0.015625)"/>
+     <use xlink:href="#DejaVuSans-c" transform="translate(927.587891 0.015625)"/>
+    </g>
+   </g>
+  </g>
+  <g id="axes_3">
+   <g id="patch_8">
+    <path d="M 551.52 246.24 
+L 563.616 246.24 
+L 563.616 44.64 
+L 551.52 44.64 
+z
+" style="fill: #ffffff"/>
+   </g>
+   <image xlink:href="data:image/png;base64,
+iVBORw0KGgoAAAANSUhEUgAAABEAAAEYCAYAAAC6FR2GAAABqElEQVR4nO2cyw3DMAxDJTujdYTuP0rTe9ObnoEHQRmAICnSygdIvvJ9R/G6IlcVI65cWQdpxiQYJgBILkIOwSQAJnWE4OQQ0+kVNk1OTHIAECj2opxM7M+AaDy5GTllDNXK0IBopjOe/AOxyKG6g4AQnoimY2GCTMfTnWax9+QEYkKAEDc5Hjm9RjzdOccEAIE2IMFkpvN7Md3RyBkmf5l47tkAEE/se3kyTE6BeOSUv9+FqjvdpqNhMnKeIPOocohJLznd7qjHEzOTyPpKV8kBQHrJoVaGJCf9NiBgrCZsokPJ051mOQHeBpnkMCBhkZOAsaIzlpDTLfaIJ4gc03QIT+pEoO5AI7bkZInkjCcPJsTyIjxhuiMythcTKCcaORYQUeyREWuMNYGIjP1YmACemLpDGLstxopyspvJYUZclyPqzgbkUNMhmBCJZZggh5KmgAQTKvaIHE3sCSbdusN4YpkOkVimO1DYJGuUCRszYk13mJUhmo5n71jOE+iuwPKAAMkpY2DdIZhoXupu4CsR5QnCBACBPCGYMJ4Af9iA5CBMJP8O+gLtJo0yDScBtQAAAABJRU5ErkJggg==" id="image8ffaf171a5" transform="scale(1 -1) translate(0 -201.6)" x="551.52" y="-43.92" width="12.24" height="201.6"/>
+   <g id="matplotlib.axis_5"/>
+   <g id="matplotlib.axis_6">
+    <g id="ytick_13">
+     <g id="line2d_25">
+      <defs>
+       <path id="mdb83727f6e" d="M 0 0 
+L 3.5 0 
+" style="stroke: #000000; stroke-width: 0.8"/>
+      </defs>
+      <g>
+       <use xlink:href="#mdb83727f6e" x="563.616" y="225.416553" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_24">
+      <!-- 0.70 -->
+      <g transform="translate(570.616 228.455616) scale(0.08 -0.08)">
+       <defs>
+        <path id="DejaVuSans-11" d="M 684 794 
+L 1344 794 
+L 1344 0 
+L 684 0 
+L 684 794 
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-1a" d="M 525 4666 
+L 3525 4666 
+L 3525 4397 
+L 1831 0 
+L 1172 0 
+L 2766 4134 
+L 525 4134 
+L 525 4666 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-13"/>
+       <use xlink:href="#DejaVuSans-11" transform="translate(63.625 0)"/>
+       <use xlink:href="#DejaVuSans-1a" transform="translate(95.40625 0)"/>
+       <use xlink:href="#DejaVuSans-13" transform="translate(159.03125 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_14">
+     <g id="line2d_26">
+      <g>
+       <use xlink:href="#mdb83727f6e" x="563.616" y="200.251425" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_25">
+      <!-- 0.75 -->
+      <g transform="translate(570.616 203.290488) scale(0.08 -0.08)">
+       <use xlink:href="#DejaVuSans-13"/>
+       <use xlink:href="#DejaVuSans-11" transform="translate(63.625 0)"/>
+       <use xlink:href="#DejaVuSans-1a" transform="translate(95.40625 0)"/>
+       <use xlink:href="#DejaVuSans-18" transform="translate(159.03125 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_15">
+     <g id="line2d_27">
+      <g>
+       <use xlink:href="#mdb83727f6e" x="563.616" y="175.086297" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_26">
+      <!-- 0.80 -->
+      <g transform="translate(570.616 178.12536) scale(0.08 -0.08)">
+       <defs>
+        <path id="DejaVuSans-1b" d="M 2034 2216 
+Q 1584 2216 1326 1975 
+Q 1069 1734 1069 1313 
+Q 1069 891 1326 650 
+Q 1584 409 2034 409 
+Q 2484 409 2743 651 
+Q 3003 894 3003 1313 
+Q 3003 1734 2745 1975 
+Q 2488 2216 2034 2216 
+z
+M 1403 2484 
+Q 997 2584 770 2862 
+Q 544 3141 544 3541 
+Q 544 4100 942 4425 
+Q 1341 4750 2034 4750 
+Q 2731 4750 3128 4425 
+Q 3525 4100 3525 3541 
+Q 3525 3141 3298 2862 
+Q 3072 2584 2669 2484 
+Q 3125 2378 3379 2068 
+Q 3634 1759 3634 1313 
+Q 3634 634 3220 271 
+Q 2806 -91 2034 -91 
+Q 1263 -91 848 271 
+Q 434 634 434 1313 
+Q 434 1759 690 2068 
+Q 947 2378 1403 2484 
+z
+M 1172 3481 
+Q 1172 3119 1398 2916 
+Q 1625 2713 2034 2713 
+Q 2441 2713 2670 2916 
+Q 2900 3119 2900 3481 
+Q 2900 3844 2670 4047 
+Q 2441 4250 2034 4250 
+Q 1625 4250 1398 4047 
+Q 1172 3844 1172 3481 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-13"/>
+       <use xlink:href="#DejaVuSans-11" transform="translate(63.625 0)"/>
+       <use xlink:href="#DejaVuSans-1b" transform="translate(95.40625 0)"/>
+       <use xlink:href="#DejaVuSans-13" transform="translate(159.03125 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_16">
+     <g id="line2d_28">
+      <g>
+       <use xlink:href="#mdb83727f6e" x="563.616" y="149.921169" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_27">
+      <!-- 0.85 -->
+      <g transform="translate(570.616 152.960231) scale(0.08 -0.08)">
+       <use xlink:href="#DejaVuSans-13"/>
+       <use xlink:href="#DejaVuSans-11" transform="translate(63.625 0)"/>
+       <use xlink:href="#DejaVuSans-1b" transform="translate(95.40625 0)"/>
+       <use xlink:href="#DejaVuSans-18" transform="translate(159.03125 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_17">
+     <g id="line2d_29">
+      <g>
+       <use xlink:href="#mdb83727f6e" x="563.616" y="124.756041" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_28">
+      <!-- 0.90 -->
+      <g transform="translate(570.616 127.795103) scale(0.08 -0.08)">
+       <defs>
+        <path id="DejaVuSans-1c" d="M 703 97 
+L 703 672 
+Q 941 559 1184 500 
+Q 1428 441 1663 441 
+Q 2288 441 2617 861 
+Q 2947 1281 2994 2138 
+Q 2813 1869 2534 1725 
+Q 2256 1581 1919 1581 
+Q 1219 1581 811 2004 
+Q 403 2428 403 3163 
+Q 403 3881 828 4315 
+Q 1253 4750 1959 4750 
+Q 2769 4750 3195 4129 
+Q 3622 3509 3622 2328 
+Q 3622 1225 3098 567 
+Q 2575 -91 1691 -91 
+Q 1453 -91 1209 -44 
+Q 966 3 703 97 
+z
+M 1959 2075 
+Q 2384 2075 2632 2365 
+Q 2881 2656 2881 3163 
+Q 2881 3666 2632 3958 
+Q 2384 4250 1959 4250 
+Q 1534 4250 1286 3958 
+Q 1038 3666 1038 3163 
+Q 1038 2656 1286 2365 
+Q 1534 2075 1959 2075 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-13"/>
+       <use xlink:href="#DejaVuSans-11" transform="translate(63.625 0)"/>
+       <use xlink:href="#DejaVuSans-1c" transform="translate(95.40625 0)"/>
+       <use xlink:href="#DejaVuSans-13" transform="translate(159.03125 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_18">
+     <g id="line2d_30">
+      <g>
+       <use xlink:href="#mdb83727f6e" x="563.616" y="99.590913" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_29">
+      <!-- 0.95 -->
+      <g transform="translate(570.616 102.629975) scale(0.08 -0.08)">
+       <use xlink:href="#DejaVuSans-13"/>
+       <use xlink:href="#DejaVuSans-11" transform="translate(63.625 0)"/>
+       <use xlink:href="#DejaVuSans-1c" transform="translate(95.40625 0)"/>
+       <use xlink:href="#DejaVuSans-18" transform="translate(159.03125 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_19">
+     <g id="line2d_31">
+      <g>
+       <use xlink:href="#mdb83727f6e" x="563.616" y="74.425785" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_30">
+      <!-- 1.00 -->
+      <g transform="translate(570.616 77.464847) scale(0.08 -0.08)">
+       <use xlink:href="#DejaVuSans-14"/>
+       <use xlink:href="#DejaVuSans-11" transform="translate(63.625 0)"/>
+       <use xlink:href="#DejaVuSans-13" transform="translate(95.40625 0)"/>
+       <use xlink:href="#DejaVuSans-13" transform="translate(159.03125 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_20">
+     <g id="line2d_32">
+      <g>
+       <use xlink:href="#mdb83727f6e" x="563.616" y="49.260657" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_31">
+      <!-- 1.05 -->
+      <g transform="translate(570.616 52.299719) scale(0.08 -0.08)">
+       <use xlink:href="#DejaVuSans-14"/>
+       <use xlink:href="#DejaVuSans-11" transform="translate(63.625 0)"/>
+       <use xlink:href="#DejaVuSans-13" transform="translate(95.40625 0)"/>
+       <use xlink:href="#DejaVuSans-18" transform="translate(159.03125 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="text_32">
+     <!-- gap thickness h -->
+     <g transform="translate(599.267094 180.878906) rotate(-90) scale(0.09 -0.09)">
+      <defs>
+       <path id="DejaVuSans-4b" d="M 3513 2113 
+L 3513 0 
+L 2938 0 
+L 2938 2094 
+Q 2938 2591 2744 2837 
+Q 2550 3084 2163 3084 
+Q 1697 3084 1428 2787 
+Q 1159 2491 1159 1978 
+L 1159 0 
+L 581 0 
+L 581 4863 
+L 1159 4863 
+L 1159 2956 
+Q 1366 3272 1645 3428 
+Q 1925 3584 2291 3584 
+Q 2894 3584 3203 3211 
+Q 3513 2838 3513 2113 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-4e" d="M 581 4863 
+L 1159 4863 
+L 1159 1991 
+L 2875 3500 
+L 3609 3500 
+L 1753 1863 
+L 3688 0 
+L 2938 0 
+L 1159 1709 
+L 1159 0 
+L 581 0 
+L 581 4863 
+z
+" transform="scale(0.015625)"/>
+      </defs>
+      <use xlink:href="#DejaVuSans-4a"/>
+      <use xlink:href="#DejaVuSans-44" transform="translate(63.484375 0)"/>
+      <use xlink:href="#DejaVuSans-53" transform="translate(124.765625 0)"/>
+      <use xlink:href="#DejaVuSans-3" transform="translate(188.25 0)"/>
+      <use xlink:href="#DejaVuSans-57" transform="translate(220.03125 0)"/>
+      <use xlink:href="#DejaVuSans-4b" transform="translate(259.234375 0)"/>
+      <use xlink:href="#DejaVuSans-4c" transform="translate(322.609375 0)"/>
+      <use xlink:href="#DejaVuSans-46" transform="translate(350.390625 0)"/>
+      <use xlink:href="#DejaVuSans-4e" transform="translate(405.375 0)"/>
+      <use xlink:href="#DejaVuSans-51" transform="translate(463.28125 0)"/>
+      <use xlink:href="#DejaVuSans-48" transform="translate(526.65625 0)"/>
+      <use xlink:href="#DejaVuSans-56" transform="translate(588.1875 0)"/>
+      <use xlink:href="#DejaVuSans-56" transform="translate(640.28125 0)"/>
+      <use xlink:href="#DejaVuSans-3" transform="translate(692.375 0)"/>
+      <use xlink:href="#DejaVuSans-4b" transform="translate(724.15625 0)"/>
+     </g>
+    </g>
+   </g>
+   <g id="LineCollection_1"/>
+   <g id="patch_9">
+    <path d="M 551.52 246.24 
+L 557.568 246.24 
+L 563.616 246.24 
+L 563.616 44.64 
+L 557.568 44.64 
+L 551.52 44.64 
+L 551.52 246.24 
+z
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+  </g>
+  <g id="text_33">
+   <!-- Same press, same instant t=60: plate stiffness sets depth against width -->
+   <g transform="translate(7.2 15.558281) scale(0.11 -0.11)">
+    <defs>
+     <path id="DejaVuSans-36" d="M 3425 4513 
+L 3425 3897 
+Q 3066 4069 2747 4153 
+Q 2428 4238 2131 4238 
+Q 1616 4238 1336 4038 
+Q 1056 3838 1056 3469 
+Q 1056 3159 1242 3001 
+Q 1428 2844 1947 2747 
+L 2328 2669 
+Q 3034 2534 3370 2195 
+Q 3706 1856 3706 1288 
+Q 3706 609 3251 259 
+Q 2797 -91 1919 -91 
+Q 1588 -91 1214 -16 
+Q 841 59 441 206 
+L 441 856 
+Q 825 641 1194 531 
+Q 1563 422 1919 422 
+Q 2459 422 2753 634 
+Q 3047 847 3047 1241 
+Q 3047 1584 2836 1778 
+Q 2625 1972 2144 2069 
+L 1759 2144 
+Q 1053 2284 737 2584 
+Q 422 2884 422 3419 
+Q 422 4038 858 4394 
+Q 1294 4750 2059 4750 
+Q 2388 4750 2728 4690 
+Q 3069 4631 3425 4513 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-f" d="M 750 794 
+L 1409 794 
+L 1409 256 
+L 897 -744 
+L 494 -744 
+L 750 256 
+L 750 794 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-1d" d="M 750 794 
+L 1409 794 
+L 1409 0 
+L 750 0 
+L 750 794 
+z
+M 750 3309 
+L 1409 3309 
+L 1409 2516 
+L 750 2516 
+L 750 3309 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-13ae" d="M 4531 4863 
+L 4531 4384 
+L 3981 4384 
+Q 3672 4384 3551 4259 
+Q 3431 4134 3431 3809 
+L 3431 3500 
+L 4378 3500 
+L 4378 3053 
+L 3431 3053 
+L 3431 0 
+L 2853 0 
+L 2853 3053 
+L 1275 3053 
+L 1275 0 
+L 697 0 
+L 697 3053 
+L 147 3053 
+L 147 3500 
+L 697 3500 
+L 697 3744 
+Q 697 4328 969 4595 
+Q 1241 4863 1831 4863 
+L 2375 4863 
+L 2375 4384 
+L 1825 4384 
+Q 1516 4384 1394 4259 
+Q 1275 4134 1275 3809 
+L 1275 3500 
+L 2853 3500 
+L 2853 3744 
+Q 2853 4328 3125 4595 
+Q 3397 4863 3988 4863 
+L 4531 4863 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-5a" d="M 269 3500 
+L 844 3500 
+L 1563 769 
+L 2278 3500 
+L 2956 3500 
+L 3675 769 
+L 4391 3500 
+L 4966 3500 
+L 4050 0 
+L 3372 0 
+L 2619 2869 
+L 1863 0 
+L 1184 0 
+L 269 3500 
+z
+" transform="scale(0.015625)"/>
+    </defs>
+    <use xlink:href="#DejaVuSans-36"/>
+    <use xlink:href="#DejaVuSans-44" transform="translate(63.484375 0)"/>
+    <use xlink:href="#DejaVuSans-50" transform="translate(124.765625 0)"/>
+    <use xlink:href="#DejaVuSans-48" transform="translate(222.171875 0)"/>
+    <use xlink:href="#DejaVuSans-3" transform="translate(283.703125 0)"/>
+    <use xlink:href="#DejaVuSans-53" transform="translate(315.484375 0)"/>
+    <use xlink:href="#DejaVuSans-55" transform="translate(378.96875 0)"/>
+    <use xlink:href="#DejaVuSans-48" transform="translate(417.875 0)"/>
+    <use xlink:href="#DejaVuSans-56" transform="translate(479.40625 0)"/>
+    <use xlink:href="#DejaVuSans-56" transform="translate(531.5 0)"/>
+    <use xlink:href="#DejaVuSans-f" transform="translate(583.59375 0)"/>
+    <use xlink:href="#DejaVuSans-3" transform="translate(615.375 0)"/>
+    <use xlink:href="#DejaVuSans-56" transform="translate(647.15625 0)"/>
+    <use xlink:href="#DejaVuSans-44" transform="translate(699.25 0)"/>
+    <use xlink:href="#DejaVuSans-50" transform="translate(760.53125 0)"/>
+    <use xlink:href="#DejaVuSans-48" transform="translate(857.9375 0)"/>
+    <use xlink:href="#DejaVuSans-3" transform="translate(919.46875 0)"/>
+    <use xlink:href="#DejaVuSans-4c" transform="translate(951.25 0)"/>
+    <use xlink:href="#DejaVuSans-51" transform="translate(979.03125 0)"/>
+    <use xlink:href="#DejaVuSans-56" transform="translate(1042.40625 0)"/>
+    <use xlink:href="#DejaVuSans-57" transform="translate(1094.5 0)"/>
+    <use xlink:href="#DejaVuSans-44" transform="translate(1133.703125 0)"/>
+    <use xlink:href="#DejaVuSans-51" transform="translate(1194.984375 0)"/>
+    <use xlink:href="#DejaVuSans-57" transform="translate(1258.359375 0)"/>
+    <use xlink:href="#DejaVuSans-3" transform="translate(1297.5625 0)"/>
+    <use xlink:href="#DejaVuSans-57" transform="translate(1329.34375 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(1368.546875 0)"/>
+    <use xlink:href="#DejaVuSans-19" transform="translate(1452.34375 0)"/>
+    <use xlink:href="#DejaVuSans-13" transform="translate(1515.96875 0)"/>
+    <use xlink:href="#DejaVuSans-1d" transform="translate(1579.59375 0)"/>
+    <use xlink:href="#DejaVuSans-3" transform="translate(1613.28125 0)"/>
+    <use xlink:href="#DejaVuSans-53" transform="translate(1645.0625 0)"/>
+    <use xlink:href="#DejaVuSans-4f" transform="translate(1708.546875 0)"/>
+    <use xlink:href="#DejaVuSans-44" transform="translate(1736.328125 0)"/>
+    <use xlink:href="#DejaVuSans-57" transform="translate(1797.609375 0)"/>
+    <use xlink:href="#DejaVuSans-48" transform="translate(1836.8125 0)"/>
+    <use xlink:href="#DejaVuSans-3" transform="translate(1898.34375 0)"/>
+    <use xlink:href="#DejaVuSans-56" transform="translate(1930.125 0)"/>
+    <use xlink:href="#DejaVuSans-57" transform="translate(1982.21875 0)"/>
+    <use xlink:href="#DejaVuSans-4c" transform="translate(2021.421875 0)"/>
+    <use xlink:href="#DejaVuSans-13ae" transform="translate(2049.203125 0)"/>
+    <use xlink:href="#DejaVuSans-51" transform="translate(2118.09375 0)"/>
+    <use xlink:href="#DejaVuSans-48" transform="translate(2181.46875 0)"/>
+    <use xlink:href="#DejaVuSans-56" transform="translate(2243 0)"/>
+    <use xlink:href="#DejaVuSans-56" transform="translate(2295.09375 0)"/>
+    <use xlink:href="#DejaVuSans-3" transform="translate(2347.1875 0)"/>
+    <use xlink:href="#DejaVuSans-56" transform="translate(2378.96875 0)"/>
+    <use xlink:href="#DejaVuSans-48" transform="translate(2431.0625 0)"/>
+    <use xlink:href="#DejaVuSans-57" transform="translate(2492.59375 0)"/>
+    <use xlink:href="#DejaVuSans-56" transform="translate(2531.796875 0)"/>
+    <use xlink:href="#DejaVuSans-3" transform="translate(2583.890625 0)"/>
+    <use xlink:href="#DejaVuSans-47" transform="translate(2615.671875 0)"/>
+    <use xlink:href="#DejaVuSans-48" transform="translate(2679.15625 0)"/>
+    <use xlink:href="#DejaVuSans-53" transform="translate(2740.6875 0)"/>
+    <use xlink:href="#DejaVuSans-57" transform="translate(2804.171875 0)"/>
+    <use xlink:href="#DejaVuSans-4b" transform="translate(2843.375 0)"/>
+    <use xlink:href="#DejaVuSans-3" transform="translate(2906.75 0)"/>
+    <use xlink:href="#DejaVuSans-44" transform="translate(2938.53125 0)"/>
+    <use xlink:href="#DejaVuSans-4a" transform="translate(2999.8125 0)"/>
+    <use xlink:href="#DejaVuSans-44" transform="translate(3063.296875 0)"/>
+    <use xlink:href="#DejaVuSans-4c" transform="translate(3124.578125 0)"/>
+    <use xlink:href="#DejaVuSans-51" transform="translate(3152.359375 0)"/>
+    <use xlink:href="#DejaVuSans-56" transform="translate(3215.734375 0)"/>
+    <use xlink:href="#DejaVuSans-57" transform="translate(3267.828125 0)"/>
+    <use xlink:href="#DejaVuSans-3" transform="translate(3307.03125 0)"/>
+    <use xlink:href="#DejaVuSans-5a" transform="translate(3338.8125 0)"/>
+    <use xlink:href="#DejaVuSans-4c" transform="translate(3420.59375 0)"/>
+    <use xlink:href="#DejaVuSans-47" transform="translate(3448.375 0)"/>
+    <use xlink:href="#DejaVuSans-57" transform="translate(3511.859375 0)"/>
+    <use xlink:href="#DejaVuSans-4b" transform="translate(3551.0625 0)"/>
+   </g>
+  </g>
+ </g>
+ <defs>
+  <clipPath id="pd7c3492578">
+   <rect x="60.133642" y="44.327273" width="209.583345" height="209.583345"/>
+  </clipPath>
+  <clipPath id="pe62b927044">
+   <rect x="310.542588" y="44.327273" width="209.583345" height="209.583345"/>
+  </clipPath>
+ </defs>
+</svg>

--- a/docs/report/figures/make_field_figures.py
+++ b/docs/report/figures/make_field_figures.py
@@ -4,7 +4,7 @@
 
 """Regenerate the field-visualisation figures for the applications report.
 
-Reads the `.vti` / `.bin` output of three real runs (see
+Reads the `.vti` / `.bin` output of a handful of real runs (see
 `run_field_demos.sh` for how to reproduce them) and renders SVGs into this
 directory using `field_io.py` (readers) and `field_plots.py` (panels,
 montages, comparisons). The report itself has no compute engine: it reads
@@ -218,12 +218,106 @@ def figure_tungsten_seed_panel():
     return out, fig
 
 
+def figure_surface_diffusion_comparison():
+    """Isotropic vs anisotropic anneal of the *same* nanosurface, at t=8.
+
+    `nanosurface_isotropic.json` and `nanosurface_anisotropic.json` start
+    from the identical crossed corrugation -- 16 periods along x superposed
+    on 16 periods along y, amplitude 0.05 each -- and differ in exactly one
+    number, the anisotropy strength `eps_a`. Everything visible between the
+    two panels is therefore the anisotropy.
+
+    Isotropically the linear symbol depends only on |k|, so both ridge sets
+    decay at the same rate and the egg-crate pattern survives, only fainter.
+    With `eps_a=0.5, m=6`, `B(theta) = B_0[1 + eps_a cos(m theta)]` makes
+    the two orientations inequivalent: the x-varying ridges, whose gradient
+    points along x and so samples the stiff end of B near theta=0, are
+    erased, while the y-varying ridges near the soft theta=pi/2
+    (cos(3 pi) = -1) survive. The right panel is what
+    `energy_ky_frac = 0.751` in `nanosurface_anisotropic.csv` looks like as
+    a surface.
+
+    Do not read the panel amplitudes off the isolated single-orientation
+    rates B_0(1 +- eps_a)k^4: theta is the orientation of the *combined*
+    gradient of both ridge sets, so the two do not decay independently
+    (`docs/report/07_surface_diffusion.qmd` makes the same point about the
+    measured 3:1 split).
+
+    t=8 is the shipped `t1`, not an extension: h decays as exp(-B k^4 t),
+    so the +-0.1 initial corrugation is down to +-0.005 here and running
+    further leaves nothing to see. `h` is a signed height about a conserved
+    mean of zero, so the map is diverging and centred on 0 -- the shared
+    scale also carries the *amplitude* difference (RMS roughness 0.00238 vs
+    0.00155), which a per-panel autoscale would have hidden.
+    """
+    run_dir = DATA_DIR / "surface_diffusion_nanosurface" / "results" / "surface_diffusion"
+    isotropic = read_vti(run_dir / "nanosurface_isotropic_0016.vti", time=8.0)
+    anisotropic = read_vti(run_dir / "nanosurface_anisotropic_0016.vti", time=8.0)
+    fig = render_comparison(
+        isotropic,
+        anisotropic,
+        kind="diverging",
+        center=0.0,
+        label_a="isotropic ($\\epsilon_a=0$)",
+        label_b="anisotropic ($\\epsilon_a=0.5$, $m=6$)",
+        suptitle="Same corrugated surface, same t=8: sixfold stiffness picks an orientation",
+        cbar_label="surface height h",
+        axis_units="grid units",
+    )
+    out = HERE / "surface_diffusion_nanosurface_comparison.svg"
+    fig.savefig(out, format="svg", bbox_inches="tight")
+    return out, fig
+
+
+def figure_ehd_film_comparison():
+    """Compliant vs stiff plate under the same load, at the instant it lifts.
+
+    `load_relaxation_compliant.json` (B=100) and
+    `load_relaxation_stiff.json` (B=640) apply the identical Gaussian press
+    (p0=0.5, width a=8) over 0 <= t < 60 to an initially uniform gap
+    h0=1, and differ only in the plate's bending stiffness. Save index 6 is
+    t=60, the moment the load comes off -- also where both runs' CSV records
+    their minimum central gap, so this is the deepest the dent ever gets.
+
+    The two panels answer the chapter's question in one look. The compliant
+    plate dents *deeper* (h_centre 0.659 against 0.747) and *narrower* (RMS
+    spreading radius 12.3 against 14.2); the stiff plate spreads the same
+    displaced volume over a wider, shallower depression, ringed by the
+    slight bulge where the liquid pushed out has to go. Both dents sit well
+    inside the 256-cell periodic box, which is the visual form of the
+    chapter's claim that the measured spreading radius is measuring the
+    disturbance and not the domain.
+
+    A gap thickness cannot go negative, so the map is sequential; the shared
+    scale is what makes "deeper" and "shallower" comparable rather than two
+    separately autoscaled blobs that would look identical.
+    """
+    run_dir = DATA_DIR / "ehd_film_load" / "results" / "ehd_film_nonlinear"
+    compliant = read_vti(run_dir / "load_relaxation_compliant_0006.vti", time=60.0)
+    stiff = read_vti(run_dir / "load_relaxation_stiff_0006.vti", time=60.0)
+    fig = render_comparison(
+        compliant,
+        stiff,
+        kind="sequential",
+        label_a="compliant plate ($B=100$)",
+        label_b="stiff plate ($B=640$)",
+        suptitle="Same press, same instant t=60: plate stiffness sets depth against width",
+        cbar_label="gap thickness h",
+        axis_units="grid units",
+    )
+    out = HERE / "ehd_film_load_comparison.svg"
+    fig.savefig(out, format="svg", bbox_inches="tight")
+    return out, fig
+
+
 FIGURES = [
     figure_cahn_hilliard_coarsening_montage,
     figure_cahn_hilliard_comparison,
     figure_thin_film_dewetting_montage,
     figure_thin_film_comparison,
     figure_tungsten_seed_panel,
+    figure_surface_diffusion_comparison,
+    figure_ehd_film_comparison,
 ]
 
 

--- a/docs/report/figures/run_field_demos.sh
+++ b/docs/report/figures/run_field_demos.sh
@@ -26,9 +26,13 @@
 #                     (SLURM_JOB_ID/TMPDIR are read from the environment by
 #                     srun itself; export them before calling this script.)
 #
-# All three apps here (cahn_hilliard, thin_film, tungsten) are single-field,
-# single-rank spectral-ETD demos: `-n 1` is enough and keeps the run trivial
-# to place in its own output directory.
+# Every app here is a single-field, single-rank demo: `-n 1` is enough and
+# keeps each run trivial to place in its own output directory. Three of them
+# (cahn_hilliard, thin_film, tungsten) go through the JSON
+# `SpectralETDSession`; the other two (surface_diffusion_anisotropic,
+# ehd_film_nonlinear) are standalone science drivers whose `fields[]` output
+# is written by `openpfc_apps/field_snapshots.hpp` instead, using the same
+# JSON spelling.
 
 set -Eeuo pipefail
 
@@ -125,6 +129,45 @@ json.dump(d, open("'"$DATA_DIR"'/tungsten_seed/run_config.json", "w"), indent=2)
 '
 echo "==> tungsten_seed (256^3, t1=12)"
 (cd "$DATA_DIR/tungsten_seed" && $RUNNER "$BUILD_DIR/apps/tungsten/tungsten" run_config.json)
+
+# --- surface_diffusion: isotropic vs anisotropic nanosurface anneal --------
+# The shipped science pair, run unmodified: both presets start from the
+# *identical* crossed corrugation (16 periods per axis, amplitude 0.05) and
+# differ only in eps_a, so any difference in the final surface is the
+# anisotropy and nothing else. They write distinct filenames
+# (nanosurface_isotropic_%04d.vti / nanosurface_anisotropic_%04d.vti) so both
+# share one results/surface_diffusion/ directory.
+#
+# Unlike the thin_film runs above, `t1` is NOT extended past the shipped
+# value: t1=8 is already where the two runs differ most before the surface
+# flattens into round-off. h decays as exp(-B k^4 t) and by t=8 the initial
+# +-0.1 corrugation is down to +-0.005 -- the orientation contrast is still
+# clearly visible, but running much further leaves nothing to look at.
+run_case surface_diffusion surface_diffusion_anisotropic \
+  "$REPO_ROOT/apps/surface_diffusion/inputs_json/nanosurface_isotropic.json" \
+  surface_diffusion_nanosurface results/surface_diffusion
+run_case surface_diffusion surface_diffusion_anisotropic \
+  "$REPO_ROOT/apps/surface_diffusion/inputs_json/nanosurface_anisotropic.json" \
+  surface_diffusion_nanosurface results/surface_diffusion
+
+# --- ehd_film: compliant vs stiff plate under the same load ----------------
+# The shipped science pair, again run unmodified and into one directory
+# (load_relaxation_compliant_%04d.vti / load_relaxation_stiff_%04d.vti).
+# Same Gaussian load (p0=0.5, a=8) held over 0 <= t < 60 then released; the
+# only difference between the two is the bending stiffness B (100 vs 640).
+#
+# The figure is rendered from save index 6, i.e. t=60 -- the instant the load
+# comes off, which is also where the diagnostics CSV records `h_center`'s
+# minimum in both runs. Later saves show the dent healing, not the stiffness
+# contrast at its clearest. Do not shorten `t1`: the 600-unit tail is what
+# the chapter's spreading-radius claim (peaks under 22% of the domain
+# half-width) is measured over.
+run_case ehd_film ehd_film_nonlinear \
+  "$REPO_ROOT/apps/ehd_film/inputs_json/load_relaxation_compliant.json" \
+  ehd_film_load results/ehd_film_nonlinear
+run_case ehd_film ehd_film_nonlinear \
+  "$REPO_ROOT/apps/ehd_film/inputs_json/load_relaxation_stiff.json" \
+  ehd_film_load results/ehd_film_nonlinear
 
 echo
 echo "Done. Data written under: $DATA_DIR"

--- a/docs/report/figures/surface_diffusion_nanosurface_comparison.svg
+++ b/docs/report/figures/surface_diffusion_nanosurface_comparison.svg
@@ -1,0 +1,1654 @@
+<?xml version="1.0" encoding="utf-8" standalone="no"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN"
+  "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="620.422953pt" height="289.111321pt" viewBox="0 0 620.422953 289.111321" xmlns="http://www.w3.org/2000/svg" version="1.1">
+ <metadata>
+  <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+   <cc:Work>
+    <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
+    <dc:date>2026-09-10T11:53:01.108966</dc:date>
+    <dc:format>image/svg+xml</dc:format>
+    <dc:creator>
+     <cc:Agent>
+      <dc:title>Matplotlib v3.11.1, https://matplotlib.org/</dc:title>
+     </cc:Agent>
+    </dc:creator>
+   </cc:Work>
+  </rdf:RDF>
+ </metadata>
+ <defs>
+  <style type="text/css">*{stroke-linejoin: round; stroke-linecap: butt}</style>
+ </defs>
+ <g id="figure_1">
+  <g id="patch_1">
+   <path d="M 0 289.111321 
+L 620.422953 289.111321 
+L 620.422953 0 
+L 0 0 
+z
+" style="fill: #ffffff"/>
+  </g>
+  <g id="axes_1">
+   <g id="patch_2">
+    <path d="M 61.416909 253.910618 
+L 271.000255 253.910618 
+L 271.000255 44.327273 
+L 61.416909 44.327273 
+z
+" style="fill: #ffffff"/>
+   </g>
+   <g clip-path="url(#p65b044fd6f)">
+    <image xlink:href="data:image/png;base64,
+iVBORw0KGgoAAAANSUhEUgAAASMAAAEjCAYAAAB5IGctAAAdx0lEQVR4nO2dz6tm2VWG9w33ghOh44+U2oUhrZCGIEgMOBHBiaAzR90zQVAzECL4DwiZOAkYyMiBkFm3E2cRnAQEoRtaELUhithEboPVmnSBE6GblIO6+9a6u969a+0f55x1bj3PrNJfvVn73eecOvf7zvfciz9Mn3+SbvjKKz+WUkrpt/7411NKKT34va+llFL69Kdeyy9Jl//zHymllD769rdSSil95xvfTSml9N7j/0tlzm//yW+klFL63O/+0e1/y1m1HJtVzqNmKnPUTOU8dqYyp7W2nKPW1pOjZipz1Nr26FrlfHKTc7W4a0+Omuk+dz3S0arzw2bVctTaenLUTDnnMwkAIACX9mr2xdd/MqWU0md/+UsppWf/In74v5/cvubhzf/2yi+9fvN3/unpf/jeD57Lya/5xFwVc9artRyTVc6jZirnUTOV87RyWmvLOWpt5bpaOWqm/C/H9WTX9l+g60pHra5VzmzX5dp6ctRM1xt0XT0eO4/r2a7LtXk6ap0fPTk2a6RrldNzDeHOCABCcPHh1796+55RvlJd/OYfpJRSevv9/04ppfTuBz+8/Qu/+oWfSCml9MaXfjqllNKTv/2LlFJKj//5e+lFOTarlmOzyhw1U5mjZurJaa3N/utS68jmvHmT86OOjo7u+jM3OW85ctRMPV2/aXLKjmzX5Uw9e9Za25Zdl3ufUkof/+P7KaVndw09e6Zmmj0/ynlSmuu6dX689/2Pb//bVz7/2ZTS8x1xZwQAIeBiBAAhuPjkP//l9se0/GZTvrX65l8/vY37r3//4PYv/MwvfiGllNLXfufprV2+1bIf/eU3v94qcmxWLcdmlTlqpjJHzdSTY7Py7ehVkaPW1srp6ajVdTlPK0fN1NO1J0etbfWeqZl69iylY49r++NRnqk2TytHzTTaddmRfSO+1pHnuPbsmZopz8OdEQCE4FJ9hJvftMpXsx/823vP/cV3P/jZlFJKv/bzr6SU7n70l3Pym1b2qlhmlTk2q5ynNVPOUTP15LTWZj+eXNXRVjkqy9N1z56pmVbvmZrJ09FDx/G45XH93vd/7k6OnemIrvM8NqecR8205flRdsSdEQCE4NL+TJyvcPljvHfMz4mZ/PNefs3DH796GmRy8hU3f4T39x05NuthMY+aqcxRM/Xk2Ne9epNzVeTY13hyWh2t6nokx2aN7JmaafWetWbydv3qxPE4elzn17wquh6ZR83U03X+/7IzlfO0ZvJ07Tk/1Ex5Hu6MACAEXIwAIASX9tu8+QnKN26f6Hz60Zt9E618ojM/PfmReFK1zLFZtRyb9XzO8zOpJ0zLmXpybNaTSo5aWyunp6M4Xb84R820es/UTGfq2j7t/qh44vmorvNM5Txqpp6uPXumZnrCE9gAEIlL61vJ3579lZs/v3lzdbvz8eTNm035qvgPf/ZXKaWU/vXOt5t1js2q5disMkfNVOaomXpyWmuz38CudeTJUTNF69qTo2ZavWdqpi26zm+iPtml6/dfmFPOo2Za1/Wzhy5rHdk34msdefZMzZRzuDMCgBBcWpNd9pL8ws3PgJ/78vMf2d1a2m5ek6+KnpyUnn2MWMu5k1Xk2KxajpypI6e5NjNjubauHDFTmaPWtmfXnhw50+I9UzNt0fXVZNcPF3Vdy5EzNboeyVEz5Y6uJs8PzzWEOyMACIE0PdYshinN2wdnjHg2a5V9cNb0WObM2gejdL2F6XEkR820RddnNj22DKa9pseZrj0m1JQwPQJAcLgYAUAIpHa2VE96lJEezafNquXYrDJHzVTmqJl6clpr82g1PTlqpmhde3LUTKv3TM20Zdcj+trW2lra2aO79mhnR8+PkeOaOyMACMG06bHHrGezRox4aqYek50np7W2VUa8lNaZHld1PWp6rNkwz256XGXVvM+mxxETqpoJ0yMAhGLY9Fha2rY0PdqfNzE9YnrE9NjfNaZHAAAnw6bH/I74HqZH+05+zUCH6bE/x2ZhesT02JoJ0yMAvDRwMQKAEGB6xPQ4nKNmwvR4N+co02N+c7h8mNPOtKfp0b6BXnvAlDsjAAgBpkdMj8M5aiZMj5geWzlqJkyPABAKaXp87eZnyQeTpscyx2b1GPFyjppptRGvuTaHyW7WPhil6weTpsdVe6ZmGjU9Rj2uPTlyph26Hj0/RrrmzggAQsDFCABCILWz+aO+We1szlFazR49p/3oMWfVctRMLRVqmdNaW0vPWepCWzlqpjJHrW3Prme1s6v2TM3Uowpure16UDu7Zdcj2lnb9ax2ttZRr3a21TXaWQAIDaZHTI/DOWomTI+YHls5aiZMjwAQipfC9NhjxGutDdMjpkc1T2ttmB4xPQLAybhUv4gumn1wlTUQ0+M5TY+rOlplevR0Hc30qHKONj2WOdwZAUAIuBgBQAgu7Rt0PdrZPVWoqxSmvdrZEa0m2tm1e9Za21Ha2RGlqs06QjtrXxNFO1vqnbkzAoAQYHpcZLI7k30Q0+MxpscoXW9lMPXkqJkwPQJAKJqmx3x1m7UP2it3zWS3t+mxXNuo6bHM8Rjx1EyYHvutgSu7HjE9quN6Vdejpsfa8ejJUTPNmh57riHcGQFACDA9YnoczpEzRbMPNtZG15geAQCeg4sRAIRgF9Oj+v5b1axnsjwmu1HTYy2ntTZleqyZ9Vo5aqZVpsdVXXsshmqmPUyPo1bN1abHVV17ctRMZzA99lxDuDMCgBC4TI/2W8H5gaVR+2DOquXYrJbJrpajZso5Fybn7UpOa20t02NPjpqpzFFr68lRM42aHke6XrVnaqbRrj3Htcf0ONq1x/S4Z9ce0+Pq80PNhOkRAEIxbXrssRjarFqOzVptDbyPpsetut7bPrjK9Ki6PvK4vs+mx5E9UzNhegSAUHAxAoAQXKpf1reV5lNloZ1FO9vKUWvzdPTQcTy+TNrZPI/NOVo7W3bEnREAhOBSGfFW2QdHzHo262jTY/6mcn6jz/4riekxyZkwPcY0PdpfwhjF9Fh2xJ0RAIQA02PDZLeVEU/PFK1rTI/enNbaMD1iegSAk9FtelxlxBs1Pc6Y7Dw5rbVtaXqM1rUnR820pX2QrmN37TU91jrizggAQsDFCABCsKl2tlSq2qwePadHFzuqnc0fa9rvex2pnbUfs14d2LXNKTta1bVXhVrryLVnjbVFOa49OXImtLMAAOvpNj32GPFKG6LN6jHitQyNPSY7T05rbXuYHqN0rb4mtMqq2WsfXN11tOM6oulx9vzA9AgAp0WaHj2WtlVGPPVw2IihUT3UNWp6rK3tKNPjnl177IOrul5pevR0FM302LNnaqbZ82PU9DhzftgsTI8AEBJMj4tNdluaHvfsGtMjpkeVY7MwPQLAvYSLEQCEQJoePba30tJmH2q6njQ95qwypzWTMuKN5KiZlMlulTVwqxyV1dP1rH1wdM9Wdb2l6dHT0Z6mR0/XmB4BAJxI06PHQJdfs4fp0VrqagY6jxHPk6NmUia7GSOemmnWPri661n74Ko9a810lOmx5/zYw/To6RrTIwCAE0yPi012Z7APYnrcvmv10GOUrjE9AgA04GIEACFAOxtEO/um6Dq/QfijA7p+U+SU86iZVNfl2l4G7Wy5Z2ptkbWztT2zWWhnAeBecgrT4yqTnccY2VzbDqbHo7tumR6Psg+uMj2uOq7LnNbaMD1iegSAk3EK0+Mqk11k02OUriPaB1d1veq4LnNaaztb13uYHmsdcWcEACFwmR7tF/HyI9yjRrycVcuxWaWhL6VnnpQyx2MNVEa8MsdmteyDtY48OWqmaF2/1chZ1fWo6VF1PWJ63LJr9dBjrSNPjs2K2rXn/FAzYXoEgFBwMQKAEExrZ0uFZSvHZo3oOdVMPVpNT05rbav0nCmNaWe37HpUO1vOtEqFOqqd7ekoynF9Vu3syJ6pmdDOAkAolpkeV9oHt7IGYnr0d43p8e48rRyVhekR0yMAnJTLWZMdpkdMj60clYXpcf+uMT0CADjB9IjpcThHzYTp8W7Ok4BdY3oEAGjAxQgAQtA0Pa6yD3qsgV7TYznTKvugfVO3tjaPEc+To2aK1vWWpseeHDUTXcfs2pOjZsL0CACh2N30WLMG9poeR+yDyvRY5jTX5rAPzpoeXz2461WmR0/Xs6bH+2jVxPQIAHAw3abHfIWLYnos51EzKdPjp5Wc1tq2ND2W86i19eSotfXYBz05aqaerntNj2XObNfXG1g1Z7u+DmJ6LDtaaXqsdcSdEQCEgIsRAIRAamc9ek6PUrVHYdrSc67SznpyWmvbQju7SoXq6XpP7eyqPVMzHa2dXX1c35euPTlqJrSzABAKTI+YHpvztHLUTJgeMT3amTA9AsDpuFQfT45Y2s5geszretHa9jQ9ero+o+nR0/WWpsejrZp7mh49XWN6BABwcml/Js5XuB5L25lMj/Y15dqOMj16uj6j6dHTNabH/brG9AgA4ISLEQCEAO0s2tnhHDUT2tm7OWhn0c4CwMnA9IjpcThHzRTNPthaW+Su85u6T07UNaZHALgXSNPjlka8GfugzcL02M5RM2F63O64PtL0qLoeNT3WOpo9PzA9AsBp4GIEACGQ2tmaUjWldXrOHu2s/chwRqvZyrkv2tlVXUfUzq7uegvt7EjXnhw10+rzw75uVjvbuoagnQWA0LhMj/ZbwfmBpaNNj3mmch41U09Oa20t02NPjpqp1fWofbDWUa99cKuuR+2DEbv2HNcf3/z6niyr37Jrj+mxnEfNNHp+YHoEgNOC6RHTY3OeVo6aadQ+WLMYqpmOMj2OdITpEdMjAJyMS/Wpicf2VlraHjpyVFaPEa81kzLZjRgj1Uyj9sERG+aWVs1W19cDOWqm1XumZlp1PN4X0+No16Omx63OD+6MACAEXIwAIASXo3rOVdrZMsdm9Whn7WtqOkxPjn1d/uZ0foOuV8+5uqNyntGcWe3sqq49Oa2ZWnv2Mmlne7ue1c7WjmvPnqmZ0M4CQCgwPTZMdlsZ8fRMfiMepkf/nrXWtuVxrR56jNI1pkcAgAaYHjE9DueomaLZB1tru/PLLAuz4tFdRzM92ve+ah1hegSAe4E0Pb528wW6B0GMeHkeNVMU02OXEU/MtIXpcZV9cMTQqPbsvpgey/PDZh1helx1fqi1jZoeR64h3BkBQAi4GAFACKTpMftNeixtHrNeSs++A1XNMVnlPDarlqNm6rEPttbmMeJ5ctRMq0yPs12vMj2qPZs1PY7sWWtto6bHvLYtui7Nir1d1wym3q7LtY2aHms5aiZMjwAQCml6LC2GytK2yoinfg3wiMlOPdRV5lyYnHJt9nH52tpapkeV47EPruq6zFEz9XTtsRiqtfV0PWp67Nmz1tq2PK49pseePVMzzZ4fHtPj6vPDZmF6BICQTJseeyyGNquWY7NWWwM9OTZrxGS3pelxz673tg+uMj2qjo48ru+z6XFkz9RMmB4BIBRcjAAgBJtoZ0cUph4VamumldrZmnq0V6s5ojDdUjtbzpPSmHZ2lQrVk6Nm8nSNdnY77azn/Mi/4gjtLACcDkyPRU5Kz3wrpVmx1z642ho4m1POY7NGctRMPV17clozebvG9LjW9FjryO5Zfs07mB4B4GxgejyR6XHfrs9peozW9ZOAXWN6BABogOkR0+NwjprprKbHaF1HMz2uOj/UTJgeASAUXIwAIARSO7ulCrWmHvXoOdVMUbSzq1SoUbqe1c6u2jM108vQ9dUZu3bkqJnQzgJAKKTpcUv7YM1A5zHiqZmimB5X2QejdD1rely1Z2qmLbruMT3u0XWP6XGPrntNjyPHNXdGABCCi+s//f1bn1HNQOextG1pxPOY7JQ1sGbWU2vzGBpnTY8fm18pU+s6f8EwpfrDYSutmrWubU6eqfzVzWpts3u2yvSouj6j6dHT0arzQ60N0yMAvHRgesT0OJyjZsL0iOnRzoTpEQBOBxcjAAjB5SfiY0WPpc1jxCtzVJayD5bmOPum7ow10JPTWluvyW6ko6O7XmUfXLVnam1bWjVXdb2n6dHTNaZHAAAnl1fmDbp8hfNY2jxGvJEcm1XmqKweI54nx76uZXqsra3X9Bit61X2wVV71lrbUabHEYuhzVptevR0jekRAMAJpkdMj8M5aiZMj/pBVbU2TI+YHgEgIFyMACAETe1svtWKoue0WVG1s/YNyycDHUXp+mXTzpaaV0/OGxt2PaqdLc/Znhw1U89xjXYWAO4FLtOj/chu1oiXs+6b6bFcVzNHzHQG++B9Mz1GOa49OXKmRtcjOWqmruPakaNmwvQIAKFomh7zV0Vm7YPqKydVs57JUia7cqZRI16ZM2p6rM3TylEzbWl6HOn6DKbH2a6vJ02Pq45rT46aafX5YV9XdjRqeuy5hnBnBAAhkKZHjxHPYzGMZnr05LTW1mvEG+koSteeHDXT6j1TM9F1zK49OWomTI8AEAouRgAQArSzHdrZVXpONVOPnvNqh67Pqp1VHaGdRTsLAODmUn2E67G9lZY2+9H4dYfJrmXEK3NaM7VMdj05aiZlstuqoyhde3JsVs0Y2VqbJ0fN1NvRatPjbNcjOWqm2a5HTY9bnR/cGQFACC5HjXj5NS0j3kiOzSpzVJYy2dUMdJ6c1trsv7YeI95WHe3RtSdHzbR6z1ozebtebXrs6WjW9LhF17Omx5nzQ82E6REAQoHpcbHJ7gz2QUyP23etHnqM0jWmRwCABlyMACAE3abHVUa8Wo7NWm2y8+S01qZMdiM5aqYt7YMjXa80Pa6yD67qeo/jusf06NkzNdMZTI89XXNnBAAhkKbH126+hftA2AevKpa2XvtgLedOlsMaWObImTpymmtz2AddOWImZXo8sustTY89e6Zmitj1kabH14xZ4MGk6bF27veeH2UOpkcAOA3S9Ji9JMrSdqQRT8202ojXWtuWpsdoXUe0D9K17sh6hGa7rp37vefHyDWEOyMACAEXIwAIgdTOXtx8HPd2hzLysXhS9Wjt7OPiydBR7WyZk1K9I0+OzVrVdZmjZlJd1zrqVaGOdO3JUTNtqZ0tnwre8rju2TObtarrVdrZnvNDzYR2FgBCMW167DHr2awRI56aqcdk58lprW3UiNdjaIzStdc+ONP1FvbBVabHM3R9tOmxNo+dCdMjAJyOTUyPWxnxWjN5THb30fR43+yDmB7v5thvu0cxPdY6wvQIAPeCTUyPMzk262jTY/5CX/6ZeJURT83UY8TD9Hg3x75GdXRm06P1CEUxPdY6wvQIAPcCLkYAEILLR3/5zds/5Iefnrls6srI8oElpecsc2xWj57TunVqOkz1UNdITmttvXrOkY48es59un5xjlrb6j1TM7VUqLmjR+Khx56utziuHxUPGR7ddTmPmmn0/Bi5hnBnBAAhuPybP/+72z988fWnV8qWpa20/fVYDG1WLcdmKZNdaaAbtQ/Wclpr8xjxPDlqJmV6PLLrlabHmT1TM/V3ffe4XmXVHO9az2NzSmOkmsljevR1/ewu0mN6nDk/1EyYHgEgFC7To8fS5smxWT1GvFUmu5Z90H6EO2J6LOdp5oiZlH3wiK5XmR7Vno3kqLV17ZmYKdpx7cmRM+1geuw6rjE9AsB9oNv0mK9wHiNemWOzqjkmS5ns8tdXris5aiZlH/y0WJu9cveYHst5Ru2D5TxqbZ6u7dd7ah157IPqa0I9Xas9G8lRa+vZMzVTuWcp9ZkeVx/Xas+ONj2OHNeenJTqHXFnBAAh4GIEACGQpkePEW/ErGez9jA9juS01jZrxBu1Dx7Rda/pcas9UzPRdcyuPTlqJh56BIBQhDE92it3/uhvlcmuJ6e1tlEjXl6b/Xh0lemxlqNm6unaax8s1za6Z7UcNdMepseePWutbaXpcVXXmB4BABqENj2WNsTWTKuMeDZr1mQ3Yg3c0j5Y5qi17Wkf9OSomTwdYXo81vT47gc/fGEOpkcACAkXIwAIwbR2dlbzuUo7u0rPabNmtbOrFKa1eUZzZrWzq7r25LRmau0Z2lk9j51pS+1sfs07aGcB4GxcfvTtb93+IX9XpGYxTKnPPljm2KyaWc9mPZ/z/Exljs0ayWmtrdf06LEGxu36xTlqbav3TM3Us2c2a5Xp0dORx6p5VNet47rHqjmyZ2qmJzz0CACRuPzON757+4fSHKdMjyNGPHvlLs1xZY7N8pjsyhw1U09Oa23KZDeSo2ZaZXpc1fWWpseePVNrm+16j+O6x6rp2TM10+rzw2a1TI8z54eaCdMjAIRiU9OjsgZGNT3aT6jOaHpc1fUq06Ona699sNaRa89MVjTTY8+eyZkwPQIArIeLEQCEoFs726PnzK9Res5qjslardW0r6nltNamtLMjOWqmKF335KiZerr2qlBXdb3quG5pZ4/oegvt7Oz5MdI1d0YAEAJpery4+Tju7WBGPJs1YrK7MDnl2lomu8fioa5aR732wZGuH4sH8cocNdPLaB9srU11XT6Ip7o+2vRYHo9Hd91zfqiZMD0CQCjCmB6VEQ/TY3zT40zXmB4xPdoc7owAIATLTI8rjXhbWQMxPWJ67M05g+kxWxVba8P0CADghIsRAIRgmenxalGOzSpzVJYy4tUMjUeZHmc72ipHra3XPjjTtSenNdOWpsctjutZ02M5U/4xy76mNCtuaXqszWNfg+kRAE6HND16jHjlA0ses57N6jHiWbdOzUCnHuoayWmtrdc+ONJRnK5fnKNmWr1naqYtux4xRrbWZrt+VDxkeHTX5TxqptHzY+S45s4IAELQbXpcbR/sMeKl9LyBbpV90P7GjNraeo14PR2tMj16DI1Hmx57ctRMW3S9yvTo6/p9OY9aW2/XNdNjO+fZQ5czXXv2LKV6R9wZAUAIuBgBQAikdnZLFWpNPerRc6qZVqlQe7Waq1Soe3QdTTvbq0Ldo+va8XhU1z1q3jCKX0dOSmhnASA40vTYsg/mB5t67IPq+2/VHJOlrIGfFjOVOWqmnpzW2pR9sMwZNT2WOWpte3btyVEzrd4zNVPPnrXWNmvV3LLro62aI8e1JyelekfcGQFACKTp0WPEO6Pp0ZPTWttR9sEjun5ZTY90Pd61J0fNxEOPABCKadPjKiOexz6oZlptxLNZIya7LU2Pe3a9t31wlelRdYTpcRvT48ieqZkwPQJAKLgYAUAI7o12Vmk1R7WztbX16jlHOorSNdrZu/O0clTWntrZ0fMD7SwAgCCM6fGhMOI9LHJUljLZPSxMdj05rbX1GvHKtdmuy5lGux7J8XTttQ/OdO3Jac20pelx9Z7ZrFHT40zXW5geW3uG6REATos0PdYshin1GfHKHJtV5rTsg9YbUzPQvSEe6hrJaa2t1/RYrs3TUZyuX5yj1rZ6z9RMPXtms3pMjz17pmbyWDWP6rp1XHtMj7WOPHumZnrCQ48AEAkuRgAQgsO1s6Xm02Z5tJqjKtRaTmttSqtZ03yqtR2lnR3p+mza2dmuV2lnR3TKnvNDzdSjnfXk2KyRrj3nR0poZwEgOJgeXwLT40jXmB6P7RrTIwDAQXSbHkeMePZbwTUDndf0OGOy8+S01qZMdiM5aqZV9sFVXa80Pa6yD67qOtpx7clRM0Xr2pOjZsL0CAChuPjw61+99RnlK9XFzTvgb3dY2h6Lh8PKHJuVc8oHn2xWzvGY7NRDXWXOhckp19Yy2ZU5am09OWqmVtdlR3t03bIPrupa2QdV1x77oKcjj31wVdce02NPjs0a6Vrt2ajpsdaR5/xQa8P0CACh4GIEACGY1s6WCstWjs0a0XOqmTxazVXa2VV6TjXTaNdoZ9OdrJ7jcY+u77N2dkTLrGZCOwsAoVhmevSY9VRWjxGvNROmx/1Mj6u69uSomVYdj5ge1x7XszncGQFACJaZHmdzMD2ex/S4qmtPTmum1p5hetTz2JlGTY+149qzZ2omTI8AEAppeixtb/bnzdoDSx6zns1qPRxWmuOszqKcqfVw2EhOa20tk11Pjp4pWtcvzlEzrd4zNdOWXXtMj6NdPyoeMjy663IeNdPo+TFyXHNnBAAh4GIEACHoNj3WTHZ7GPHUTGWOmqknp7W2XtPjSEdRuvbkqJlW75maacuu9zE9vt+do2Za1/Wzhy5nuvaaHmsdcWcEACH4f95IyMe194fPAAAAAElFTkSuQmCC" id="imagec87ddc7782" transform="scale(1 -1) translate(0 -209.52)" x="61.2" y="-44.311321" width="209.52" height="209.52"/>
+   </g>
+   <g id="matplotlib.axis_1">
+    <g id="xtick_1">
+     <g id="line2d_1">
+      <defs>
+       <path id="md7568791be" d="M 0 0 
+L 0 3.5 
+" style="stroke: #000000; stroke-width: 0.8"/>
+      </defs>
+      <g>
+       <use xlink:href="#md7568791be" x="61.416909" y="253.910618" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_1">
+      <!-- 0 -->
+      <g transform="translate(58.871909 266.988743) scale(0.08 -0.08)">
+       <defs>
+        <path id="DejaVuSans-13" d="M 2034 4250 
+Q 1547 4250 1301 3770 
+Q 1056 3291 1056 2328 
+Q 1056 1369 1301 889 
+Q 1547 409 2034 409 
+Q 2525 409 2770 889 
+Q 3016 1369 3016 2328 
+Q 3016 3291 2770 3770 
+Q 2525 4250 2034 4250 
+z
+M 2034 4750 
+Q 2819 4750 3233 4129 
+Q 3647 3509 3647 2328 
+Q 3647 1150 3233 529 
+Q 2819 -91 2034 -91 
+Q 1250 -91 836 529 
+Q 422 1150 422 2328 
+Q 422 3509 836 4129 
+Q 1250 4750 2034 4750 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-13"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_2">
+     <g id="line2d_2">
+      <g>
+       <use xlink:href="#md7568791be" x="94.164307" y="253.910618" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_2">
+      <!-- 20 -->
+      <g transform="translate(89.074307 266.988743) scale(0.08 -0.08)">
+       <defs>
+        <path id="DejaVuSans-15" d="M 1228 531 
+L 3431 531 
+L 3431 0 
+L 469 0 
+L 469 531 
+Q 828 903 1448 1529 
+Q 2069 2156 2228 2338 
+Q 2531 2678 2651 2914 
+Q 2772 3150 2772 3378 
+Q 2772 3750 2511 3984 
+Q 2250 4219 1831 4219 
+Q 1534 4219 1204 4116 
+Q 875 4013 500 3803 
+L 500 4441 
+Q 881 4594 1212 4672 
+Q 1544 4750 1819 4750 
+Q 2544 4750 2975 4387 
+Q 3406 4025 3406 3419 
+Q 3406 3131 3298 2873 
+Q 3191 2616 2906 2266 
+Q 2828 2175 2409 1742 
+Q 1991 1309 1228 531 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-15"/>
+       <use xlink:href="#DejaVuSans-13" transform="translate(63.625 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_3">
+     <g id="line2d_3">
+      <g>
+       <use xlink:href="#md7568791be" x="126.911705" y="253.910618" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_3">
+      <!-- 40 -->
+      <g transform="translate(121.821705 266.988743) scale(0.08 -0.08)">
+       <defs>
+        <path id="DejaVuSans-17" d="M 2419 4116 
+L 825 1625 
+L 2419 1625 
+L 2419 4116 
+z
+M 2253 4666 
+L 3047 4666 
+L 3047 1625 
+L 3713 1625 
+L 3713 1100 
+L 3047 1100 
+L 3047 0 
+L 2419 0 
+L 2419 1100 
+L 313 1100 
+L 313 1709 
+L 2253 4666 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-17"/>
+       <use xlink:href="#DejaVuSans-13" transform="translate(63.625 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_4">
+     <g id="line2d_4">
+      <g>
+       <use xlink:href="#md7568791be" x="159.659102" y="253.910618" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_4">
+      <!-- 60 -->
+      <g transform="translate(154.569102 266.988743) scale(0.08 -0.08)">
+       <defs>
+        <path id="DejaVuSans-19" d="M 2113 2584 
+Q 1688 2584 1439 2293 
+Q 1191 2003 1191 1497 
+Q 1191 994 1439 701 
+Q 1688 409 2113 409 
+Q 2538 409 2786 701 
+Q 3034 994 3034 1497 
+Q 3034 2003 2786 2293 
+Q 2538 2584 2113 2584 
+z
+M 3366 4563 
+L 3366 3988 
+Q 3128 4100 2886 4159 
+Q 2644 4219 2406 4219 
+Q 1781 4219 1451 3797 
+Q 1122 3375 1075 2522 
+Q 1259 2794 1537 2939 
+Q 1816 3084 2150 3084 
+Q 2853 3084 3261 2657 
+Q 3669 2231 3669 1497 
+Q 3669 778 3244 343 
+Q 2819 -91 2113 -91 
+Q 1303 -91 875 529 
+Q 447 1150 447 2328 
+Q 447 3434 972 4092 
+Q 1497 4750 2381 4750 
+Q 2619 4750 2861 4703 
+Q 3103 4656 3366 4563 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-19"/>
+       <use xlink:href="#DejaVuSans-13" transform="translate(63.625 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_5">
+     <g id="line2d_5">
+      <g>
+       <use xlink:href="#md7568791be" x="192.4065" y="253.910618" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_5">
+      <!-- 80 -->
+      <g transform="translate(187.3165 266.988743) scale(0.08 -0.08)">
+       <defs>
+        <path id="DejaVuSans-1b" d="M 2034 2216 
+Q 1584 2216 1326 1975 
+Q 1069 1734 1069 1313 
+Q 1069 891 1326 650 
+Q 1584 409 2034 409 
+Q 2484 409 2743 651 
+Q 3003 894 3003 1313 
+Q 3003 1734 2745 1975 
+Q 2488 2216 2034 2216 
+z
+M 1403 2484 
+Q 997 2584 770 2862 
+Q 544 3141 544 3541 
+Q 544 4100 942 4425 
+Q 1341 4750 2034 4750 
+Q 2731 4750 3128 4425 
+Q 3525 4100 3525 3541 
+Q 3525 3141 3298 2862 
+Q 3072 2584 2669 2484 
+Q 3125 2378 3379 2068 
+Q 3634 1759 3634 1313 
+Q 3634 634 3220 271 
+Q 2806 -91 2034 -91 
+Q 1263 -91 848 271 
+Q 434 634 434 1313 
+Q 434 1759 690 2068 
+Q 947 2378 1403 2484 
+z
+M 1172 3481 
+Q 1172 3119 1398 2916 
+Q 1625 2713 2034 2713 
+Q 2441 2713 2670 2916 
+Q 2900 3119 2900 3481 
+Q 2900 3844 2670 4047 
+Q 2441 4250 2034 4250 
+Q 1625 4250 1398 4047 
+Q 1172 3844 1172 3481 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-1b"/>
+       <use xlink:href="#DejaVuSans-13" transform="translate(63.625 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_6">
+     <g id="line2d_6">
+      <g>
+       <use xlink:href="#md7568791be" x="225.153898" y="253.910618" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_6">
+      <!-- 100 -->
+      <g transform="translate(217.518898 266.988743) scale(0.08 -0.08)">
+       <defs>
+        <path id="DejaVuSans-14" d="M 794 531 
+L 1825 531 
+L 1825 4091 
+L 703 3866 
+L 703 4441 
+L 1819 4666 
+L 2450 4666 
+L 2450 531 
+L 3481 531 
+L 3481 0 
+L 794 0 
+L 794 531 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-14"/>
+       <use xlink:href="#DejaVuSans-13" transform="translate(63.625 0)"/>
+       <use xlink:href="#DejaVuSans-13" transform="translate(127.25 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_7">
+     <g id="line2d_7">
+      <g>
+       <use xlink:href="#md7568791be" x="257.901296" y="253.910618" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_7">
+      <!-- 120 -->
+      <g transform="translate(250.266296 266.988743) scale(0.08 -0.08)">
+       <use xlink:href="#DejaVuSans-14"/>
+       <use xlink:href="#DejaVuSans-15" transform="translate(63.625 0)"/>
+       <use xlink:href="#DejaVuSans-13" transform="translate(127.25 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="text_8">
+     <!-- x (grid units) -->
+     <g transform="translate(137.297488 279.749212) scale(0.09 -0.09)">
+      <defs>
+       <path id="DejaVuSans-5b" d="M 3513 3500 
+L 2247 1797 
+L 3578 0 
+L 2900 0 
+L 1881 1375 
+L 863 0 
+L 184 0 
+L 1544 1831 
+L 300 3500 
+L 978 3500 
+L 1906 2253 
+L 2834 3500 
+L 3513 3500 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-3" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-b" d="M 1984 4856 
+Q 1566 4138 1362 3434 
+Q 1159 2731 1159 2009 
+Q 1159 1288 1364 580 
+Q 1569 -128 1984 -844 
+L 1484 -844 
+Q 1016 -109 783 600 
+Q 550 1309 550 2009 
+Q 550 2706 781 3412 
+Q 1013 4119 1484 4856 
+L 1984 4856 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-4a" d="M 2906 1791 
+Q 2906 2416 2648 2759 
+Q 2391 3103 1925 3103 
+Q 1463 3103 1205 2759 
+Q 947 2416 947 1791 
+Q 947 1169 1205 825 
+Q 1463 481 1925 481 
+Q 2391 481 2648 825 
+Q 2906 1169 2906 1791 
+z
+M 3481 434 
+Q 3481 -459 3084 -895 
+Q 2688 -1331 1869 -1331 
+Q 1566 -1331 1297 -1286 
+Q 1028 -1241 775 -1147 
+L 775 -588 
+Q 1028 -725 1275 -790 
+Q 1522 -856 1778 -856 
+Q 2344 -856 2625 -561 
+Q 2906 -266 2906 331 
+L 2906 616 
+Q 2728 306 2450 153 
+Q 2172 0 1784 0 
+Q 1141 0 747 490 
+Q 353 981 353 1791 
+Q 353 2603 747 3093 
+Q 1141 3584 1784 3584 
+Q 2172 3584 2450 3431 
+Q 2728 3278 2906 2969 
+L 2906 3500 
+L 3481 3500 
+L 3481 434 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-55" d="M 2631 2963 
+Q 2534 3019 2420 3045 
+Q 2306 3072 2169 3072 
+Q 1681 3072 1420 2755 
+Q 1159 2438 1159 1844 
+L 1159 0 
+L 581 0 
+L 581 3500 
+L 1159 3500 
+L 1159 2956 
+Q 1341 3275 1631 3429 
+Q 1922 3584 2338 3584 
+Q 2397 3584 2469 3576 
+Q 2541 3569 2628 3553 
+L 2631 2963 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-4c" d="M 603 3500 
+L 1178 3500 
+L 1178 0 
+L 603 0 
+L 603 3500 
+z
+M 603 4863 
+L 1178 4863 
+L 1178 4134 
+L 603 4134 
+L 603 4863 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-47" d="M 2906 2969 
+L 2906 4863 
+L 3481 4863 
+L 3481 0 
+L 2906 0 
+L 2906 525 
+Q 2725 213 2448 61 
+Q 2172 -91 1784 -91 
+Q 1150 -91 751 415 
+Q 353 922 353 1747 
+Q 353 2572 751 3078 
+Q 1150 3584 1784 3584 
+Q 2172 3584 2448 3432 
+Q 2725 3281 2906 2969 
+z
+M 947 1747 
+Q 947 1113 1208 752 
+Q 1469 391 1925 391 
+Q 2381 391 2643 752 
+Q 2906 1113 2906 1747 
+Q 2906 2381 2643 2742 
+Q 2381 3103 1925 3103 
+Q 1469 3103 1208 2742 
+Q 947 2381 947 1747 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-58" d="M 544 1381 
+L 544 3500 
+L 1119 3500 
+L 1119 1403 
+Q 1119 906 1312 657 
+Q 1506 409 1894 409 
+Q 2359 409 2629 706 
+Q 2900 1003 2900 1516 
+L 2900 3500 
+L 3475 3500 
+L 3475 0 
+L 2900 0 
+L 2900 538 
+Q 2691 219 2414 64 
+Q 2138 -91 1772 -91 
+Q 1169 -91 856 284 
+Q 544 659 544 1381 
+z
+M 1991 3584 
+L 1991 3584 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-51" d="M 3513 2113 
+L 3513 0 
+L 2938 0 
+L 2938 2094 
+Q 2938 2591 2744 2837 
+Q 2550 3084 2163 3084 
+Q 1697 3084 1428 2787 
+Q 1159 2491 1159 1978 
+L 1159 0 
+L 581 0 
+L 581 3500 
+L 1159 3500 
+L 1159 2956 
+Q 1366 3272 1645 3428 
+Q 1925 3584 2291 3584 
+Q 2894 3584 3203 3211 
+Q 3513 2838 3513 2113 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-57" d="M 1172 4494 
+L 1172 3500 
+L 2356 3500 
+L 2356 3053 
+L 1172 3053 
+L 1172 1153 
+Q 1172 725 1289 603 
+Q 1406 481 1766 481 
+L 2356 481 
+L 2356 0 
+L 1766 0 
+Q 1100 0 847 248 
+Q 594 497 594 1153 
+L 594 3053 
+L 172 3053 
+L 172 3500 
+L 594 3500 
+L 594 4494 
+L 1172 4494 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-56" d="M 2834 3397 
+L 2834 2853 
+Q 2591 2978 2328 3040 
+Q 2066 3103 1784 3103 
+Q 1356 3103 1142 2972 
+Q 928 2841 928 2578 
+Q 928 2378 1081 2264 
+Q 1234 2150 1697 2047 
+L 1894 2003 
+Q 2506 1872 2764 1633 
+Q 3022 1394 3022 966 
+Q 3022 478 2636 193 
+Q 2250 -91 1575 -91 
+Q 1294 -91 989 -36 
+Q 684 19 347 128 
+L 347 722 
+Q 666 556 975 473 
+Q 1284 391 1588 391 
+Q 1994 391 2212 530 
+Q 2431 669 2431 922 
+Q 2431 1156 2273 1281 
+Q 2116 1406 1581 1522 
+L 1381 1569 
+Q 847 1681 609 1914 
+Q 372 2147 372 2553 
+Q 372 3047 722 3315 
+Q 1072 3584 1716 3584 
+Q 2034 3584 2315 3537 
+Q 2597 3491 2834 3397 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-c" d="M 513 4856 
+L 1013 4856 
+Q 1481 4119 1714 3412 
+Q 1947 2706 1947 2009 
+Q 1947 1309 1714 600 
+Q 1481 -109 1013 -844 
+L 513 -844 
+Q 928 -128 1133 580 
+Q 1338 1288 1338 2009 
+Q 1338 2731 1133 3434 
+Q 928 4138 513 4856 
+z
+" transform="scale(0.015625)"/>
+      </defs>
+      <use xlink:href="#DejaVuSans-5b"/>
+      <use xlink:href="#DejaVuSans-3" transform="translate(59.1875 0)"/>
+      <use xlink:href="#DejaVuSans-b" transform="translate(90.96875 0)"/>
+      <use xlink:href="#DejaVuSans-4a" transform="translate(129.984375 0)"/>
+      <use xlink:href="#DejaVuSans-55" transform="translate(193.46875 0)"/>
+      <use xlink:href="#DejaVuSans-4c" transform="translate(234.578125 0)"/>
+      <use xlink:href="#DejaVuSans-47" transform="translate(262.359375 0)"/>
+      <use xlink:href="#DejaVuSans-3" transform="translate(325.84375 0)"/>
+      <use xlink:href="#DejaVuSans-58" transform="translate(357.625 0)"/>
+      <use xlink:href="#DejaVuSans-51" transform="translate(421 0)"/>
+      <use xlink:href="#DejaVuSans-4c" transform="translate(484.375 0)"/>
+      <use xlink:href="#DejaVuSans-57" transform="translate(512.15625 0)"/>
+      <use xlink:href="#DejaVuSans-56" transform="translate(551.359375 0)"/>
+      <use xlink:href="#DejaVuSans-c" transform="translate(603.453125 0)"/>
+     </g>
+    </g>
+   </g>
+   <g id="matplotlib.axis_2">
+    <g id="ytick_1">
+     <g id="line2d_8">
+      <defs>
+       <path id="m243e268fb4" d="M 0 0 
+L -3.5 0 
+" style="stroke: #000000; stroke-width: 0.8"/>
+      </defs>
+      <g>
+       <use xlink:href="#m243e268fb4" x="61.416909" y="253.910618" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_9">
+      <!-- 0 -->
+      <g transform="translate(49.326909 256.94968) scale(0.08 -0.08)">
+       <use xlink:href="#DejaVuSans-13"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_2">
+     <g id="line2d_9">
+      <g>
+       <use xlink:href="#m243e268fb4" x="61.416909" y="221.16322" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_10">
+      <!-- 20 -->
+      <g transform="translate(44.236909 224.202283) scale(0.08 -0.08)">
+       <use xlink:href="#DejaVuSans-15"/>
+       <use xlink:href="#DejaVuSans-13" transform="translate(63.625 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_3">
+     <g id="line2d_10">
+      <g>
+       <use xlink:href="#m243e268fb4" x="61.416909" y="188.415823" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_11">
+      <!-- 40 -->
+      <g transform="translate(44.236909 191.454885) scale(0.08 -0.08)">
+       <use xlink:href="#DejaVuSans-17"/>
+       <use xlink:href="#DejaVuSans-13" transform="translate(63.625 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_4">
+     <g id="line2d_11">
+      <g>
+       <use xlink:href="#m243e268fb4" x="61.416909" y="155.668425" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_12">
+      <!-- 60 -->
+      <g transform="translate(44.236909 158.707487) scale(0.08 -0.08)">
+       <use xlink:href="#DejaVuSans-19"/>
+       <use xlink:href="#DejaVuSans-13" transform="translate(63.625 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_5">
+     <g id="line2d_12">
+      <g>
+       <use xlink:href="#m243e268fb4" x="61.416909" y="122.921027" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_13">
+      <!-- 80 -->
+      <g transform="translate(44.236909 125.96009) scale(0.08 -0.08)">
+       <use xlink:href="#DejaVuSans-1b"/>
+       <use xlink:href="#DejaVuSans-13" transform="translate(63.625 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_6">
+     <g id="line2d_13">
+      <g>
+       <use xlink:href="#m243e268fb4" x="61.416909" y="90.173629" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_14">
+      <!-- 100 -->
+      <g transform="translate(39.146909 93.212692) scale(0.08 -0.08)">
+       <use xlink:href="#DejaVuSans-14"/>
+       <use xlink:href="#DejaVuSans-13" transform="translate(63.625 0)"/>
+       <use xlink:href="#DejaVuSans-13" transform="translate(127.25 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_7">
+     <g id="line2d_14">
+      <g>
+       <use xlink:href="#m243e268fb4" x="61.416909" y="57.426232" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_15">
+      <!-- 120 -->
+      <g transform="translate(39.146909 60.465294) scale(0.08 -0.08)">
+       <use xlink:href="#DejaVuSans-14"/>
+       <use xlink:href="#DejaVuSans-15" transform="translate(63.625 0)"/>
+       <use xlink:href="#DejaVuSans-13" transform="translate(127.25 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="text_16">
+     <!-- y (grid units) -->
+     <g transform="translate(32.9848 178.030039) rotate(-90) scale(0.09 -0.09)">
+      <defs>
+       <path id="DejaVuSans-5c" d="M 2059 -325 
+Q 1816 -950 1584 -1140 
+Q 1353 -1331 966 -1331 
+L 506 -1331 
+L 506 -850 
+L 844 -850 
+Q 1081 -850 1212 -737 
+Q 1344 -625 1503 -206 
+L 1606 56 
+L 191 3500 
+L 800 3500 
+L 1894 763 
+L 2988 3500 
+L 3597 3500 
+L 2059 -325 
+z
+" transform="scale(0.015625)"/>
+      </defs>
+      <use xlink:href="#DejaVuSans-5c"/>
+      <use xlink:href="#DejaVuSans-3" transform="translate(59.1875 0)"/>
+      <use xlink:href="#DejaVuSans-b" transform="translate(90.96875 0)"/>
+      <use xlink:href="#DejaVuSans-4a" transform="translate(129.984375 0)"/>
+      <use xlink:href="#DejaVuSans-55" transform="translate(193.46875 0)"/>
+      <use xlink:href="#DejaVuSans-4c" transform="translate(234.578125 0)"/>
+      <use xlink:href="#DejaVuSans-47" transform="translate(262.359375 0)"/>
+      <use xlink:href="#DejaVuSans-3" transform="translate(325.84375 0)"/>
+      <use xlink:href="#DejaVuSans-58" transform="translate(357.625 0)"/>
+      <use xlink:href="#DejaVuSans-51" transform="translate(421 0)"/>
+      <use xlink:href="#DejaVuSans-4c" transform="translate(484.375 0)"/>
+      <use xlink:href="#DejaVuSans-57" transform="translate(512.15625 0)"/>
+      <use xlink:href="#DejaVuSans-56" transform="translate(551.359375 0)"/>
+      <use xlink:href="#DejaVuSans-c" transform="translate(603.453125 0)"/>
+     </g>
+    </g>
+   </g>
+   <g id="patch_3">
+    <path d="M 61.416909 253.910618 
+L 61.416909 44.327273 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_4">
+    <path d="M 61.416909 253.910618 
+L 271.000255 253.910618 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="text_17">
+    <!-- isotropic ($\epsilon_a=0$) -->
+    <g transform="translate(61.416909 38.327273) scale(0.105 -0.105)">
+     <defs>
+      <path id="DejaVuSans-52" d="M 1959 3097 
+Q 1497 3097 1228 2736 
+Q 959 2375 959 1747 
+Q 959 1119 1226 758 
+Q 1494 397 1959 397 
+Q 2419 397 2687 759 
+Q 2956 1122 2956 1747 
+Q 2956 2369 2687 2733 
+Q 2419 3097 1959 3097 
+z
+M 1959 3584 
+Q 2709 3584 3137 3096 
+Q 3566 2609 3566 1747 
+Q 3566 888 3137 398 
+Q 2709 -91 1959 -91 
+Q 1206 -91 779 398 
+Q 353 888 353 1747 
+Q 353 2609 779 3096 
+Q 1206 3584 1959 3584 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-53" d="M 1159 525 
+L 1159 -1331 
+L 581 -1331 
+L 581 3500 
+L 1159 3500 
+L 1159 2969 
+Q 1341 3281 1617 3432 
+Q 1894 3584 2278 3584 
+Q 2916 3584 3314 3078 
+Q 3713 2572 3713 1747 
+Q 3713 922 3314 415 
+Q 2916 -91 2278 -91 
+Q 1894 -91 1617 61 
+Q 1341 213 1159 525 
+z
+M 3116 1747 
+Q 3116 2381 2855 2742 
+Q 2594 3103 2138 3103 
+Q 1681 3103 1420 2742 
+Q 1159 2381 1159 1747 
+Q 1159 1113 1420 752 
+Q 1681 391 2138 391 
+Q 2594 391 2855 752 
+Q 3116 1113 3116 1747 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-46" d="M 3122 3366 
+L 3122 2828 
+Q 2878 2963 2633 3030 
+Q 2388 3097 2138 3097 
+Q 1578 3097 1268 2742 
+Q 959 2388 959 1747 
+Q 959 1106 1268 751 
+Q 1578 397 2138 397 
+Q 2388 397 2633 464 
+Q 2878 531 3122 666 
+L 3122 134 
+Q 2881 22 2623 -34 
+Q 2366 -91 2075 -91 
+Q 1284 -91 818 406 
+Q 353 903 353 1747 
+Q 353 2603 823 3093 
+Q 1294 3584 2113 3584 
+Q 2378 3584 2631 3529 
+Q 2884 3475 3122 3366 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Oblique-349" d="M 1263 1888 
+Q 925 1963 778 2166 
+Q 669 2309 669 2503 
+Q 669 3034 1175 3344 
+Q 1575 3588 2188 3588 
+Q 2425 3588 2684 3550 
+Q 2944 3513 3234 3438 
+L 3134 2916 
+Q 2847 3006 2606 3047 
+Q 2359 3088 2138 3088 
+Q 1766 3088 1522 2944 
+Q 1228 2772 1228 2522 
+Q 1228 2356 1381 2241 
+Q 1563 2103 1925 2103 
+L 2409 2103 
+L 2319 1628 
+L 1856 1628 
+Q 1425 1628 1172 1469 
+Q 828 1253 828 916 
+Q 828 703 1013 563 
+Q 1244 388 1716 388 
+Q 2006 388 2284 444 
+Q 2563 503 2806 619 
+L 2700 84 
+Q 2403 -3 2131 -47 
+Q 1859 -91 1609 -91 
+Q 866 -91 516 194 
+Q 250 413 250 781 
+Q 250 1278 600 1584 
+Q 859 1813 1263 1888 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Oblique-44" d="M 3438 1997 
+L 3047 0 
+L 2472 0 
+L 2578 531 
+Q 2325 219 2001 64 
+Q 1678 -91 1281 -91 
+Q 834 -91 548 182 
+Q 263 456 263 884 
+Q 263 1497 752 1853 
+Q 1241 2209 2100 2209 
+L 2900 2209 
+L 2931 2363 
+Q 2938 2388 2941 2417 
+Q 2944 2447 2944 2509 
+Q 2944 2788 2717 2942 
+Q 2491 3097 2081 3097 
+Q 1800 3097 1504 3025 
+Q 1209 2953 897 2809 
+L 997 3341 
+Q 1322 3463 1633 3523 
+Q 1944 3584 2234 3584 
+Q 2853 3584 3176 3315 
+Q 3500 3047 3500 2534 
+Q 3500 2431 3484 2292 
+Q 3469 2153 3438 1997 
+z
+M 2816 1759 
+L 2241 1759 
+Q 1534 1759 1195 1570 
+Q 856 1381 856 984 
+Q 856 709 1029 553 
+Q 1203 397 1509 397 
+Q 1978 397 2328 733 
+Q 2678 1069 2791 1631 
+L 2816 1759 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-20" d="M 678 2906 
+L 4684 2906 
+L 4684 2381 
+L 678 2381 
+L 678 2906 
+z
+M 678 1631 
+L 4684 1631 
+L 4684 1100 
+L 678 1100 
+L 678 1631 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-4c" transform="translate(0 0.015625)"/>
+     <use xlink:href="#DejaVuSans-56" transform="translate(27.783203 0.015625)"/>
+     <use xlink:href="#DejaVuSans-52" transform="translate(79.882812 0.015625)"/>
+     <use xlink:href="#DejaVuSans-57" transform="translate(141.064453 0.015625)"/>
+     <use xlink:href="#DejaVuSans-55" transform="translate(180.273438 0.015625)"/>
+     <use xlink:href="#DejaVuSans-52" transform="translate(219.386719 0.015625)"/>
+     <use xlink:href="#DejaVuSans-53" transform="translate(280.568359 0.015625)"/>
+     <use xlink:href="#DejaVuSans-4c" transform="translate(344.044922 0.015625)"/>
+     <use xlink:href="#DejaVuSans-46" transform="translate(371.828125 0.015625)"/>
+     <use xlink:href="#DejaVuSans-3" transform="translate(426.808594 0.015625)"/>
+     <use xlink:href="#DejaVuSans-b" transform="translate(458.595703 0.015625)"/>
+     <use xlink:href="#DejaVuSans-Oblique-349" transform="translate(497.609375 0.015625)"/>
+     <use xlink:href="#DejaVuSans-Oblique-44" transform="translate(551.662109 -14.984326) scale(0.7)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(616.774414 0.015625)"/>
+     <use xlink:href="#DejaVuSans-13" transform="translate(720.045898 0.015625)"/>
+     <use xlink:href="#DejaVuSans-c" transform="translate(783.668945 0.015625)"/>
+    </g>
+   </g>
+  </g>
+  <g id="axes_2">
+   <g id="patch_5">
+    <path d="M 311.825855 253.910618 
+L 521.4092 253.910618 
+L 521.4092 44.327273 
+L 311.825855 44.327273 
+z
+" style="fill: #ffffff"/>
+   </g>
+   <g clip-path="url(#p68d571bf38)">
+    <image xlink:href="data:image/png;base64,
+iVBORw0KGgoAAAANSUhEUgAAASMAAAEjCAYAAAB5IGctAAAOu0lEQVR4nO3dy44dZxWG4WXkxEpiTEgAKQKFTDgKwQgEV8ANcAdcB3fGHAQTiBDHCYlAkYAcCIYoB2IG7W5Xdlb/VMrVu7/99/OOgt18WvvrVmnZWn7r1q9+9MMHVVXPvPBsnfPCD75VVVV3vvm9qqq6de/5qqp68PbrF1/z7m9/UVVVr/3sN1VV9e/X3rr4vfOsy3KWWVtyupkOc5ZZW3K6mQ5zus+2piNd79v1mpxupr2/Z91Mul7f9acKAAK4/dw3vlRVVc+88Ojp/sSXv15VVQ8+/1JVVf33qc9UVdWn7nx68TVvV1XVc2/9q6qq7jx79+L3zrMuy1lmbcnpZjrMWWZtyelmOszpPtuajnS9b9drcrqZ9v6edTPpus/pPpvNCEAEt95/+acPqqrq3ucufvGDL3y1qqpeefv9qqp6850Pqqrqs0/dvviaL997oqqqbv/tj2e/8PY/HqU+zLosZ5n14sOcJwY57z/MefVhTjfTx+ZZZm3IaT/bQc4y6xN1tOj6cKatXV+Ws8yates1Od1MXdeXdrQiZ5mV1vWLi44u+2xrul6T0820pmubEYAIPIwARHDr7/+8/6Cq6v77H1784h/+8Z+qqvr5q29VVdVf3zj731987umLr/n+i89WVdXXPnf2a3efePRcO8+6LGeZtSWnm+kwZ5m1Jaeb6TCn+2xrOtL1vl2vyelm2vt71s2k6z6n+2w2IwAR3P7bf87+Ymn5l3B/ev3sKfbyw6fa3998p6qqXr//3sXXPP/Mk1VVdffJs7+QWv7F1HnWZTnLrC053UyHOcusLTndTIc53Wdb05Gu9+16TU43097fs24mXfc53WezGQGI4PYXnj57Kj29/DPte2d/hnv94Z/p/nr37Am2/PPeV54/++8v3nv4dFv8/8+zLstZZm3J6WY6zFlmbcnpZjrM6T7bmo50vW/Xa3K6mfb+nnUz6brP6T6bzQhABB5GACJoL7DTroIPL7m7mdIuVduZmkvVva7d07r+JDntZzvIWWZtvcBe0/WaC+y0f1mwpus1P9drul57gb2la5sRgAhuvfqTHz/0GT36F7d3v/Pds9986dtVVfXh+b+4feefF1/z4M8vV1XV/V//sqqq/v3aI0/JedZlOcusLTndTIc5y6wtOd1MhzndZ1vTka737XpNTjfT3t+zbiZdr+/aZgQggttv/O4vVVX17lv3L37xzrNnzpE7z9w7+6LG0vbeK7+vqqo3fvdKVX3UZHeedVnOMmtLTjfTYc4ya0tON9NhTvfZ1nSk6327XpPTzbT396ybSdfru7YZAYiA6ZHpcZjTzZTWNdPjHF3bjABE4GEEIIIrPXpccxy25aCvmylNhVr1eAd0p66dPeYh3rG1s8c8evxYTjPTXl3TzgJAMT0yPf6fnG6mtK6ZHufo2mYEIAKmR6bHYU43U1rXTI9zdG0zAhAB0yPT4zCnmymta6bHObq2GQGIwMMIQASbjx63WAOv8uhxzXFYounxmAemaVbNY5se9zp6POaBadrPNdMjgOlhemR6HOZ0M6V1zfQ4R9c2IwARMD0yPQ5zupnSumZ6nKNrmxGACDyMAERAO0s7O8zpZkrrmnZ2jq5tRgAiaI8e97IPppke93rlcuLrrffqeubXW5/i0eMxrZqOHgGgmB6ZHv9PTjdTWtdMj3N0bTMCEAHTI9PjMKebKa1rpsc5urYZAYjAwwhABLSztLPDnG6mtK5pZ+fo2mYEIIJrP3o85nFYoulxy3HY1tdbH9Oq6ejxZpsevd4awMnC9Mj0OMzpZkrrmulxjq5tRgAiYHpkehzmdDOldc30OEfXNiMAEXgYAYiA6ZHpcZjTzZTWNdPjHF3bjABEcO1Hj8c0Pe71yuVE0+Mxjx6ZHk+v672OHq+ya5sRgAiYHpkehzndTGldMz3O0bXNCEAEHkYAIqCdpZ0d5nQzpXVNOztH1zYjABEwPTI9DnO6mdK6Znqco2ubEYAIrv3okelxzq5v+tFjWtdebw0AK2F6ZHoc5nQzpXXN9DhH1zYjABF4GAGIgHaWdnaY082U1jXt7Bxd24wARMD0yPQ4zOlmSuua6XGOrm1GACJojx4f6zhskZV2iHds0+PjHNDpOsM+eN1Hj15vDQBHhumR6XGY082U1jXT4xxd24wAROBhBCACpkemx2FON1Na10yPc3RtMwIQAdMj0+Mwp5sprWumxzm6thkBiGDz0eMp2gdP9fXWWzqapetE0+Mxf67XHD0yPQLAjngYAYiAdpZ2dpjTzZTWNe3sHF3bjABEwPTI9DjM6WZK65rpcY6ubUYAImB6ZHoc5nQzpXXN9DhH1zYjABHcqKPHvV65vKfpca/XW+919PhJOnL06Oixy+lmcvQI4GTwMAIQAe0s7ewwp5sprWva2Tm6thkBiIDpkelxmNPNlNY10+McXduMAETA9Mj0OMzpZkrrmulxjq5tRgAiuNLXW9/k1wAPP5uuq+p0jx7Tuk48evR6awAni4cRgAiYHpkehzndTGldMz3O0bXNCEAETI9Mj8Ocbqa0rpke5+jaZgQgAqZHpsdhTjdTWtdMj3N0bTMCEIGHEYAIbpR2dq+r4LUX2Jd2RDv7kZz2swVfYKf9XCdeYNPOAjhZmB6ZHoc53UxpXTM9ztG1zQhABEyPTI/DnG6mtK6ZHufo2mYEIAKmR6bHYU43U1rXTI9zdG0zAhCBhxGACNqjx70O8dKOw46tnT3m0eNeXe919PhJctrP5uixz2lmcvQIADvC9Mj0OMzpZkrrmulxjq5tRgAiYHpkehzmdDOldc30OEfXNiMAEXgYAYiAdpZ2dpjTzZTWNe3sHF3bjABEcKNMj3sd4iUePa4xPW75nnUz3fSjx72smqdoelzbtaNHACcL0yPT4zCnmymta6bHObq2GQGIgOmR6XGY082U1jXT4xxd24wAROBhBCAC2lna2WFON1Na17Szc3RtMwIQwbWbHrcc9HUzpb1yefjZHD1+JKedydHjRz7bqR09bunaZgQgAqZHpsdhTjdTWtdMj3N0bTMCEAHTI9PjMKebKa1rpsc5urYZAYjAwwhABEyPTI/DnG6mtK6ZHufo2mYEIIJrP3r0euvjHT2mHeKd6tGj11uPc7qZHD0COBmYHpkehzndTGldMz3O0bXNCEAEHkYAIqCdpZ0d5nQzpXVNOztH1zYjABEwPTI9DnO6mdK6Znqco2ubEYAINr/eestR13Ufhx376PFxrIE3oeu9XiW+9hDvFE2PaT/XV9m1zQhABEyPTI/DnG6mtK6ZHufo2mYEIAIPIwAR0M7Szg5zupnSuqadnaNrmxGACJgemR6HOd1MaV0zPc7Rtc0IQATXbnpMe711oulxzQHdXl2nvd76ul+5fN1Hj2mvt2Z6BDA9TI9Mj8Ocbqa0rpke5+jaZgQgAg8jABEwPTI9DnO6mdK6Znqco2ubEYAImB6ZHoc53UxpXTM9ztG1zQhABEyPTI/DnG6mtAPTmY8e036umR4BTI+HEYAIaGdpZ4c53UxpXdPOztG1zQhABEyPTI/DnG6mtK6ZHufo2mYEIAKmR6bHYU43U1rXTI9zdG0zAhDBjTI9HtM+OPxswV2nmR4/WHR9WUd7Hj0+zvesm2m2n+u1XTM9AjhZPIwAREA7Szs7zOlmSuuadnaOrm1GACJgemR6HOZ0M6V1zfQ4R9c2IwARMD0yPQ5zupnSumZ6nKNrmxGACDYfPbIPVvvZko8e01657PXWp/dzzfQIYHo8jABEwPTI9DjM6WZK65rpcY6ubUYAImB6ZHoc5nQzpXXN9DhH1zYjABEwPTI9DnO6mdK6Znqco2ubEYAIPIwAREA7Szs7zOlm2usqOFE7e4oX2Gu+Z3tdYNPOApgepkemx2FON1Na10yPc3RtMwIQAdMj0+Mwp5sprWumxzm6thkBiIDpkelxmNPNlNY10+McXduMAETgYQQggms/ekzTc8589Jh2iJd49Pg437NlVlrXa44e9+za0SOAk4XpkelxmNPNlNY10+McXduMAETA9Mj0OMzpZkrrmulxjq5tRgAiYHpkehzmdDOldc30OEfXNiMAEXgYAYjgRh09HvMQr53pBpkeT/XocY3p8RR/rvcyPa7J6WZy9AjgZGB6ZHoc5nQzpXXN9DhH1zYjABEwPTI9DnO6mdK6Znqco2ubEYAIPIwAREA7Szs7zOlmSuuadnaOrm1GACJojx4fy4i3yEo7DluTs9dxWDvTFR49nuIrl0/16PGYXX8sp5nJ0SMA7AjTI9PjMKebKa1rpsc5urYZAYiA6ZHpcZjTzZTWNdPjHF3bjABE4GEEIALaWdrZYU43U1rXtLNzdG0zAhCBo8dJXm+91yEe02PW0SPTIwAcGaZHpsdhTjdTWtdMj3N0bTMCEAHTI9PjMKebKa1rpsc5urYZAYjAwwhABEyPTI/DnG6mtK6ZHufo2mYEIIIrfb31muOwLTndTI4e9+na0aPXWy9n2tq1o0cAJwvTI9PjMKebKa1rpsc5urYZAYjAwwhABLSztLPDnG6mtK5pZ+fo2mYEIAKmR6bHYU43U1rXTI9zdG0zAhDBlR49rjkOO+bR416HeIlHj3t17ehxn6PHWX+uHT0CmB6mR6bHYU43U1rXTI9zdG0zAhCBhxGACGhnaWeHOd1MaV3Tzs7Rtc0IQARMj0yPw5xuprSumR7n6NpmBCCCza+33vKq5Os24q3J2cuI1850Aq+3TrNqJh49HrPrj+U0MyWaHrd0bTMCEIGHEYAIaGdpZ4c53UxpXdPOztG1zQhABEyPTI/DnG6mtK6ZHufo2mYEIAKmR6bHYU43U1rXTI9zdG0zAhAB0+MVHeINP1tw10yPc5oevd4aAFbiYQQgAtpZ2tlhTjdTWte0s3N0bTMCEAHTI9PjMKebKa1rpsc5urYZAYiA6ZHpcZjTzZTWNdPjHF3bjABEcKVHj3sZ8U7xEK+d6ZqPHmftOvHo8ZhWTUePALAjHkYAImB6ZHoc5nQzpXXN9DhH1zYjABH8D/61+DBibT17AAAAAElFTkSuQmCC" id="image4b0157f63b" transform="scale(1 -1) translate(0 -209.52)" x="311.76" y="-44.311321" width="209.52" height="209.52"/>
+   </g>
+   <g id="matplotlib.axis_3">
+    <g id="xtick_8">
+     <g id="line2d_15">
+      <g>
+       <use xlink:href="#md7568791be" x="311.825855" y="253.910618" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_18">
+      <!-- 0 -->
+      <g transform="translate(309.280855 266.988743) scale(0.08 -0.08)">
+       <use xlink:href="#DejaVuSans-13"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_9">
+     <g id="line2d_16">
+      <g>
+       <use xlink:href="#md7568791be" x="344.573252" y="253.910618" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_19">
+      <!-- 20 -->
+      <g transform="translate(339.483252 266.988743) scale(0.08 -0.08)">
+       <use xlink:href="#DejaVuSans-15"/>
+       <use xlink:href="#DejaVuSans-13" transform="translate(63.625 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_10">
+     <g id="line2d_17">
+      <g>
+       <use xlink:href="#md7568791be" x="377.32065" y="253.910618" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_20">
+      <!-- 40 -->
+      <g transform="translate(372.23065 266.988743) scale(0.08 -0.08)">
+       <use xlink:href="#DejaVuSans-17"/>
+       <use xlink:href="#DejaVuSans-13" transform="translate(63.625 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_11">
+     <g id="line2d_18">
+      <g>
+       <use xlink:href="#md7568791be" x="410.068048" y="253.910618" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_21">
+      <!-- 60 -->
+      <g transform="translate(404.978048 266.988743) scale(0.08 -0.08)">
+       <use xlink:href="#DejaVuSans-19"/>
+       <use xlink:href="#DejaVuSans-13" transform="translate(63.625 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_12">
+     <g id="line2d_19">
+      <g>
+       <use xlink:href="#md7568791be" x="442.815445" y="253.910618" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_22">
+      <!-- 80 -->
+      <g transform="translate(437.725445 266.988743) scale(0.08 -0.08)">
+       <use xlink:href="#DejaVuSans-1b"/>
+       <use xlink:href="#DejaVuSans-13" transform="translate(63.625 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_13">
+     <g id="line2d_20">
+      <g>
+       <use xlink:href="#md7568791be" x="475.562843" y="253.910618" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_23">
+      <!-- 100 -->
+      <g transform="translate(467.927843 266.988743) scale(0.08 -0.08)">
+       <use xlink:href="#DejaVuSans-14"/>
+       <use xlink:href="#DejaVuSans-13" transform="translate(63.625 0)"/>
+       <use xlink:href="#DejaVuSans-13" transform="translate(127.25 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_14">
+     <g id="line2d_21">
+      <g>
+       <use xlink:href="#md7568791be" x="508.310241" y="253.910618" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_24">
+      <!-- 120 -->
+      <g transform="translate(500.675241 266.988743) scale(0.08 -0.08)">
+       <use xlink:href="#DejaVuSans-14"/>
+       <use xlink:href="#DejaVuSans-15" transform="translate(63.625 0)"/>
+       <use xlink:href="#DejaVuSans-13" transform="translate(127.25 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="text_25">
+     <!-- x (grid units) -->
+     <g transform="translate(387.706434 279.749212) scale(0.09 -0.09)">
+      <use xlink:href="#DejaVuSans-5b"/>
+      <use xlink:href="#DejaVuSans-3" transform="translate(59.1875 0)"/>
+      <use xlink:href="#DejaVuSans-b" transform="translate(90.96875 0)"/>
+      <use xlink:href="#DejaVuSans-4a" transform="translate(129.984375 0)"/>
+      <use xlink:href="#DejaVuSans-55" transform="translate(193.46875 0)"/>
+      <use xlink:href="#DejaVuSans-4c" transform="translate(234.578125 0)"/>
+      <use xlink:href="#DejaVuSans-47" transform="translate(262.359375 0)"/>
+      <use xlink:href="#DejaVuSans-3" transform="translate(325.84375 0)"/>
+      <use xlink:href="#DejaVuSans-58" transform="translate(357.625 0)"/>
+      <use xlink:href="#DejaVuSans-51" transform="translate(421 0)"/>
+      <use xlink:href="#DejaVuSans-4c" transform="translate(484.375 0)"/>
+      <use xlink:href="#DejaVuSans-57" transform="translate(512.15625 0)"/>
+      <use xlink:href="#DejaVuSans-56" transform="translate(551.359375 0)"/>
+      <use xlink:href="#DejaVuSans-c" transform="translate(603.453125 0)"/>
+     </g>
+    </g>
+   </g>
+   <g id="matplotlib.axis_4">
+    <g id="ytick_8">
+     <g id="line2d_22">
+      <g>
+       <use xlink:href="#m243e268fb4" x="311.825855" y="253.910618" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_9">
+     <g id="line2d_23">
+      <g>
+       <use xlink:href="#m243e268fb4" x="311.825855" y="221.16322" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_10">
+     <g id="line2d_24">
+      <g>
+       <use xlink:href="#m243e268fb4" x="311.825855" y="188.415823" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_11">
+     <g id="line2d_25">
+      <g>
+       <use xlink:href="#m243e268fb4" x="311.825855" y="155.668425" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_12">
+     <g id="line2d_26">
+      <g>
+       <use xlink:href="#m243e268fb4" x="311.825855" y="122.921027" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_13">
+     <g id="line2d_27">
+      <g>
+       <use xlink:href="#m243e268fb4" x="311.825855" y="90.173629" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_14">
+     <g id="line2d_28">
+      <g>
+       <use xlink:href="#m243e268fb4" x="311.825855" y="57.426232" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+    </g>
+   </g>
+   <g id="patch_6">
+    <path d="M 311.825855 253.910618 
+L 311.825855 44.327273 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_7">
+    <path d="M 311.825855 253.910618 
+L 521.4092 253.910618 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="text_26">
+    <!-- anisotropic ($\epsilon_a=0.5$, $m=6$) -->
+    <g transform="translate(311.825855 38.327273) scale(0.105 -0.105)">
+     <defs>
+      <path id="DejaVuSans-44" d="M 2194 1759 
+Q 1497 1759 1228 1600 
+Q 959 1441 959 1056 
+Q 959 750 1161 570 
+Q 1363 391 1709 391 
+Q 2188 391 2477 730 
+Q 2766 1069 2766 1631 
+L 2766 1759 
+L 2194 1759 
+z
+M 3341 1997 
+L 3341 0 
+L 2766 0 
+L 2766 531 
+Q 2569 213 2275 61 
+Q 1981 -91 1556 -91 
+Q 1019 -91 701 211 
+Q 384 513 384 1019 
+Q 384 1609 779 1909 
+Q 1175 2209 1959 2209 
+L 2766 2209 
+L 2766 2266 
+Q 2766 2663 2505 2880 
+Q 2244 3097 1772 3097 
+Q 1472 3097 1187 3025 
+Q 903 2953 641 2809 
+L 641 3341 
+Q 956 3463 1253 3523 
+Q 1550 3584 1831 3584 
+Q 2591 3584 2966 3190 
+Q 3341 2797 3341 1997 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-11" d="M 684 794 
+L 1344 794 
+L 1344 0 
+L 684 0 
+L 684 794 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-18" d="M 691 4666 
+L 3169 4666 
+L 3169 4134 
+L 1269 4134 
+L 1269 2991 
+Q 1406 3038 1543 3061 
+Q 1681 3084 1819 3084 
+Q 2600 3084 3056 2656 
+Q 3513 2228 3513 1497 
+Q 3513 744 3044 326 
+Q 2575 -91 1722 -91 
+Q 1428 -91 1123 -41 
+Q 819 9 494 109 
+L 494 744 
+Q 775 591 1075 516 
+Q 1375 441 1709 441 
+Q 2250 441 2565 725 
+Q 2881 1009 2881 1497 
+Q 2881 1984 2565 2268 
+Q 2250 2553 1709 2553 
+Q 1456 2553 1204 2497 
+Q 953 2441 691 2322 
+L 691 4666 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-f" d="M 750 794 
+L 1409 794 
+L 1409 256 
+L 897 -744 
+L 494 -744 
+L 750 256 
+L 750 794 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Oblique-50" d="M 5747 2113 
+L 5338 0 
+L 4763 0 
+L 5166 2094 
+Q 5191 2228 5203 2325 
+Q 5216 2422 5216 2491 
+Q 5216 2772 5059 2928 
+Q 4903 3084 4622 3084 
+Q 4203 3084 3875 2770 
+Q 3547 2456 3450 1953 
+L 3066 0 
+L 2491 0 
+L 2900 2094 
+Q 2925 2209 2937 2307 
+Q 2950 2406 2950 2484 
+Q 2950 2769 2794 2926 
+Q 2638 3084 2363 3084 
+Q 1938 3084 1609 2770 
+Q 1281 2456 1184 1953 
+L 800 0 
+L 225 0 
+L 909 3500 
+L 1484 3500 
+L 1375 2956 
+Q 1609 3263 1923 3423 
+Q 2238 3584 2597 3584 
+Q 2978 3584 3223 3384 
+Q 3469 3184 3519 2828 
+Q 3781 3197 4126 3390 
+Q 4472 3584 4856 3584 
+Q 5306 3584 5551 3325 
+Q 5797 3066 5797 2591 
+Q 5797 2488 5784 2364 
+Q 5772 2241 5747 2113 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-44" transform="translate(0 0.015625)"/>
+     <use xlink:href="#DejaVuSans-51" transform="translate(61.279297 0.015625)"/>
+     <use xlink:href="#DejaVuSans-4c" transform="translate(124.658203 0.015625)"/>
+     <use xlink:href="#DejaVuSans-56" transform="translate(152.441406 0.015625)"/>
+     <use xlink:href="#DejaVuSans-52" transform="translate(204.541016 0.015625)"/>
+     <use xlink:href="#DejaVuSans-57" transform="translate(265.722656 0.015625)"/>
+     <use xlink:href="#DejaVuSans-55" transform="translate(304.931641 0.015625)"/>
+     <use xlink:href="#DejaVuSans-52" transform="translate(344.044922 0.015625)"/>
+     <use xlink:href="#DejaVuSans-53" transform="translate(405.226562 0.015625)"/>
+     <use xlink:href="#DejaVuSans-4c" transform="translate(468.703125 0.015625)"/>
+     <use xlink:href="#DejaVuSans-46" transform="translate(496.486328 0.015625)"/>
+     <use xlink:href="#DejaVuSans-3" transform="translate(551.466797 0.015625)"/>
+     <use xlink:href="#DejaVuSans-b" transform="translate(583.253906 0.015625)"/>
+     <use xlink:href="#DejaVuSans-Oblique-349" transform="translate(622.267578 0.015625)"/>
+     <use xlink:href="#DejaVuSans-Oblique-44" transform="translate(676.320312 -14.984326) scale(0.7)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(741.432617 0.015625)"/>
+     <use xlink:href="#DejaVuSans-13" transform="translate(844.704102 0.015625)"/>
+     <use xlink:href="#DejaVuSans-11" transform="translate(908.327148 0.015625)"/>
+     <use xlink:href="#DejaVuSans-18" transform="translate(940.114258 0.015625)"/>
+     <use xlink:href="#DejaVuSans-f" transform="translate(1003.737305 0.015625)"/>
+     <use xlink:href="#DejaVuSans-3" transform="translate(1035.524414 0.015625)"/>
+     <use xlink:href="#DejaVuSans-Oblique-50" transform="translate(1067.311523 0.015625)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(1184.206055 0.015625)"/>
+     <use xlink:href="#DejaVuSans-19" transform="translate(1287.477539 0.015625)"/>
+     <use xlink:href="#DejaVuSans-c" transform="translate(1351.100586 0.015625)"/>
+    </g>
+   </g>
+  </g>
+  <g id="axes_3">
+   <g id="patch_8">
+    <path d="M 551.52 246.24 
+L 563.616 246.24 
+L 563.616 44.64 
+L 551.52 44.64 
+z
+" style="fill: #ffffff"/>
+   </g>
+   <image xlink:href="data:image/png;base64,
+iVBORw0KGgoAAAANSUhEUgAAABEAAAEYCAYAAAC6FR2GAAABq0lEQVR4nO2awQ3DMAzEHDvdpyt1/xki99/mJwYgBHUA4nQ6ybHR4/X+7JH8ncdcWUY9yAIg01MOA5kOJXkZw2UsETZPOeViL4GYYl8rsVDsD0IJATkAiKgcAMLMziSM1XhCtTjN6MTeQTRho84dTYsZY9MMVWJrDeDSxJ5QUg1yapRAEOBebCpHMzvEUtJ4Ui/2DXkC0ufOHQT5PkH2SZ4BfSnV8gS6oWtuXkxONCdge3KnJM1gplj0urWQezETNk3sNZ4AjHHOoVGiOXfa2BsleYYr9gCEeWerFnsAojGWij0AKeeJZBVAs7PTf90a59hBKAEgiJLRnpghkYdQs6PxpBMrhjCeaGLfYXsKElcesoGcMEqYci5EiWZ2mBZLPKGUaMphwmaBaFaBanYknhRbj6LNhrR4X5Yjg1Di8YSBBBH7Yp4g5YSlnJ6dpyAhKqen+BdCDCA0OyJjgQcHZrMFogSAmIyVlMPEPogWixLLdEdTTg/gH4QoR3RkQN2xtNhTThDv9hcDSTNESpjZ0ZSjUoJAPOVUUkLFHoEQ6zEvpFqLW8lDSpDZ+QKw6E3CtpFWcAAAAABJRU5ErkJggg==" id="imageecaac8c743" transform="scale(1 -1) translate(0 -201.6)" x="551.52" y="-43.92" width="12.24" height="201.6"/>
+   <g id="matplotlib.axis_5"/>
+   <g id="matplotlib.axis_6">
+    <g id="ytick_15">
+     <g id="line2d_29">
+      <defs>
+       <path id="m0163c6370c" d="M 0 0 
+L 3.5 0 
+" style="stroke: #000000; stroke-width: 0.8"/>
+      </defs>
+      <g>
+       <use xlink:href="#m0163c6370c" x="563.616" y="230.070661" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_27">
+      <!-- −0.004 -->
+      <g transform="translate(570.616 233.109724) scale(0.08 -0.08)">
+       <defs>
+        <path id="DejaVuSans-c9c" d="M 678 2272 
+L 4684 2272 
+L 4684 1741 
+L 678 1741 
+L 678 2272 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-c9c"/>
+       <use xlink:href="#DejaVuSans-13" transform="translate(83.796875 0)"/>
+       <use xlink:href="#DejaVuSans-11" transform="translate(147.421875 0)"/>
+       <use xlink:href="#DejaVuSans-13" transform="translate(179.203125 0)"/>
+       <use xlink:href="#DejaVuSans-13" transform="translate(242.828125 0)"/>
+       <use xlink:href="#DejaVuSans-17" transform="translate(306.453125 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_16">
+     <g id="line2d_30">
+      <g>
+       <use xlink:href="#m0163c6370c" x="563.616" y="187.755331" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_28">
+      <!-- −0.002 -->
+      <g transform="translate(570.616 190.794393) scale(0.08 -0.08)">
+       <use xlink:href="#DejaVuSans-c9c"/>
+       <use xlink:href="#DejaVuSans-13" transform="translate(83.796875 0)"/>
+       <use xlink:href="#DejaVuSans-11" transform="translate(147.421875 0)"/>
+       <use xlink:href="#DejaVuSans-13" transform="translate(179.203125 0)"/>
+       <use xlink:href="#DejaVuSans-13" transform="translate(242.828125 0)"/>
+       <use xlink:href="#DejaVuSans-15" transform="translate(306.453125 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_17">
+     <g id="line2d_31">
+      <g>
+       <use xlink:href="#m0163c6370c" x="563.616" y="145.44" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_29">
+      <!-- 0.000 -->
+      <g transform="translate(570.616 148.479062) scale(0.08 -0.08)">
+       <use xlink:href="#DejaVuSans-13"/>
+       <use xlink:href="#DejaVuSans-11" transform="translate(63.625 0)"/>
+       <use xlink:href="#DejaVuSans-13" transform="translate(95.40625 0)"/>
+       <use xlink:href="#DejaVuSans-13" transform="translate(159.03125 0)"/>
+       <use xlink:href="#DejaVuSans-13" transform="translate(222.65625 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_18">
+     <g id="line2d_32">
+      <g>
+       <use xlink:href="#m0163c6370c" x="563.616" y="103.124669" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_30">
+      <!-- 0.002 -->
+      <g transform="translate(570.616 106.163732) scale(0.08 -0.08)">
+       <use xlink:href="#DejaVuSans-13"/>
+       <use xlink:href="#DejaVuSans-11" transform="translate(63.625 0)"/>
+       <use xlink:href="#DejaVuSans-13" transform="translate(95.40625 0)"/>
+       <use xlink:href="#DejaVuSans-13" transform="translate(159.03125 0)"/>
+       <use xlink:href="#DejaVuSans-15" transform="translate(222.65625 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_19">
+     <g id="line2d_33">
+      <g>
+       <use xlink:href="#m0163c6370c" x="563.616" y="60.809339" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_31">
+      <!-- 0.004 -->
+      <g transform="translate(570.616 63.848401) scale(0.08 -0.08)">
+       <use xlink:href="#DejaVuSans-13"/>
+       <use xlink:href="#DejaVuSans-11" transform="translate(63.625 0)"/>
+       <use xlink:href="#DejaVuSans-13" transform="translate(95.40625 0)"/>
+       <use xlink:href="#DejaVuSans-13" transform="translate(159.03125 0)"/>
+       <use xlink:href="#DejaVuSans-17" transform="translate(222.65625 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="text_32">
+     <!-- surface height h -->
+     <g transform="translate(611.060844 182.126953) rotate(-90) scale(0.09 -0.09)">
+      <defs>
+       <path id="DejaVuSans-49" d="M 2375 4863 
+L 2375 4384 
+L 1825 4384 
+Q 1516 4384 1395 4259 
+Q 1275 4134 1275 3809 
+L 1275 3500 
+L 2222 3500 
+L 2222 3053 
+L 1275 3053 
+L 1275 0 
+L 697 0 
+L 697 3053 
+L 147 3053 
+L 147 3500 
+L 697 3500 
+L 697 3744 
+Q 697 4328 969 4595 
+Q 1241 4863 1831 4863 
+L 2375 4863 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-48" d="M 3597 1894 
+L 3597 1613 
+L 953 1613 
+Q 991 1019 1311 708 
+Q 1631 397 2203 397 
+Q 2534 397 2845 478 
+Q 3156 559 3463 722 
+L 3463 178 
+Q 3153 47 2828 -22 
+Q 2503 -91 2169 -91 
+Q 1331 -91 842 396 
+Q 353 884 353 1716 
+Q 353 2575 817 3079 
+Q 1281 3584 2069 3584 
+Q 2775 3584 3186 3129 
+Q 3597 2675 3597 1894 
+z
+M 3022 2063 
+Q 3016 2534 2758 2815 
+Q 2500 3097 2075 3097 
+Q 1594 3097 1305 2825 
+Q 1016 2553 972 2059 
+L 3022 2063 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-4b" d="M 3513 2113 
+L 3513 0 
+L 2938 0 
+L 2938 2094 
+Q 2938 2591 2744 2837 
+Q 2550 3084 2163 3084 
+Q 1697 3084 1428 2787 
+Q 1159 2491 1159 1978 
+L 1159 0 
+L 581 0 
+L 581 4863 
+L 1159 4863 
+L 1159 2956 
+Q 1366 3272 1645 3428 
+Q 1925 3584 2291 3584 
+Q 2894 3584 3203 3211 
+Q 3513 2838 3513 2113 
+z
+" transform="scale(0.015625)"/>
+      </defs>
+      <use xlink:href="#DejaVuSans-56"/>
+      <use xlink:href="#DejaVuSans-58" transform="translate(52.09375 0)"/>
+      <use xlink:href="#DejaVuSans-55" transform="translate(115.46875 0)"/>
+      <use xlink:href="#DejaVuSans-49" transform="translate(156.578125 0)"/>
+      <use xlink:href="#DejaVuSans-44" transform="translate(191.78125 0)"/>
+      <use xlink:href="#DejaVuSans-46" transform="translate(253.0625 0)"/>
+      <use xlink:href="#DejaVuSans-48" transform="translate(308.046875 0)"/>
+      <use xlink:href="#DejaVuSans-3" transform="translate(369.578125 0)"/>
+      <use xlink:href="#DejaVuSans-4b" transform="translate(401.359375 0)"/>
+      <use xlink:href="#DejaVuSans-48" transform="translate(464.734375 0)"/>
+      <use xlink:href="#DejaVuSans-4c" transform="translate(526.265625 0)"/>
+      <use xlink:href="#DejaVuSans-4a" transform="translate(554.046875 0)"/>
+      <use xlink:href="#DejaVuSans-4b" transform="translate(617.53125 0)"/>
+      <use xlink:href="#DejaVuSans-57" transform="translate(680.90625 0)"/>
+      <use xlink:href="#DejaVuSans-3" transform="translate(720.109375 0)"/>
+      <use xlink:href="#DejaVuSans-4b" transform="translate(751.890625 0)"/>
+     </g>
+    </g>
+   </g>
+   <g id="LineCollection_1"/>
+   <g id="patch_9">
+    <path d="M 551.52 246.24 
+L 557.568 246.24 
+L 563.616 246.24 
+L 563.616 44.64 
+L 557.568 44.64 
+L 551.52 44.64 
+L 551.52 246.24 
+z
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+  </g>
+  <g id="text_33">
+   <!-- Same corrugated surface, same t=8: sixfold stiffness picks an orientation -->
+   <g transform="translate(7.2 15.558281) scale(0.11 -0.11)">
+    <defs>
+     <path id="DejaVuSans-36" d="M 3425 4513 
+L 3425 3897 
+Q 3066 4069 2747 4153 
+Q 2428 4238 2131 4238 
+Q 1616 4238 1336 4038 
+Q 1056 3838 1056 3469 
+Q 1056 3159 1242 3001 
+Q 1428 2844 1947 2747 
+L 2328 2669 
+Q 3034 2534 3370 2195 
+Q 3706 1856 3706 1288 
+Q 3706 609 3251 259 
+Q 2797 -91 1919 -91 
+Q 1588 -91 1214 -16 
+Q 841 59 441 206 
+L 441 856 
+Q 825 641 1194 531 
+Q 1563 422 1919 422 
+Q 2459 422 2753 634 
+Q 3047 847 3047 1241 
+Q 3047 1584 2836 1778 
+Q 2625 1972 2144 2069 
+L 1759 2144 
+Q 1053 2284 737 2584 
+Q 422 2884 422 3419 
+Q 422 4038 858 4394 
+Q 1294 4750 2059 4750 
+Q 2388 4750 2728 4690 
+Q 3069 4631 3425 4513 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-50" d="M 3328 2828 
+Q 3544 3216 3844 3400 
+Q 4144 3584 4550 3584 
+Q 5097 3584 5394 3201 
+Q 5691 2819 5691 2113 
+L 5691 0 
+L 5113 0 
+L 5113 2094 
+Q 5113 2597 4934 2840 
+Q 4756 3084 4391 3084 
+Q 3944 3084 3684 2787 
+Q 3425 2491 3425 1978 
+L 3425 0 
+L 2847 0 
+L 2847 2094 
+Q 2847 2600 2669 2842 
+Q 2491 3084 2119 3084 
+Q 1678 3084 1418 2786 
+Q 1159 2488 1159 1978 
+L 1159 0 
+L 581 0 
+L 581 3500 
+L 1159 3500 
+L 1159 2956 
+Q 1356 3278 1631 3431 
+Q 1906 3584 2284 3584 
+Q 2666 3584 2933 3390 
+Q 3200 3197 3328 2828 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-1d" d="M 750 794 
+L 1409 794 
+L 1409 0 
+L 750 0 
+L 750 794 
+z
+M 750 3309 
+L 1409 3309 
+L 1409 2516 
+L 750 2516 
+L 750 3309 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-4f" d="M 603 4863 
+L 1178 4863 
+L 1178 0 
+L 603 0 
+L 603 4863 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-13ae" d="M 4531 4863 
+L 4531 4384 
+L 3981 4384 
+Q 3672 4384 3551 4259 
+Q 3431 4134 3431 3809 
+L 3431 3500 
+L 4378 3500 
+L 4378 3053 
+L 3431 3053 
+L 3431 0 
+L 2853 0 
+L 2853 3053 
+L 1275 3053 
+L 1275 0 
+L 697 0 
+L 697 3053 
+L 147 3053 
+L 147 3500 
+L 697 3500 
+L 697 3744 
+Q 697 4328 969 4595 
+Q 1241 4863 1831 4863 
+L 2375 4863 
+L 2375 4384 
+L 1825 4384 
+Q 1516 4384 1394 4259 
+Q 1275 4134 1275 3809 
+L 1275 3500 
+L 2853 3500 
+L 2853 3744 
+Q 2853 4328 3125 4595 
+Q 3397 4863 3988 4863 
+L 4531 4863 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-4e" d="M 581 4863 
+L 1159 4863 
+L 1159 1991 
+L 2875 3500 
+L 3609 3500 
+L 1753 1863 
+L 3688 0 
+L 2938 0 
+L 1159 1709 
+L 1159 0 
+L 581 0 
+L 581 4863 
+z
+" transform="scale(0.015625)"/>
+    </defs>
+    <use xlink:href="#DejaVuSans-36"/>
+    <use xlink:href="#DejaVuSans-44" transform="translate(63.484375 0)"/>
+    <use xlink:href="#DejaVuSans-50" transform="translate(124.765625 0)"/>
+    <use xlink:href="#DejaVuSans-48" transform="translate(222.171875 0)"/>
+    <use xlink:href="#DejaVuSans-3" transform="translate(283.703125 0)"/>
+    <use xlink:href="#DejaVuSans-46" transform="translate(315.484375 0)"/>
+    <use xlink:href="#DejaVuSans-52" transform="translate(370.46875 0)"/>
+    <use xlink:href="#DejaVuSans-55" transform="translate(431.65625 0)"/>
+    <use xlink:href="#DejaVuSans-55" transform="translate(471.015625 0)"/>
+    <use xlink:href="#DejaVuSans-58" transform="translate(512.125 0)"/>
+    <use xlink:href="#DejaVuSans-4a" transform="translate(575.5 0)"/>
+    <use xlink:href="#DejaVuSans-44" transform="translate(638.984375 0)"/>
+    <use xlink:href="#DejaVuSans-57" transform="translate(700.265625 0)"/>
+    <use xlink:href="#DejaVuSans-48" transform="translate(739.46875 0)"/>
+    <use xlink:href="#DejaVuSans-47" transform="translate(801 0)"/>
+    <use xlink:href="#DejaVuSans-3" transform="translate(864.484375 0)"/>
+    <use xlink:href="#DejaVuSans-56" transform="translate(896.265625 0)"/>
+    <use xlink:href="#DejaVuSans-58" transform="translate(948.359375 0)"/>
+    <use xlink:href="#DejaVuSans-55" transform="translate(1011.734375 0)"/>
+    <use xlink:href="#DejaVuSans-49" transform="translate(1052.84375 0)"/>
+    <use xlink:href="#DejaVuSans-44" transform="translate(1088.046875 0)"/>
+    <use xlink:href="#DejaVuSans-46" transform="translate(1149.328125 0)"/>
+    <use xlink:href="#DejaVuSans-48" transform="translate(1204.3125 0)"/>
+    <use xlink:href="#DejaVuSans-f" transform="translate(1265.84375 0)"/>
+    <use xlink:href="#DejaVuSans-3" transform="translate(1297.625 0)"/>
+    <use xlink:href="#DejaVuSans-56" transform="translate(1329.40625 0)"/>
+    <use xlink:href="#DejaVuSans-44" transform="translate(1381.5 0)"/>
+    <use xlink:href="#DejaVuSans-50" transform="translate(1442.78125 0)"/>
+    <use xlink:href="#DejaVuSans-48" transform="translate(1540.1875 0)"/>
+    <use xlink:href="#DejaVuSans-3" transform="translate(1601.71875 0)"/>
+    <use xlink:href="#DejaVuSans-57" transform="translate(1633.5 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(1672.703125 0)"/>
+    <use xlink:href="#DejaVuSans-1b" transform="translate(1756.5 0)"/>
+    <use xlink:href="#DejaVuSans-1d" transform="translate(1820.125 0)"/>
+    <use xlink:href="#DejaVuSans-3" transform="translate(1853.8125 0)"/>
+    <use xlink:href="#DejaVuSans-56" transform="translate(1885.59375 0)"/>
+    <use xlink:href="#DejaVuSans-4c" transform="translate(1937.6875 0)"/>
+    <use xlink:href="#DejaVuSans-5b" transform="translate(1965.46875 0)"/>
+    <use xlink:href="#DejaVuSans-49" transform="translate(2024.65625 0)"/>
+    <use xlink:href="#DejaVuSans-52" transform="translate(2059.859375 0)"/>
+    <use xlink:href="#DejaVuSans-4f" transform="translate(2121.046875 0)"/>
+    <use xlink:href="#DejaVuSans-47" transform="translate(2148.828125 0)"/>
+    <use xlink:href="#DejaVuSans-3" transform="translate(2212.3125 0)"/>
+    <use xlink:href="#DejaVuSans-56" transform="translate(2244.09375 0)"/>
+    <use xlink:href="#DejaVuSans-57" transform="translate(2296.1875 0)"/>
+    <use xlink:href="#DejaVuSans-4c" transform="translate(2335.390625 0)"/>
+    <use xlink:href="#DejaVuSans-13ae" transform="translate(2363.171875 0)"/>
+    <use xlink:href="#DejaVuSans-51" transform="translate(2432.0625 0)"/>
+    <use xlink:href="#DejaVuSans-48" transform="translate(2495.4375 0)"/>
+    <use xlink:href="#DejaVuSans-56" transform="translate(2556.96875 0)"/>
+    <use xlink:href="#DejaVuSans-56" transform="translate(2609.0625 0)"/>
+    <use xlink:href="#DejaVuSans-3" transform="translate(2661.15625 0)"/>
+    <use xlink:href="#DejaVuSans-53" transform="translate(2692.9375 0)"/>
+    <use xlink:href="#DejaVuSans-4c" transform="translate(2756.421875 0)"/>
+    <use xlink:href="#DejaVuSans-46" transform="translate(2784.203125 0)"/>
+    <use xlink:href="#DejaVuSans-4e" transform="translate(2839.1875 0)"/>
+    <use xlink:href="#DejaVuSans-56" transform="translate(2897.09375 0)"/>
+    <use xlink:href="#DejaVuSans-3" transform="translate(2949.1875 0)"/>
+    <use xlink:href="#DejaVuSans-44" transform="translate(2980.96875 0)"/>
+    <use xlink:href="#DejaVuSans-51" transform="translate(3042.25 0)"/>
+    <use xlink:href="#DejaVuSans-3" transform="translate(3105.625 0)"/>
+    <use xlink:href="#DejaVuSans-52" transform="translate(3137.40625 0)"/>
+    <use xlink:href="#DejaVuSans-55" transform="translate(3198.59375 0)"/>
+    <use xlink:href="#DejaVuSans-4c" transform="translate(3239.703125 0)"/>
+    <use xlink:href="#DejaVuSans-48" transform="translate(3267.484375 0)"/>
+    <use xlink:href="#DejaVuSans-51" transform="translate(3329.015625 0)"/>
+    <use xlink:href="#DejaVuSans-57" transform="translate(3392.390625 0)"/>
+    <use xlink:href="#DejaVuSans-44" transform="translate(3431.59375 0)"/>
+    <use xlink:href="#DejaVuSans-57" transform="translate(3492.875 0)"/>
+    <use xlink:href="#DejaVuSans-4c" transform="translate(3532.078125 0)"/>
+    <use xlink:href="#DejaVuSans-52" transform="translate(3559.859375 0)"/>
+    <use xlink:href="#DejaVuSans-51" transform="translate(3621.046875 0)"/>
+   </g>
+  </g>
+ </g>
+ <defs>
+  <clipPath id="p65b044fd6f">
+   <rect x="61.416909" y="44.327273" width="209.583345" height="209.583345"/>
+  </clipPath>
+  <clipPath id="p68d571bf38">
+   <rect x="311.825855" y="44.327273" width="209.583345" height="209.583345"/>
+  </clipPath>
+ </defs>
+</svg>

--- a/tests/unit/frontend/io/CMakeLists.txt
+++ b/tests/unit/frontend/io/CMakeLists.txt
@@ -33,3 +33,15 @@ add_test(NAME png_writer COMMAND ${MPIEXEC_EXECUTABLE} ${MPIEXEC_NUMPROC_FLAG} 1
 add_test(NAME png_writer_parallel COMMAND ${MPIEXEC_EXECUTABLE} ${MPIEXEC_NUMPROC_FLAG} 2
                  ${MPIEXEC_PREFLAGS} $<TARGET_FILE:test_png_writer> ${MPIEXEC_POSTFLAGS})
 set_tests_properties(png_writer png_writer_parallel PROPERTIES RUN_SERIAL TRUE)
+
+# `openpfc_apps/field_snapshots.hpp` lives in apps/common (it is shared by the
+# standalone science drivers, not by the library), so this target needs that
+# include path and nlohmann_json explicitly.
+add_executable(test_field_snapshots test_field_snapshots.cpp)
+target_include_directories(test_field_snapshots PRIVATE
+    ${CMAKE_SOURCE_DIR}/apps/common/include)
+target_link_libraries(test_field_snapshots PRIVATE openpfc Catch2::Catch2
+    MPI::MPI_CXX nlohmann_json::nlohmann_json)
+add_test(NAME field_snapshots COMMAND ${MPIEXEC_EXECUTABLE} ${MPIEXEC_NUMPROC_FLAG} 1
+                 ${MPIEXEC_PREFLAGS} $<TARGET_FILE:test_field_snapshots> ${MPIEXEC_POSTFLAGS})
+set_tests_properties(field_snapshots PROPERTIES RUN_SERIAL TRUE)

--- a/tests/unit/frontend/io/test_field_snapshots.cpp
+++ b/tests/unit/frontend/io/test_field_snapshots.cpp
@@ -1,0 +1,144 @@
+// SPDX-FileCopyrightText: 2026 VTT Technical Research Centre of Finland Ltd
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+/**
+ * @file test_field_snapshots.cpp
+ * @brief `openpfc_apps/field_snapshots.hpp`: the standalone drivers' `fields[]`.
+ *
+ * The two science drivers that own their own `main()`
+ * (`surface_diffusion_anisotropic`, `ehd_film_nonlinear`) get their field
+ * output from this helper rather than from `SpectralETDSession`. The point of
+ * these tests is the failure modes, not the happy path: a preset that
+ * *believes* it is writing snapshots and silently is not would be invisible
+ * until someone tried to render a figure from the missing files, which is
+ * exactly how the report chapters lost their figures in the first place.
+ */
+
+#define CATCH_CONFIG_RUNNER
+#include <catch2/catch_session.hpp>
+#include <catch2/catch_test_macros.hpp>
+
+#include <cstdio>
+#include <filesystem>
+#include <string>
+
+#include <unistd.h>
+
+#include <nlohmann/json.hpp>
+
+#include <openpfc/kernel/data/domain.hpp>
+#include <openpfc/kernel/data/grid_field.hpp>
+#include <openpfc/kernel/mpi/mpi.hpp>
+#include <openpfc_apps/field_snapshots.hpp>
+
+using json = nlohmann::json;
+
+int main(int argc, char *argv[]) {
+  MPI_Init(&argc, &argv);
+  Catch::Session session;
+  session.configData().rngSeed = 1u;
+  session.configData().runOrder = Catch::TestRunOrder::Declared;
+  const int cli = session.applyCommandLine(argc, argv);
+  if (cli != 0) {
+    MPI_Finalize();
+    return cli;
+  }
+  const int result = session.run();
+  MPI_Finalize();
+  return result;
+}
+
+namespace {
+
+/// A tiny host field, laid out the way the standalone drivers lay theirs out.
+pfc::data::Field<double> make_field(const pfc::Domain &domain) {
+  const auto size = pfc::domain::get_size(domain);
+  const auto owned =
+      pfc::Box3i::from_bounds({0, 0, 0}, {size[0] - 1, size[1] - 1, size[2] - 1});
+  return pfc::data::Field<double>(domain, owned, 0);
+}
+
+pfc::Domain small_domain() {
+  return pfc::domain::create(pfc::GridSize({4, 4, 1}),
+                             pfc::PhysicalOrigin({0.0, 0.0, 0.0}),
+                             pfc::GridSpacing({1.0, 1.0, 1.0}));
+}
+
+} // namespace
+
+TEST_CASE("field_snapshots: no fields[] means no writer and no files",
+          "[apps][field_snapshots]") {
+  const auto domain = small_domain();
+  auto field = make_field(domain);
+
+  // The pre-existing behaviour of both drivers, and what their test presets
+  // still rely on: diagnostics only, no file-system traffic at all.
+  REQUIRE(pfc::apps::make_field_snapshot_writer(json::object(), "h", field) ==
+          nullptr);
+  REQUIRE(pfc::apps::make_field_snapshot_writer(json{{"fields", json::array()}}, "h",
+                                                field) == nullptr);
+
+  // A null writer is a no-op rather than a crash, so a driver can call the
+  // write unconditionally at every save.
+  REQUIRE_NOTHROW(pfc::apps::write_field_snapshot(nullptr, 0, field));
+}
+
+TEST_CASE("field_snapshots: a malformed fields[] is rejected, not ignored",
+          "[apps][field_snapshots]") {
+  const auto domain = small_domain();
+  auto field = make_field(domain);
+
+  SECTION("wrong field name") {
+    const json cfg = {{"fields", {{{"name", "psi"}, {"data", "out_%04d.vti"}}}}};
+    REQUIRE_THROWS_AS(pfc::apps::make_field_snapshot_writer(cfg, "h", field),
+                      std::invalid_argument);
+  }
+  SECTION("more entries than the driver has fields") {
+    const json cfg = {{"fields",
+                       {{{"name", "h"}, {"data", "a_%04d.vti"}},
+                        {{"name", "h"}, {"data", "b_%04d.vti"}}}}};
+    REQUIRE_THROWS_AS(pfc::apps::make_field_snapshot_writer(cfg, "h", field),
+                      std::invalid_argument);
+  }
+  SECTION("an output format this helper cannot write") {
+    const json cfg = {{"fields", {{{"name", "h"}, {"data", "out_%04d.bin"}}}}};
+    REQUIRE_THROWS_AS(pfc::apps::make_field_snapshot_writer(cfg, "h", field),
+                      std::invalid_argument);
+  }
+  SECTION("fields[] is not an array") {
+    const json cfg = {{"fields", {{"name", "h"}}}};
+    REQUIRE_THROWS_AS(pfc::apps::make_field_snapshot_writer(cfg, "h", field),
+                      std::invalid_argument);
+  }
+}
+
+TEST_CASE("field_snapshots: snapshots are indexed by save and land on disk",
+          "[apps][field_snapshots]") {
+  if (pfc::mpi::get_size() != 1) return; // single-rank helper check
+
+  const auto dir = std::filesystem::temp_directory_path() /
+                   ("openpfc_field_snapshots_" + std::to_string(::getpid()));
+  std::filesystem::remove_all(dir);
+
+  const auto domain = small_domain();
+  auto field = make_field(domain);
+  field.apply([](const pfc::Real3 &x) { return x[0] + 10.0 * x[1]; });
+
+  // A `results/`-style path whose directory does not exist yet: the helper is
+  // expected to create it, as the drivers' diagnostics CSV already does.
+  const std::string pattern = (dir / "results" / "h_%04d.vti").string();
+  const json cfg = {{"fields", {{{"name", "h"}, {"data", pattern}}}}};
+  auto writer = pfc::apps::make_field_snapshot_writer(cfg, "h", field);
+  REQUIRE(writer != nullptr);
+
+  for (int i = 0; i < 3; ++i)
+    pfc::apps::write_field_snapshot(writer.get(), i, field);
+
+  // Save index, not step index: the first save is _0000.
+  REQUIRE(std::filesystem::exists(dir / "results" / "h_0000.vti"));
+  REQUIRE(std::filesystem::exists(dir / "results" / "h_0001.vti"));
+  REQUIRE(std::filesystem::exists(dir / "results" / "h_0002.vti"));
+  REQUIRE(std::filesystem::file_size(dir / "results" / "h_0000.vti") > 0);
+
+  std::filesystem::remove_all(dir);
+}


### PR DESCRIPTION
Two application chapters had no figure — and could not have had one, because their science presets wrote no field output at all. This gives each a real figure rendered from a real run, and fixes the reason they were missing.

## Why a code change was needed

`surface_diffusion_anisotropic` and `ehd_film_nonlinear` are the two science drivers that own their own `main()` rather than running on `SpectralETDSession` (their physics is not a reciprocal-space symbol). Neither had ever had a field writer, so `nanosurface_*.json` and `load_relaxation_*.json` could only be read through their diagnostics CSV. A CSV can say that the anisotropic anneal ends with three quarters of its spectral energy in `k_y`; it cannot show which ridge set was erased.

New `apps/common/include/openpfc_apps/field_snapshots.hpp` gives both drivers the session's own `fields[]` spelling, so a reader moving between `smoothing.json` and `nanosurface_isotropic.json` does not meet a second convention. Two calls: build the writer once, write a snapshot wherever the driver already samples diagnostics. Snapshot indices count saves, not steps, exactly as `SpectralETDSession::write_results` does, so frame *i* is at `i * saveat`.

Design points:

- **Omitting `fields[]` keeps the old behaviour** — diagnostics only, no file-system traffic. The test presets rely on that.
- **A malformed `fields[]` throws rather than being ignored.** A preset that believes it is writing output and is not stays invisible until someone tries to render a figure from files that are not there — which is exactly how these two chapters lost their figures.
- Only the subset these single-field drivers can honour is accepted: one entry, naming the driver's field, `.vti`.
- Covered by `ctest -R field_snapshots` (`tests/unit/frontend/io/test_field_snapshots.cpp`), which tests the failure modes and the directory-creation/save-index behaviour.

## Shipped inputs modified, and why

Four presets each gain a `fields[]` block, path following the existing `results/<app>/<name>_%04d.vti` convention:

| Preset | Added | Why |
|---|---|---|
| `apps/surface_diffusion/inputs_json/nanosurface_isotropic.json` | `results/surface_diffusion/nanosurface_isotropic_%04d.vti` | the isotropic half of the orientation-selection contrast |
| `apps/surface_diffusion/inputs_json/nanosurface_anisotropic.json` | `results/surface_diffusion/nanosurface_anisotropic_%04d.vti` | the anisotropic half |
| `apps/ehd_film/inputs_json/load_relaxation_compliant.json` | `results/ehd_film_nonlinear/load_relaxation_compliant_%04d.vti` | the compliant half of the stiffness contrast |
| `apps/ehd_film/inputs_json/load_relaxation_stiff.json` | `results/ehd_film_nonlinear/load_relaxation_stiff_%04d.vti` | the stiff half |

Distinct filenames per case, so a pair shares one results directory. All four were re-run afterwards and reproduce their previously reported numbers exactly (`rms_roughness` 0.0023821 / 0.0015488, `energy_ky_frac` 0.75063, `spreading_radius_max` 23.083 / 27.406, volume drift ~2e-14).

## `07_surface_diffusion` — @fig-sd-nanosurface

**What it shows.** `nanosurface_isotropic.json` against `nanosurface_anisotropic.json` at `t=8`, side by side on one shared diverging scale centred on the conserved mean height `h=0`.

**Which run.** Both shipped presets, unmodified, single rank, 128², `t1=8` — not extended (`h` decays as `exp(-B k⁴ t)`; by `t=8` the ±0.1 corrugation is at ±0.005 and running further leaves nothing to see). Recipe in `run_field_demos.sh`.

**What the reader should see.** The two runs start from the *identical* crossed corrugation and differ in one number. Isotropically the symbol depends on `|k|` alone, so both ridge sets decay together and the egg-crate survives, merely fainter. With `eps_a=0.5, m=6` the surface has become **stripes**: the x-varying ridges, whose gradient samples the stiff end of `B(θ)` near `θ=0`, are gone; the y-varying ridges near the soft `θ=π/2` remain. That is `energy_kx_frac`/`energy_ky_frac` = 0.249/0.751 drawn. The shared scale also carries the amplitude difference (RMS 0.00155 against 0.00238).

## `09_ehd_film` — @fig-ehd-load

**What it shows.** `load_relaxation_compliant.json` (B=100) against `load_relaxation_stiff.json` (B=640) at `t=60`, one shared sequential scale (a gap thickness is one-sided).

**Which run.** Both shipped presets, unmodified, single rank, 256², full `t1=600`; the figure is save index 6.

**What the reader should see.** Same Gaussian press (`p0=0.5`, `a=8`) held over `0 ≤ t < 60` and sampled at the instant it lifts — also where both runs' CSV records their minimum central gap, so this is the deepest either dent ever gets. The compliant plate yields into a deeper, tighter well (`h_centre` 0.659, radius 12.3); the stiff plate puts almost the same displaced volume (106 against 111) into a shallower, wider depression (0.747, radius 14.2). Both are ringed by the bulge where the displaced liquid went, and both sit well inside the periodic box — the visual form of the chapter's claim that the measured spreading radius is measuring the disturbance and not the domain.

## Chapter text that disagreed with the runs

`09_ehd_film.qmd`'s **Binaries and inputs** said, in full: "`ehd_film` (CPU), `ehd_film_hip`. Preset `relaxation.json`." — naming only the verifier, while the entire *Problem setup* table above it describes `ehd_film_nonlinear` and the two `load_relaxation_*` presets. A reader following that section would never find the binary that produces the chapter's own observables. Corrected here.

Everything else in both chapters checked out against the actual runs: `07`'s measured-orientation-selection table reproduces to every printed digit, and `09`'s spreading-radius bound (27.4 / 23.1, under 22% of the domain half-width) is exactly what the reruns give.

## Verification

- `scripts/check_doc_links.py` — OK
- `scripts/check_doc_bash_syntax.py` — OK (84 blocks)
- `quarto render docs/report --to html` — clean; both `@fig-` cross-references resolve. The rendered `docs/report/_output/` and `.quarto/` churn was restored rather than committed (that tracked build is already stale relative to `master`); so were the five pre-existing field SVGs that a full `make_field_figures.py` run rewrites.
- LUMI CPU build with `-DOpenPFC_BUILD_TESTS=ON`; `test_field_snapshots` passes (12 assertions, 3 cases), as do `surface-diffusion-all-tests`, `ehd-film-all-tests` and both CLI smokes. The MPI-launched ctests cannot run on the login node (no allocation) — checked that the pre-existing `vtk_writer` test fails there identically, and ran the binary directly.
- Both figures were rendered to PNG and visually inspected before committing, as `docs/report/README.md` requires.
