### PR TITLE
fix: four defects found by running the shipped presets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,6 +73,91 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 
 ### Fixed
 
+- `wave2d`'s advertised observable, `global_rms_u_interior`, was identically
+  zero for every configuration on both CPU drivers. The interior visitor
+  trimmed the stencil half-width off each axis of each rank's owned box, and
+  the app is an `nz == 1` slab: `[hw, 1 - hw)` in z is empty, so the reduction
+  summed no cells and printed the `0` that an empty sum and a genuinely zero
+  field share. Nothing caught it because nothing distinguished the two. The
+  observable now trims only axes that can spare the shell -- the slab's single
+  z layer is kept, because z is not a dimension this model has -- and trims in
+  *global* index space rather than per rank, so the number no longer shrinks
+  as ranks are added and eat a shell at every subdomain seam. `report()` also
+  carries the visited count: the run line prints `interior_cells=`, an empty
+  interior prints `global_rms_u_interior=undefined interior_cells=0` and exits
+  non-zero, and the reduction can no longer report nothing as if it were zero.
+  `wave2d_fd` at order 2 and `wave2d_fd_manual` now agree to the last digit
+  (0.219101 for the 64x64x50 preset), which is the cross-check the observable
+  was supposed to provide all along. Guards: `[reporting]` in `test_wave2d`
+  pins the degenerate-axis rule and sums a 2- and a 4-rank decomposition to
+  the 1-rank answer.
+
+- `wave2d_fd` advertised even FD orders 2 to 20 and only order 2 ran. Order 4
+  aborted before its first step with `create_padded_face_types_6: owned
+  extents 64x64x1 cannot host halo_width=2 owned send slabs`: a 1-thick owned
+  z extent cannot provide a 2-thick send slab. It was never asked to -- the
+  Laplacian reads x and y only -- but the face-type builder validated all
+  three axes whatever direction set the exchanger had been given, contradicting
+  its own documented contract that "orthogonal thin axes (e.g. `nz == 1` for
+  Axes2D) remain valid". `create_padded_face_types_6` now takes the active-slot
+  mask, builds and validates only the slots that will carry a message, and
+  `HostFacesHalo` resolves that mask before asking for types. `wave2d_fd` asks
+  for `halo::presets::Axes2D()`, which is what the preset was written for, and
+  all ten advertised orders run. Rejecting orders 4-20 at parse time was the
+  alternative; making them work was preferable because the y-ghost fill was
+  already general in the halo width, so the stencils were the only thing
+  standing between the app and the accuracy its usage line promised. Guard:
+  `[halo]` in `test_wave2d` constructs the exchanger at every advertised order
+  and steps a 32x32 slab at order 4, and still requires that asking for the
+  z faces on a 1-thick z is an error.
+
+- Every `.vti` written through a JSON session claimed `Spacing="1 1 1"`.
+  `pfc::apply_writer_domain` set the index geometry -- global size, local size,
+  offset -- and dropped the physical geometry the `Domain` was carrying right
+  next to it, even though `VTKWriter::set_spacing` / `set_origin` existed and
+  every hand-written call site already used them. Harmless for the `dx = 1`
+  presets and wrong by 4x for a `dx = 0.25` run, in a way nothing in the file
+  reveals: ParaView simply renders at the wrong scale and every length measured
+  off it inherits the error. `ResultsWriter` gains a `set_geometry(origin,
+  spacing)` hook, defaulting to a no-op so index-only sinks such as
+  `BinaryWriter` need not implement it, `VTKWriter` overrides it, and
+  `apply_writer_domain` forwards what the `Domain` already knows. No committed
+  test or golden file depended on the old value -- the two existing spacing
+  assertions in `test_vtk_writer` set the spacing themselves. Guard: two
+  `[geometry]` cases write a real `.vti` through `apply_writer_domain` at
+  `dx = 0.25` and `dx = 0.5` and read the header back.
+
+- `allen_cahn`'s pass criterion measured the grid rather than the physics, and
+  doubled as the process exit status. It required the superlevel area to reach
+  5x its initial value, but the seed radius scales with the grid
+  (`sigma = 0.055*min(nx,ny)`) while the interface speed does not, so
+  `((R0 + v t)/R0)^2` shrinks as the box grows: the same physics scored 6.08x
+  at 64^2, 3.50x at 128^2 and 2.55x at 256^2 -- pass, fail, fail. The criterion
+  is now the interface velocity `dR/dt`, with `R = sqrt(A/pi)` the equivalent
+  radius of the same superlevel area, measured over the *second half* of the
+  run and compared with the sharp-interface solvability result
+  `v = (3/2) F eps sqrt(2M)`. The second half because the Gaussian initial
+  condition is far from the equilibrium `tanh` and its collapse moves the
+  contour by a distance that scales with the seed -- a whole-run average
+  inherits exactly the grid dependence the area ratio had. Measured that way
+  the three grids agree to 5% (12.4 / 12.8 / 13.1 against a prediction of
+  11.4). The accepted band is a factor of two either way rather than a
+  percentage, because the shipped preset's interface is `eps*sqrt(2M) = 0.76`
+  cells wide -- under one grid spacing, so the front is lattice-limited and
+  sits tens of percent off the continuum law (`+11%` at the defaults, `-35%`
+  at `driving_force = 5`); the app now prints that width and warns. It also
+  prints the bistability limit `F eps^2 < 2/(3 sqrt 3)`, which the shipped
+  parameters clear by 6% and which `driving_force = 20` or `epsilon = 0.3`
+  crosses, flipping the whole domain instead of growing a grain -- previously
+  reported as an area ratio of 75.85 and a pass. The verdict prints as
+  `physics_check=PASS|FAIL|SKIPPED` and no longer sets the exit status: a run
+  too short to have outrun the transient, or one whose predicted advance is
+  under a cell, is skipped rather than failed, and the exit status answers
+  "did the run finish?". `--strict` opts back in to gating on a `FAIL`. Guard:
+  the new `allen-cahn-interface-kinetics` ctest -- the app had none -- runs the
+  shipped update at 64^2 and 128^2 and requires the same verdict and speeds
+  within 10%.
+
 - CI no longer fails on a third-party apt repository it does not use. The
   GitHub runner images carry apt sources for Google Chrome and Microsoft
   prod; on 2026-09-09 Chrome served a `Packages.gz` whose hash disagreed with

--- a/apps/allen_cahn/CMakeLists.txt
+++ b/apps/allen_cahn/CMakeLists.txt
@@ -99,6 +99,21 @@ if(ALLEN_CAHN_ENABLE_TESTS AND OpenPFC_BUILD_TESTS)
     set_tests_properties(allen-cahn-cpu-golden PROPERTIES
       ENVIRONMENT "OMPI_ALLOW_RUN_AS_ROOT=1;OMPI_ALLOW_RUN_AS_ROOT_CONFIRM=1")
 
+    # Grid-independence of the pass criterion. Runs the shipped update at two
+    # grid sizes, so it is the slowest test here (a few seconds) rather than a
+    # pure unit test.
+    add_executable(test_allen_cahn_interface_kinetics
+      tests/test_allen_cahn_interface_kinetics.cpp)
+    target_include_directories(test_allen_cahn_interface_kinetics PRIVATE
+      ${ALLEN_CAHN_INCLUDE_DIR})
+    target_link_libraries(test_allen_cahn_interface_kinetics PRIVATE
+      OpenPFC openpfc_apps_common Catch2::Catch2 ${_allen_cahn_heffte_tgt})
+    allen_cahn_link_libstdcxx(test_allen_cahn_interface_kinetics)
+    add_test(NAME allen-cahn-interface-kinetics
+             COMMAND test_allen_cahn_interface_kinetics)
+    set_tests_properties(allen-cahn-interface-kinetics PROPERTIES
+      ENVIRONMENT "OMPI_ALLOW_RUN_AS_ROOT=1;OMPI_ALLOW_RUN_AS_ROOT_CONFIRM=1")
+
     if(OpenPFC_ENABLE_CUDA AND OpenPFC_CUDA_AVAILABLE)
       add_executable(test_allen_cahn_cpu_vs_cuda
         tests/test_allen_cahn_cpu_vs_cuda.cpp

--- a/apps/allen_cahn/README.md
+++ b/apps/allen_cahn/README.md
@@ -11,21 +11,21 @@ Minimal 2D Allen–Cahn example on a structured grid: explicit time stepping, fi
 
 The `Problem setup` block the report contract (`#112`) asks every application
 to carry. Command-line driven, no JSON, and no science preset. Note that **no
-ctest runs this binary**: the area criterion below is enforced by the program's
-own exit code when a user runs it, while the automated suite exercises the
-update function through fixed small configurations.
+ctest runs this binary**, but the criterion it applies is no longer only
+reachable through the binary: `allen-cahn-interface-kinetics` runs the same
+update at two grid sizes and asserts that both reach the same verdict.
 
 | Item | Description |
 |---|---|
 | **Use case** | A single grain of the favoured phase growing into a matrix of the other under a constant driving force |
 | **Question** | Does the favoured phase actually take over, and by how much? |
 | **Domain** | `nx x ny x 1` slab, `dx = dy = 1` **hard-coded** (not a CLI argument). Defaults `64 x 64` |
-| **Grid/time** | `nx ny n_steps [dt] [M] [epsilon] [driving_force] [png_initial] [png_final]`; defaults 5000 steps at `dt = 9e-5`. No output cadence -- at most two PNG snapshots, initial and final |
+| **Grid/time** | `[--strict] nx ny n_steps [dt] [M] [epsilon] [driving_force] [png_initial] [png_final]`; defaults 5000 steps at `dt = 9e-5`. No output cadence -- at most two PNG snapshots, initial and final |
 | **Boundary conditions** | Periodic in x and y, by separated-layout halo exchange. There is no non-periodic option |
 | **Initial condition** | A single Gaussian nucleus, `phi = -1 + 2*exp(-r^2/(2*sigma^2))` centred in the slab, `sigma = max(2, 0.055*min(nx,ny))`. Deterministic; no noise anywhere |
 | **Key physical parameters** | `M = 8.0`, `epsilon = 0.19`, `driving_force = 10.0`. **Nondimensional and illustrative**; this app states no units and cites no reference model. `epsilon` is as much a numerical parameter as a physical one, since it sets both the interface width and the stiff reaction timestep limit |
-| **Observable** | Superlevel-set area `A = |{phi > 0}|` at start and end, reported as `N1/N0` and used as the exit status (failure unless `N1 >= 5*N0`); global `min phi`, `max phi`, `sum phi`; `avg_step_time_s`; optional grayscale PNGs |
-| **Model maturity** | numerical verification: **regression** only -- one pinned CPU checksum tied to a named machine and toolchain, plus CPU-vs-CUDA agreement to `1e-9` and CPU-vs-HIP to `1e-4`. There is no analytical or manufactured-solution check anywhere in this app. Physical completeness: **canonical** -- the standard non-conserved double-well model with a constant driving force, no elastic/thermal/solutal coupling. Calibration: **none** |
+| **Observable** | Interface velocity `dR/dt`, where `R = sqrt(A/pi)` is the equivalent radius of the superlevel-set area `A = |{phi > 0}|`, measured over the **second half** of the run and compared with the sharp-interface prediction `v = (3/2) F eps sqrt(2M)`. `A` is sampled at `t = 0, t/2, 3t/4, t`; the two quarter velocities must agree before `v_late` is judged. Also global `min phi`, `max phi`, `sum phi`; `avg_step_time_s`; optional grayscale PNGs. The verdict prints as `physics_check=PASS|FAIL|SKIPPED` and **does not** set the exit status unless `--strict` is passed |
+| **Model maturity** | numerical verification: **analytical** (loosely) and **regression** -- the end-of-run check compares the measured interface velocity with the sharp-interface solvability result `v = (3/2) F eps sqrt(2M)`, to a factor of two, which is as tight as an interface 0.76 cells wide supports; plus one pinned CPU checksum tied to a named machine and toolchain, CPU-vs-CUDA agreement to `1e-9` and CPU-vs-HIP to `1e-4`. There is no manufactured-solution check. Physical completeness: **canonical** -- the standard non-conserved double-well model with a constant driving force, no elastic/thermal/solutal coupling. Calibration: **none** |
 
 ### Why periodic
 
@@ -35,9 +35,36 @@ pins the interface and there is no curvature-driven drift towards a wall --
 which is the right idealization for asking whether a favoured phase grows at
 all. It also caps how long the experiment means anything: once the growing
 phase spans a substantial fraction of the box it starts meeting its own image,
-and the area ratio stops describing an isolated grain. The 5x criterion is a
-coarse growth check, not a measurement of interface velocity, and the app does
-**not** verify that the seed has stayed clear of its own images.
+the front stops advancing and the app does **not** verify that the seed has
+stayed clear of its own images.
+
+### Why a velocity and not an area ratio
+
+The app used to require `N1 >= 5*N0`. The seed radius scales with the grid
+(`sigma = 0.055*min(nx,ny)`) but the interface speed does not, so the ratio
+`((R0 + v t)/R0)^2` shrinks as the box grows: the same physics scored 6.08x at
+64^2, 3.50x at 128^2 and 2.55x at 256^2 -- pass, fail, fail. Measured as
+`dR/dt` over the last half of the run the three agree to 5% (12.4 / 12.8 /
+13.1). The last half, because the Gaussian initial condition is far from the
+equilibrium `tanh` and its collapse moves the contour by a distance that
+scales with the seed; a whole-run average inherits exactly the grid dependence
+the area ratio had.
+
+### Two limits worth knowing before changing the parameters
+
+* **The interface is not resolved.** `eps*sqrt(2M) = 0.76` cells at the shipped
+  preset, i.e. under one grid spacing, so the front is lattice-limited rather
+  than continuum-limited and the measured speed sits some tens of percent off
+  the sharp-interface law (`+11%` at the defaults, `-35%` at
+  `driving_force = 5`). That is why the accepted band is a factor of two either
+  way rather than a percentage. The app prints the width and warns when it is
+  below one cell.
+* **The driving force is close to its ceiling.** A front exists only while
+  `F*eps^2 < 2/(3 sqrt 3)`; above that there is no metastable `phi < 0` phase
+  and the whole domain simply decays. The shipped `F = 10`, `eps = 0.19` gives
+  `0.361` against a limit of `0.385` -- 6% of margin. `driving_force = 20` or
+  `epsilon = 0.3` crosses it and flips the entire box, which the app now says
+  out loud.
 
 ## Binaries
 
@@ -61,11 +88,11 @@ Executable: `build/apps/allen_cahn/allen_cahn`.
 ## Usage
 
 ```text
-mpirun -n <P> ./allen_cahn <nx> <ny> <n_steps> [dt] [M] [epsilon] [driving_force] [png_initial] [png_final]
+mpirun -n <P> ./allen_cahn [--strict] <nx> <ny> <n_steps> [dt] [M] [epsilon] [driving_force] [png_initial] [png_final]
 ```
 
 Defaults if omitted: `nx=ny=64`, `n_steps=5000`, `dt=0.00009`, `M=8.0`, `epsilon=0.19`, `driving_force=10.0`.
-The app counts the global visible seed area as cells with `phi > 0` at the beginning and end of the run, prints `N1/N0`, and exits with failure unless the final area is at least 5× the initial area. The optional positive `driving_force` favors the `phi≈+1` seed over the `phi≈-1` matrix. If you pass one PNG path, it writes the final field; if two, the first is the initial snapshot and the second the final (grayscale, rank 0).
+The app samples the global visible seed area (cells with `phi > 0`) at `t = 0`, `t/2`, `3t/4` and the end, converts each to an equivalent radius, and reports the interface velocity over the last half of the run against `(3/2) F eps sqrt(2M)`. The verdict prints as `physics_check=`; the exit status reports whether the *run* finished, so a deliberately short run is not a failed process. Pass `--strict` to have a `FAIL` verdict (never a `SKIPPED` one) set the exit status instead. The optional positive `driving_force` favors the `phi≈+1` seed over the `phi≈-1` matrix. If you pass one PNG path, it writes the final field; if two, the first is the initial snapshot and the second the final (grayscale, rank 0).
 The reported step timing measures the time-stepping loop only, after an MPI barrier and before PNG output or verification; `avg_step_time_s` is based on the slowest rank.
 
 Example:

--- a/apps/allen_cahn/include/allen_cahn/common.hpp
+++ b/apps/allen_cahn/include/allen_cahn/common.hpp
@@ -25,7 +25,11 @@ namespace allen_cahn {
 struct RunConfig {
   int nx_glob = 64;
   int ny_glob = 64;
-  /** Defaults are tuned so the superlevel area grows enough for the built-in check.
+  /**
+   * Long enough for the front to outrun the Gaussian initial condition and
+   * settle into steady propagation, which is what the built-in check measures.
+   * Below `kMinStepsForKinetics` the check reports SKIPPED rather than a
+   * number the transient dominates.
    */
   int n_steps = 5000;
   double dt = 0.00009;
@@ -38,15 +42,55 @@ struct RunConfig {
   std::string png_output;
   /** If non-empty, write the field right after IC, before time stepping. */
   std::string png_output_initial;
+  /** Opt in to letting a failed physics check set the process exit status. */
+  bool strict = false;
   static constexpr int kHaloWidth = 1;
   /** Superlevel for the seed-area metric: φ > 0 matches the visible seed in PNGs. */
   static constexpr double kLevelSetThreshold = 0.0;
-  /** End-of-run: global cell count above threshold must grow by this factor. */
-  static constexpr double kMinLevelSetAreaGrowthFactor = 5.0;
+  /**
+   * Band around the sharp-interface prediction that `v_late` must land in.
+   *
+   * Deliberately a factor of two either way, not a percentage. The shipped
+   * preset has an interface only `eps*sqrt(2M) = 0.76` cells wide (see
+   * `interface_width_cells`), so the front is lattice-limited rather than
+   * asymptotic and the measured speed sits a few tens of percent off the
+   * continuum law — measured `+11%` at the default parameters and `-35%` at
+   * `driving_force = 5`. A factor-of-two band still separates "a front
+   * propagates at roughly the predicted speed" from every failure mode that
+   * matters: no growth, the wrong sign, or the whole domain flipping.
+   */
+  static constexpr double kVelocityBandLo = 0.5;
+  static constexpr double kVelocityBandHi = 2.0;
+  /** Quarter-to-quarter agreement required before `v_late` counts as steady. */
+  static constexpr double kSteadyTolerance = 0.25;
+  /** Below this the last-half displacement is swamped by area quantisation. */
+  static constexpr double kMinMeasurableAdvanceCells = 1.0;
+  /** Fewer steps than this cannot outrun the initial-condition transient. */
+  static constexpr int kMinStepsForKinetics = 400;
 };
+
+/**
+ * @brief Strip `--strict` out of `argv`, leaving the positional layout intact.
+ *
+ * The rest of the CLI is positional by index, so a flag can only be added by
+ * removing it before those indices are read. Returns the new `argc`; rewrites
+ * `argv` in place.
+ */
+inline int extract_flags(int argc, char **argv, RunConfig *c) {
+  int out = 0;
+  for (int i = 0; i < argc; ++i) {
+    if (std::string(argv[i]) == "--strict") {
+      c->strict = true;
+      continue;
+    }
+    argv[out++] = argv[i];
+  }
+  return out;
+}
 
 inline RunConfig parse_args(int argc, char **argv) {
   RunConfig c;
+  argc = extract_flags(argc, argv, &c);
   if (argc > 1) {
     c.nx_glob = std::atoi(argv[1]);
   }
@@ -127,51 +171,251 @@ inline void fill_initial_condition(std::vector<double> *u,
 }
 
 /** Local count of cells with φ strictly above @p threshold. */
-inline std::int64_t count_cells_above(const std::vector<double> &u,
+inline std::int64_t count_cells_above(const double *u, std::size_t n_cells,
                                       double threshold) {
   std::int64_t n = 0;
-  for (double v : u) {
-    if (v > threshold) {
+  for (std::size_t i = 0; i < n_cells; ++i) {
+    if (u[i] > threshold) {
       ++n;
     }
   }
   return n;
 }
 
-/**
- * @brief Global superlevel area (cell count) at t=0 vs end; require N1 ≥ factor×N0.
- *        Interprets φ>threshold as the visible +1-phase seed.
- */
-inline bool verify_level_set_area_growth(MPI_Comm comm, int rank,
-                                         std::int64_t n_local_initial,
-                                         std::int64_t n_local_final,
-                                         double min_factor, double threshold_used) {
-  std::int64_t n0 = 0;
-  std::int64_t n1 = 0;
-  MPI_Reduce(&n_local_initial, &n0, 1, MPI_LONG_LONG, MPI_SUM, 0, comm);
-  MPI_Reduce(&n_local_final, &n1, 1, MPI_LONG_LONG, MPI_SUM, 0, comm);
-  int ok = 1;
-  if (rank == 0) {
-    std::cout << "Superlevel area (cells with phi > " << threshold_used
-              << "): N0=" << n0 << ", N1=" << n1;
-    if (n0 > 0) {
-      const double ratio = static_cast<double>(n1) / static_cast<double>(n0);
-      std::cout << ", N1/N0=" << ratio << "\n";
-      if (static_cast<double>(n1) < min_factor * static_cast<double>(n0)) {
-        std::cout << "Growth check (require N1 >= " << min_factor
-                  << " * N0): FAIL\n";
-        ok = 0;
-      } else {
-        std::cout << "Growth check (require N1 >= " << min_factor
-                  << " * N0): PASS\n";
-      }
-    } else {
-      std::cout << "\nGrowth check: FAIL (N0 == 0)\n";
-      ok = 0;
-    }
+/** Local count of cells with φ strictly above @p threshold. */
+inline std::int64_t count_cells_above(const std::vector<double> &u,
+                                      double threshold) {
+  return count_cells_above(u.data(), u.size(), threshold);
+}
+
+/** Global superlevel cell count, summed across `comm` and known to every rank. */
+inline std::int64_t global_area_cells(MPI_Comm comm, std::int64_t n_local) {
+  std::int64_t n = 0;
+  MPI_Allreduce(&n_local, &n, 1, MPI_INT64_T, MPI_SUM, comm);
+  return n;
+}
+
+/** Radius of the disc with the same area as @p area_cells cells of size `dx`. */
+[[nodiscard]] inline double equivalent_radius(std::int64_t area_cells,
+                                              double dx) noexcept {
+  if (area_cells <= 0) {
+    return 0.0;
   }
-  MPI_Bcast(&ok, 1, MPI_INT, 0, comm);
-  return ok != 0;
+  const double area = static_cast<double>(area_cells) * dx * dx;
+  return std::sqrt(area / 3.14159265358979323846);
+}
+
+/**
+ * @brief Equilibrium interface half-thickness `eps*sqrt(2M)`, in cells.
+ *
+ * The travelling-wave profile of `phi_t = M phi_xx - (phi^3 - phi)/eps^2` is
+ * `tanh(x / (eps*sqrt(2M)))`. Below one cell the front is pinned by the
+ * lattice rather than set by the continuum physics, and every kinetic number
+ * this app reports acquires a systematic error of tens of percent.
+ */
+[[nodiscard]] inline double interface_width_cells(double M, double epsilon,
+                                                  double dx) noexcept {
+  return epsilon * std::sqrt(2.0 * M) / dx;
+}
+
+/**
+ * @brief Sharp-interface normal velocity of a flat front.
+ *
+ * For `phi_t = M phi_xx - (phi^3 - phi)/eps^2 + F`, projecting the travelling
+ * wave onto `phi'` gives `-v \int phi'^2 = F \int phi'`. With
+ * `phi = -tanh(xi/delta)`, `delta = eps*sqrt(2M)`: `\int phi'^2 = 4/(3 delta)`
+ * and `\int phi' = -2`, hence
+ *
+ *     v = (3/2) F eps sqrt(2 M)
+ *
+ * — grid-size independent, which is the whole point: it is a property of the
+ * material parameters, not of how many cells the box happens to have.
+ */
+[[nodiscard]] inline double sharp_interface_velocity(double M, double epsilon,
+                                                     double F) noexcept {
+  return 1.5 * F * epsilon * std::sqrt(2.0 * M);
+}
+
+/**
+ * @brief Largest `F` for which the unfavoured phase is still metastable.
+ *
+ * `-(phi^3 - phi)/eps^2 + F` has three roots only while `F eps^2` stays below
+ * `max |phi^3 - phi|` on `[-1, 1]`, i.e. `2/(3 sqrt 3)`. Above it there is no
+ * `phi < 0` phase to grow into: the whole domain decays to `phi > 0` and there
+ * is no front at all.
+ */
+[[nodiscard]] inline double max_bistable_driving_force(double epsilon) noexcept {
+  return 2.0 / (3.0 * std::sqrt(3.0)) / (epsilon * epsilon);
+}
+
+/** Superlevel areas sampled at t=0, t/2, 3t/4 and the end of the run. */
+struct AreaSamples {
+  std::int64_t initial = 0;
+  std::int64_t half = 0;
+  std::int64_t three_quarter = 0;
+  std::int64_t final_ = 0;
+};
+
+enum class CheckVerdict { Pass, Fail, Skipped };
+
+/**
+ * @brief Interface kinetics derived from four superlevel-area samples.
+ *
+ * `v_late` is the rate of change of the *equivalent radius* over the second
+ * half of the run. Radius, not area: the area ratio `N1/N0` that this app used
+ * to check grows like `((R0 + vt)/R0)^2`, so the same interface speed reports a
+ * different number for every seed size — and the seed size scales with the
+ * grid. `dR/dt` does not.
+ *
+ * The second half, not the whole run: the Gaussian initial condition is far
+ * from the equilibrium `tanh`, and the front's first job is to sharpen. That
+ * transient moves the contour by a distance proportional to the seed width, so
+ * a whole-run average is grid-dependent for exactly the same reason the area
+ * ratio is. Measured over the last half instead, 64^2 / 128^2 / 256^2 agree to
+ * 5%.
+ */
+struct InterfaceKinetics {
+  double r_initial = 0.0;
+  double r_half = 0.0;
+  double r_three_quarter = 0.0;
+  double r_final = 0.0;
+  /// dR/dt over [t/2, t].
+  double v_late = 0.0;
+  /// dR/dt over [t/2, 3t/4] and [3t/4, t]; equal means steady propagation.
+  double v_third_quarter = 0.0;
+  double v_fourth_quarter = 0.0;
+  double v_theory = 0.0;
+  double interface_width = 0.0;
+  bool steady = false;
+  CheckVerdict verdict = CheckVerdict::Skipped;
+  std::string reason;
+};
+
+[[nodiscard]] inline InterfaceKinetics
+analyse_interface_kinetics(const AreaSamples &a, const RunConfig &cfg, double dx) {
+  InterfaceKinetics k;
+  k.r_initial = equivalent_radius(a.initial, dx);
+  k.r_half = equivalent_radius(a.half, dx);
+  k.r_three_quarter = equivalent_radius(a.three_quarter, dx);
+  k.r_final = equivalent_radius(a.final_, dx);
+  k.v_theory = sharp_interface_velocity(cfg.M, cfg.epsilon, cfg.driving_force);
+  k.interface_width = interface_width_cells(cfg.M, cfg.epsilon, dx);
+
+  const double dt_half = 0.5 * static_cast<double>(cfg.n_steps) * cfg.dt;
+  const double dt_quarter = 0.5 * dt_half;
+  if (dt_half > 0.0) {
+    k.v_late = (k.r_final - k.r_half) / dt_half;
+  }
+  if (dt_quarter > 0.0) {
+    k.v_third_quarter = (k.r_three_quarter - k.r_half) / dt_quarter;
+    k.v_fourth_quarter = (k.r_final - k.r_three_quarter) / dt_quarter;
+  }
+  const double v_scale = std::max(std::abs(k.v_third_quarter),
+                                  std::abs(k.v_fourth_quarter));
+  k.steady = (v_scale <= 0.0) ||
+             (std::abs(k.v_fourth_quarter - k.v_third_quarter) <=
+              RunConfig::kSteadyTolerance * v_scale);
+
+  if (a.initial <= 0) {
+    k.verdict = CheckVerdict::Fail;
+    k.reason = "no seed at t=0 (N0 == 0)";
+    return k;
+  }
+  if (cfg.n_steps < RunConfig::kMinStepsForKinetics) {
+    k.verdict = CheckVerdict::Skipped;
+    k.reason = "run shorter than " +
+               std::to_string(RunConfig::kMinStepsForKinetics) +
+               " steps: the initial-condition transient dominates";
+    return k;
+  }
+  const double floor_distance = RunConfig::kMinMeasurableAdvanceCells * dx;
+  if (std::abs(k.r_final - k.r_half) < floor_distance) {
+    // Below one cell of travel the superlevel *count* has not changed enough
+    // for dR/dt to mean anything. Whether that is the run's fault or the
+    // physics' is settled by asking how far the front was supposed to go: if
+    // even the prediction is sub-cell there is nothing to measure, otherwise
+    // the front should have moved and did not.
+    if (std::abs(k.v_theory) * dt_half < floor_distance) {
+      k.verdict = CheckVerdict::Skipped;
+      k.reason = "predicted advance over the last half of the run is under one "
+                 "cell: nothing measurable at this dt/n_steps";
+    } else {
+      k.verdict = CheckVerdict::Fail;
+      k.reason = "interface did not move a whole cell over the last half of "
+                 "the run, but was predicted to";
+    }
+    return k;
+  }
+  if (!k.steady) {
+    k.verdict = CheckVerdict::Skipped;
+    k.reason = "interface speed still changing between the last two quarters "
+               "(not yet steady); run longer";
+    return k;
+  }
+  // min/max rather than lo/hi directly: a negative driving force predicts a
+  // *shrinking* seed, and the band has to bracket that too.
+  const double bound_a = RunConfig::kVelocityBandLo * k.v_theory;
+  const double bound_b = RunConfig::kVelocityBandHi * k.v_theory;
+  if (k.v_late < std::min(bound_a, bound_b) ||
+      k.v_late > std::max(bound_a, bound_b)) {
+    k.verdict = CheckVerdict::Fail;
+    k.reason = "steady interface speed outside the sharp-interface band";
+    return k;
+  }
+  k.verdict = CheckVerdict::Pass;
+  k.reason = "steady interface speed consistent with (3/2) F eps sqrt(2M)";
+  return k;
+}
+
+[[nodiscard]] inline const char *to_string(CheckVerdict v) noexcept {
+  switch (v) {
+  case CheckVerdict::Pass: return "PASS";
+  case CheckVerdict::Fail: return "FAIL";
+  case CheckVerdict::Skipped: return "SKIPPED";
+  }
+  return "SKIPPED";
+}
+
+/** Rank-0 report of the kinetics block. Silent on every other rank. */
+inline void report_interface_kinetics(int rank, const AreaSamples &a,
+                                      const RunConfig &cfg,
+                                      const InterfaceKinetics &k) {
+  if (rank != 0) {
+    return;
+  }
+  std::cout << "Superlevel area (cells with phi > " << RunConfig::kLevelSetThreshold
+            << "): N0=" << a.initial << ", N_half=" << a.half
+            << ", N_3q=" << a.three_quarter << ", N1=" << a.final_ << "\n";
+  std::cout << "Equivalent radius: R0=" << k.r_initial << ", R_half=" << k.r_half
+            << ", R_3q=" << k.r_three_quarter << ", R1=" << k.r_final << "\n";
+  std::cout << "Interface velocity dR/dt (last half): v_late=" << k.v_late
+            << ", per quarter " << k.v_third_quarter << " / "
+            << k.v_fourth_quarter << " (steady=" << (k.steady ? "yes" : "no")
+            << ")\n";
+  std::cout << "Sharp-interface prediction (3/2) F eps sqrt(2M): v_theory="
+            << k.v_theory << ", accepted band ["
+            << std::min(RunConfig::kVelocityBandLo * k.v_theory,
+                        RunConfig::kVelocityBandHi * k.v_theory)
+            << ", "
+            << std::max(RunConfig::kVelocityBandLo * k.v_theory,
+                        RunConfig::kVelocityBandHi * k.v_theory)
+            << "]\n";
+  std::cout << "Interface width eps*sqrt(2M) = " << k.interface_width << " cells";
+  if (k.interface_width < 1.0) {
+    std::cout << "  [WARNING: below one cell — the front is lattice-limited, "
+                 "not continuum-limited]";
+  }
+  std::cout << "\n";
+  const double f_max = max_bistable_driving_force(cfg.epsilon);
+  std::cout << "Bistability limit: driving_force=" << cfg.driving_force << " vs "
+            << "2/(3 sqrt 3)/eps^2 = " << f_max;
+  if (cfg.driving_force >= f_max) {
+    std::cout << "  [VIOLATED: phi<0 is not metastable, the whole domain decays "
+                 "and there is no front]";
+  }
+  std::cout << "\n";
+  std::cout << "physics_check=" << to_string(k.verdict) << " (" << k.reason
+            << ")\n";
 }
 
 inline void report_step_timing(MPI_Comm comm, int rank, int n_steps,

--- a/apps/allen_cahn/src/cpu/allen_cahn.cpp
+++ b/apps/allen_cahn/src/cpu/allen_cahn.cpp
@@ -89,12 +89,31 @@ int main(int argc, char *argv[]) {
         pfc::comm::SparseExchange<pfc::HostSpace, double> exchanger(
             u.data(), u.size(), decomp, rank, MPI_COMM_WORLD, halo_width);
 
+        // Sample the seed area part-way through as well as at the end: the
+        // interface velocity is only meaningful once the Gaussian IC has
+        // relaxed to the equilibrium profile, so the criterion reads the last
+        // half of the run and needs the quarter marks to tell whether the
+        // front had actually settled by then.
+        allen_cahn::AreaSamples areas;
+        areas.initial = allen_cahn::global_area_cells(MPI_COMM_WORLD, n_local_initial);
+        const int step_half = cfg.n_steps / 2;
+        const int step_three_quarter = (3 * cfg.n_steps) / 4;
+
         MPI_Barrier(MPI_COMM_WORLD);
         const double step_t0 = MPI_Wtime();
         for (int step = 0; step < cfg.n_steps; ++step) {
           allen_cahn::step_explicit_euler_cpu(&u, &lap, &face_halos, &exchanger, nx, ny,
                                               nz, inv_dx2, inv_dy2, cfg.dt, cfg.M,
                                               inv_eps2, cfg.driving_force);
+          const int done = step + 1;
+          if (done == step_half || done == step_three_quarter) {
+            const std::int64_t n = allen_cahn::global_area_cells(
+                MPI_COMM_WORLD,
+                allen_cahn::count_cells_above(
+                    u, allen_cahn::RunConfig::kLevelSetThreshold));
+            if (done == step_half) areas.half = n;
+            if (done == step_three_quarter) areas.three_quarter = n;
+          }
         }
         MPI_Barrier(MPI_COMM_WORLD);
         const double step_elapsed_s = MPI_Wtime() - step_t0;
@@ -138,13 +157,23 @@ int main(int argc, char *argv[]) {
         }
         allen_cahn::report_step_timing(MPI_COMM_WORLD, rank, cfg.n_steps, step_elapsed_s);
 
-        const std::int64_t n_local_final =
-            allen_cahn::count_cells_above(u, allen_cahn::RunConfig::kLevelSetThreshold);
-        const bool growth_ok = allen_cahn::verify_level_set_area_growth(
-            MPI_COMM_WORLD, rank, n_local_initial, n_local_final,
-            allen_cahn::RunConfig::kMinLevelSetAreaGrowthFactor,
-            allen_cahn::RunConfig::kLevelSetThreshold);
+        areas.final_ = allen_cahn::global_area_cells(
+            MPI_COMM_WORLD,
+            allen_cahn::count_cells_above(u,
+                                          allen_cahn::RunConfig::kLevelSetThreshold));
+        const auto kinetics = allen_cahn::analyse_interface_kinetics(areas, cfg, dx);
+        allen_cahn::report_interface_kinetics(rank, areas, cfg, kinetics);
 
-        return growth_ok ? EXIT_SUCCESS : EXIT_FAILURE;
+        // The exit status answers "did the run finish?", not "did the physics
+        // agree?". A deliberately short run, or a parameter set outside the
+        // regime the check knows how to judge, is not a broken program. Pass
+        // --strict when you want the verdict to gate a script.
+        if (cfg.strict && kinetics.verdict == allen_cahn::CheckVerdict::Fail) {
+          if (rank == 0) {
+            std::cerr << "allen_cahn: --strict and physics_check=FAIL\n";
+          }
+          return EXIT_FAILURE;
+        }
+        return EXIT_SUCCESS;
       });
 }

--- a/apps/allen_cahn/src/cuda/allen_cahn.cpp
+++ b/apps/allen_cahn/src/cuda/allen_cahn.cpp
@@ -114,6 +114,17 @@ int main(int argc, char *argv[]) {
                     << "\n";
         }
 
+        // Sample the seed area part-way through as well as at the end: the
+        // interface velocity is only meaningful once the Gaussian IC has
+        // relaxed to the equilibrium profile, so the criterion reads the last
+        // half of the run and needs the quarter marks to tell whether the
+        // front had actually settled by then. Two extra device->host copies in
+        // a run of thousands of steps.
+        allen_cahn::AreaSamples areas;
+        areas.initial = allen_cahn::global_area_cells(MPI_COMM_WORLD, n_local_initial);
+        const int step_half = cfg.n_steps / 2;
+        const int step_three_quarter = (3 * cfg.n_steps) / 4;
+
         MPI_Barrier(MPI_COMM_WORLD);
         const double step_t0 = MPI_Wtime();
         for (int step = 0; step < cfg.n_steps; ++step) {
@@ -124,6 +135,21 @@ int main(int argc, char *argv[]) {
                                            halo_width, inv_dx2, inv_dy2, cfg.dt, cfg.M,
                                            inv_eps2, cfg.driving_force);
           u.note_device_write();
+          const int done = step + 1;
+          if (done == step_half || done == step_three_quarter) {
+            std::int64_t n_local = 0;
+            u.with_host_view([&](double *data, std::size_t n) {
+              n_local = allen_cahn::count_cells_above(
+                  data, n, allen_cahn::RunConfig::kLevelSetThreshold);
+            });
+            // Read-only peek: the device buffer is still authoritative, and
+            // saying so avoids a pointless host->device push next step.
+            u.note_device_write();
+            const std::int64_t n =
+                allen_cahn::global_area_cells(MPI_COMM_WORLD, n_local);
+            if (done == step_half) areas.half = n;
+            if (done == step_three_quarter) areas.three_quarter = n;
+          }
         }
         MPI_Barrier(MPI_COMM_WORLD);
         const double step_elapsed_s = MPI_Wtime() - step_t0;
@@ -150,12 +176,21 @@ int main(int argc, char *argv[]) {
           std::cout << "Global sum(phi) after stepping: " << sum_global << "\n";
         }
         allen_cahn::report_step_timing(MPI_COMM_WORLD, rank, cfg.n_steps, step_elapsed_s);
-        const std::int64_t n_local_final = allen_cahn::count_cells_above(
-            u_host, allen_cahn::RunConfig::kLevelSetThreshold);
-        const bool growth_ok = allen_cahn::verify_level_set_area_growth(
-            MPI_COMM_WORLD, rank, n_local_initial, n_local_final,
-            allen_cahn::RunConfig::kMinLevelSetAreaGrowthFactor,
-            allen_cahn::RunConfig::kLevelSetThreshold);
-        return growth_ok ? EXIT_SUCCESS : EXIT_FAILURE;
+        areas.final_ = allen_cahn::global_area_cells(
+            MPI_COMM_WORLD,
+            allen_cahn::count_cells_above(
+                u_host, allen_cahn::RunConfig::kLevelSetThreshold));
+        const auto kinetics = allen_cahn::analyse_interface_kinetics(areas, cfg, dx);
+        allen_cahn::report_interface_kinetics(rank, areas, cfg, kinetics);
+
+        // The exit status answers "did the run finish?", not "did the physics
+        // agree?". Pass --strict when you want the verdict to gate a script.
+        if (cfg.strict && kinetics.verdict == allen_cahn::CheckVerdict::Fail) {
+          if (rank == 0) {
+            std::cerr << "allen_cahn: --strict and physics_check=FAIL\n";
+          }
+          return EXIT_FAILURE;
+        }
+        return EXIT_SUCCESS;
       });
 }

--- a/apps/allen_cahn/src/hip/allen_cahn.cpp
+++ b/apps/allen_cahn/src/hip/allen_cahn.cpp
@@ -114,6 +114,17 @@ int main(int argc, char *argv[]) {
                     << "\n";
         }
 
+        // Sample the seed area part-way through as well as at the end: the
+        // interface velocity is only meaningful once the Gaussian IC has
+        // relaxed to the equilibrium profile, so the criterion reads the last
+        // half of the run and needs the quarter marks to tell whether the
+        // front had actually settled by then. Two extra device->host copies in
+        // a run of thousands of steps.
+        allen_cahn::AreaSamples areas;
+        areas.initial = allen_cahn::global_area_cells(MPI_COMM_WORLD, n_local_initial);
+        const int step_half = cfg.n_steps / 2;
+        const int step_three_quarter = (3 * cfg.n_steps) / 4;
+
         MPI_Barrier(MPI_COMM_WORLD);
         const double step_t0 = MPI_Wtime();
         for (int step = 0; step < cfg.n_steps; ++step) {
@@ -124,6 +135,21 @@ int main(int argc, char *argv[]) {
                                           halo_width, inv_dx2, inv_dy2, cfg.dt, cfg.M,
                                           inv_eps2, cfg.driving_force);
           u.note_device_write();
+          const int done = step + 1;
+          if (done == step_half || done == step_three_quarter) {
+            std::int64_t n_local = 0;
+            u.with_host_view([&](double *data, std::size_t n) {
+              n_local = allen_cahn::count_cells_above(
+                  data, n, allen_cahn::RunConfig::kLevelSetThreshold);
+            });
+            // Read-only peek: the device buffer is still authoritative, and
+            // saying so avoids a pointless host->device push next step.
+            u.note_device_write();
+            const std::int64_t n =
+                allen_cahn::global_area_cells(MPI_COMM_WORLD, n_local);
+            if (done == step_half) areas.half = n;
+            if (done == step_three_quarter) areas.three_quarter = n;
+          }
         }
         MPI_Barrier(MPI_COMM_WORLD);
         const double step_elapsed_s = MPI_Wtime() - step_t0;
@@ -150,12 +176,21 @@ int main(int argc, char *argv[]) {
           std::cout << "Global sum(phi) after stepping: " << sum_global << "\n";
         }
         allen_cahn::report_step_timing(MPI_COMM_WORLD, rank, cfg.n_steps, step_elapsed_s);
-        const std::int64_t n_local_final = allen_cahn::count_cells_above(
-            u_host, allen_cahn::RunConfig::kLevelSetThreshold);
-        const bool growth_ok = allen_cahn::verify_level_set_area_growth(
-            MPI_COMM_WORLD, rank, n_local_initial, n_local_final,
-            allen_cahn::RunConfig::kMinLevelSetAreaGrowthFactor,
-            allen_cahn::RunConfig::kLevelSetThreshold);
-        return growth_ok ? EXIT_SUCCESS : EXIT_FAILURE;
+        areas.final_ = allen_cahn::global_area_cells(
+            MPI_COMM_WORLD,
+            allen_cahn::count_cells_above(
+                u_host, allen_cahn::RunConfig::kLevelSetThreshold));
+        const auto kinetics = allen_cahn::analyse_interface_kinetics(areas, cfg, dx);
+        allen_cahn::report_interface_kinetics(rank, areas, cfg, kinetics);
+
+        // The exit status answers "did the run finish?", not "did the physics
+        // agree?". Pass --strict when you want the verdict to gate a script.
+        if (cfg.strict && kinetics.verdict == allen_cahn::CheckVerdict::Fail) {
+          if (rank == 0) {
+            std::cerr << "allen_cahn: --strict and physics_check=FAIL\n";
+          }
+          return EXIT_FAILURE;
+        }
+        return EXIT_SUCCESS;
       });
 }

--- a/apps/allen_cahn/tests/test_allen_cahn_interface_kinetics.cpp
+++ b/apps/allen_cahn/tests/test_allen_cahn_interface_kinetics.cpp
@@ -1,0 +1,227 @@
+// SPDX-FileCopyrightText: 2026 VTT Technical Research Centre of Finland Ltd
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+/**
+ * @file test_allen_cahn_interface_kinetics.cpp
+ * @brief The pass criterion must describe the physics, not the grid.
+ *
+ * @details
+ * The app used to require the superlevel area to reach 5x its initial value.
+ * The seed radius scales with the grid (`sigma = 0.055 * min(nx, ny)`) but the
+ * interface speed does not, so `(R0 + v t)^2 / R0^2` shrinks as the grid grows
+ * and the *same physics* scored 6.08x at 64^2, 3.50x at 128^2 and 2.55x at
+ * 256^2 — pass, fail, fail. The grid-independent quantity is `dR/dt`, and the
+ * headline test here is that two grid sizes agree on it and reach the same
+ * verdict.
+ *
+ * The kinetics are read off the second half of the run: the Gaussian initial
+ * condition is far from the equilibrium `tanh` and its collapse moves the
+ * contour by a distance that scales with the seed, so a whole-run average
+ * inherits the same grid dependence the area ratio had.
+ */
+
+#define CATCH_CONFIG_RUNNER
+#include <catch2/catch_session.hpp>
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_floating_point.hpp>
+
+#include <cmath>
+#include <cstdint>
+#include <iostream>
+#include <mpi.h>
+#include <vector>
+
+#include <allen_cahn/common.hpp>
+#include <openpfc/domain/create.hpp>
+#include <openpfc/kernel/data/strong_types.hpp>
+#include <openpfc/kernel/decomposition/decomposition.hpp>
+#include <openpfc/kernel/decomposition/decomposition_factory.hpp>
+#include <openpfc/kernel/decomposition/halo_face_layout.hpp>
+
+using Catch::Matchers::WithinAbs;
+using Catch::Matchers::WithinRel;
+
+namespace {
+
+constexpr double kDx = 1.0;
+
+/// Run the shipped CPU update and return the four superlevel-area samples the
+/// criterion reads. Single rank; mirrors `src/cpu/allen_cahn.cpp`.
+allen_cahn::AreaSamples run_and_sample(const allen_cahn::RunConfig &cfg) {
+  auto domain = pfc::domain::create(pfc::GridSize({cfg.nx_glob, cfg.ny_glob, 1}),
+                                    pfc::PhysicalOrigin({0.0, 0.0, 0.0}),
+                                    pfc::GridSpacing({kDx, kDx, kDx}));
+  auto decomp = pfc::decomposition::create(domain, 1);
+  const auto &local_box = pfc::decomposition::local_box(decomp, 0);
+  const auto local_size = local_box.size;
+  const int nx = local_size[0];
+  const int ny = local_size[1];
+  const int nz = local_size[2];
+  const auto nlocal = static_cast<std::size_t>(nx) * static_cast<std::size_t>(ny) *
+                      static_cast<std::size_t>(nz);
+
+  const double inv_dx2 = 1.0 / (kDx * kDx);
+  const double inv_eps2 = 1.0 / (cfg.epsilon * cfg.epsilon);
+
+  std::vector<double> u(nlocal);
+  std::vector<double> lap(nlocal);
+  allen_cahn::fill_initial_condition(&u, decomp, 0);
+
+  constexpr int halo_width = allen_cahn::RunConfig::kHaloWidth;
+  auto face = pfc::halo::allocate_face_halos<double>(decomp, 0, halo_width);
+  pfc::comm::SparseExchange<pfc::HostSpace, double> exch(
+      u.data(), u.size(), decomp, 0, MPI_COMM_WORLD, halo_width);
+
+  allen_cahn::AreaSamples areas;
+  areas.initial = allen_cahn::count_cells_above(
+      u, allen_cahn::RunConfig::kLevelSetThreshold);
+  const int step_half = cfg.n_steps / 2;
+  const int step_three_quarter = (3 * cfg.n_steps) / 4;
+
+  for (int step = 0; step < cfg.n_steps; ++step) {
+    allen_cahn::step_explicit_euler_cpu(&u, &lap, &face, &exch, nx, ny, nz, inv_dx2,
+                                        inv_dx2, cfg.dt, cfg.M, inv_eps2,
+                                        cfg.driving_force);
+    const int done = step + 1;
+    if (done == step_half) {
+      areas.half = allen_cahn::count_cells_above(
+          u, allen_cahn::RunConfig::kLevelSetThreshold);
+    }
+    if (done == step_three_quarter) {
+      areas.three_quarter = allen_cahn::count_cells_above(
+          u, allen_cahn::RunConfig::kLevelSetThreshold);
+    }
+  }
+  areas.final_ = allen_cahn::count_cells_above(
+      u, allen_cahn::RunConfig::kLevelSetThreshold);
+  return areas;
+}
+
+} // namespace
+
+TEST_CASE("equivalent_radius inverts the area of a disc",
+          "[AllenCahn][kinetics][unit]") {
+  REQUIRE_THAT(allen_cahn::equivalent_radius(0, 1.0), WithinAbs(0.0, 1e-15));
+  // A disc of radius 10 has area 100 pi; round-trip that back to 10.
+  const auto cells =
+      static_cast<std::int64_t>(std::lround(100.0 * 3.14159265358979323846));
+  REQUIRE_THAT(allen_cahn::equivalent_radius(cells, 1.0), WithinRel(10.0, 1e-3));
+  // dx scales lengths, so halving it halves the radius for the same cell count.
+  REQUIRE_THAT(allen_cahn::equivalent_radius(cells, 0.5),
+               WithinRel(0.5 * allen_cahn::equivalent_radius(cells, 1.0), 1e-12));
+}
+
+TEST_CASE("sharp-interface velocity follows (3/2) F eps sqrt(2M)",
+          "[AllenCahn][kinetics][unit]") {
+  // Shipped preset: M = 8, eps = 0.19, F = 10.
+  REQUIRE_THAT(allen_cahn::sharp_interface_velocity(8.0, 0.19, 10.0),
+               WithinRel(1.5 * 10.0 * 0.19 * 4.0, 1e-12));
+  // Linear in the driving force, so no driving force means no front.
+  REQUIRE_THAT(allen_cahn::sharp_interface_velocity(8.0, 0.19, 0.0),
+               WithinAbs(0.0, 1e-15));
+  // Interface half-width, in cells: below one the front is lattice-limited.
+  REQUIRE_THAT(allen_cahn::interface_width_cells(8.0, 0.19, 1.0),
+               WithinRel(0.76, 1e-9));
+  // The shipped preset sits just under the bistability limit — 6% of margin.
+  REQUIRE(10.0 < allen_cahn::max_bistable_driving_force(0.19));
+  REQUIRE(10.0 > 0.9 * allen_cahn::max_bistable_driving_force(0.19));
+}
+
+TEST_CASE("a run too short to measure is skipped, not failed",
+          "[AllenCahn][kinetics][unit]") {
+  allen_cahn::RunConfig cfg;
+  cfg.n_steps = 50;
+  allen_cahn::AreaSamples a;
+  a.initial = 52;
+  a.half = 60;
+  a.three_quarter = 70;
+  a.final_ = 80;
+  const auto k = allen_cahn::analyse_interface_kinetics(a, cfg, kDx);
+  REQUIRE(k.verdict == allen_cahn::CheckVerdict::Skipped);
+  REQUIRE(k.reason.find("shorter than") != std::string::npos);
+}
+
+TEST_CASE("a seed that does not grow fails the check",
+          "[AllenCahn][kinetics][unit]") {
+  allen_cahn::RunConfig cfg;
+  cfg.n_steps = 5000;
+  allen_cahn::AreaSamples a;
+  a.initial = 52;
+  a.half = 52;
+  a.three_quarter = 52;
+  a.final_ = 52;
+  const auto k = allen_cahn::analyse_interface_kinetics(a, cfg, kDx);
+  // The theory says this front should have advanced ~2.6 cells over the last
+  // half of the run. It advanced none, so this is the physics failing, not
+  // the run being too short.
+  REQUIRE(k.verdict == allen_cahn::CheckVerdict::Fail);
+  REQUIRE_THAT(k.v_late, WithinAbs(0.0, 1e-15));
+
+  // The same standstill in a run whose *predicted* advance is sub-cell is
+  // unmeasurable rather than wrong.
+  allen_cahn::RunConfig weak = cfg;
+  weak.driving_force = 0.01;
+  const auto unmeasurable = allen_cahn::analyse_interface_kinetics(a, weak, kDx);
+  REQUIRE(unmeasurable.verdict == allen_cahn::CheckVerdict::Skipped);
+
+  // A front that advances steadily, by more than a cell, but at well under
+  // half the predicted speed is a genuine failure — not a measurement floor.
+  a.half = 100;          // R = 5.642
+  a.three_quarter = 121; // R = 6.206
+  a.final_ = 144;        // R = 6.770, so dR = 1.13 cells over the last half
+  const auto slow = allen_cahn::analyse_interface_kinetics(a, cfg, kDx);
+  REQUIRE(slow.steady);
+  REQUIRE(slow.r_final - slow.r_half > allen_cahn::RunConfig::kMinMeasurableAdvanceCells);
+  REQUIRE(slow.v_late < allen_cahn::RunConfig::kVelocityBandLo * slow.v_theory);
+  REQUIRE(slow.verdict == allen_cahn::CheckVerdict::Fail);
+  REQUIRE(slow.reason.find("outside the sharp-interface band") !=
+          std::string::npos);
+}
+
+TEST_CASE("an empty seed fails rather than dividing by zero",
+          "[AllenCahn][kinetics][unit]") {
+  allen_cahn::RunConfig cfg;
+  cfg.n_steps = 5000;
+  allen_cahn::AreaSamples a;
+  const auto k = allen_cahn::analyse_interface_kinetics(a, cfg, kDx);
+  REQUIRE(k.verdict == allen_cahn::CheckVerdict::Fail);
+  REQUIRE(k.reason.find("N0 == 0") != std::string::npos);
+}
+
+TEST_CASE("the pass criterion is the same at 64^2 and 128^2",
+          "[AllenCahn][kinetics][integration]") {
+  int nproc = 1;
+  MPI_Comm_size(MPI_COMM_WORLD, &nproc);
+  REQUIRE(nproc == 1);
+
+  allen_cahn::RunConfig small;
+  small.nx_glob = 64;
+  small.ny_glob = 64;
+  allen_cahn::RunConfig large;
+  large.nx_glob = 128;
+  large.ny_glob = 128;
+
+  const auto k_small =
+      allen_cahn::analyse_interface_kinetics(run_and_sample(small), small, kDx);
+  const auto k_large =
+      allen_cahn::analyse_interface_kinetics(run_and_sample(large), large, kDx);
+
+  std::cout << "interface velocity 64^2: " << k_small.v_late
+            << "  128^2: " << k_large.v_late
+            << "  theory: " << k_small.v_theory << '\n';
+
+  // The whole point: same physics, same verdict, whatever the box size.
+  REQUIRE(k_small.verdict == allen_cahn::CheckVerdict::Pass);
+  REQUIRE(k_large.verdict == allen_cahn::CheckVerdict::Pass);
+
+  // And the measured speeds agree, which the area ratio never did (6.08 vs
+  // 3.50 for these two grids).
+  REQUIRE_THAT(k_large.v_late, WithinRel(k_small.v_late, 0.10));
+}
+
+int main(int argc, char *argv[]) {
+  MPI_Init(&argc, &argv);
+  const int result = Catch::Session().run(argc, argv);
+  MPI_Finalize();
+  return result;
+}

--- a/apps/wave2d/README.md
+++ b/apps/wave2d/README.md
@@ -30,7 +30,7 @@ summary line carries an amplitude, not an accuracy.
 | **Boundary conditions** | **Periodic in x** by MPI halo exchange; **physical in y**, either Dirichlet (`u = u_wall`, `v = 0` on the wall, imposed by an odd ghost mirror *and* by writing the owned boundary cells) or Neumann (even mirror). The y correction runs after the unconditional periodic exchange and overwrites the ghosts it produced |
 | **Initial condition** | Centred Gaussian bump in `u` with `v = 0`: `sigma = 0.12*min(Nx,Ny)`, centre `(0.5*(Nx-1), 0.5*(Ny-1))`. Each test picks its own `sigma`; there is no single canonical parameter set |
 | **Key physical parameters** | Wave speed `c = wave2d::kC = 1.0`, a compile-time constant not exposed on the command line. `u_wall` defaults to 0 and only affects Dirichlet runs. Nondimensional throughout |
-| **Observable** | `global_rms_u_interior`; `cfl_c_dt_dx`; `timing_s` / `avg_step_time_s`; optional VTK series of `u` |
+| **Observable** | `global_rms_u_interior` with the `interior_cells` count it was averaged over; `cfl_c_dt_dx`; `timing_s` / `avg_step_time_s`; optional VTK series of `u`. "Interior" is the **global** interior: a `fd_order/2`-wide shell is trimmed off each global axis that can spare one, so the z axis of this `nz == 1` slab is kept whole and the value does not depend on the rank count. A configuration whose interior is empty prints `global_rms_u_interior=undefined interior_cells=0` and exits non-zero rather than printing a `0` that means "nothing was summed" |
 | **Model maturity** | numerical verification: **manufactured** and **regression** -- RK2/RK4 temporal order is measured against a self-generated fine-timestep RK4 reference, not a closed form; the rest is a pinned CPU checksum, CPU-vs-device parity, cross-implementation parity and hand-checked boundary ghosts. There is **no analytical check** anywhere in this app. Physical completeness: **canonical** -- the constant-coefficient scalar wave equation, with no damping, no heterogeneous medium and no source. Calibration: **none** |
 
 ### What the two directions mean physically
@@ -53,7 +53,7 @@ steppers, not the binaries.
 | Target | Description |
 |--------|-------------|
 | `wave2d_fd_manual` | Second-order central stencil on `Field`, non-blocking halos, laboratory-style loop. |
-| `wave2d_fd` | Same BC model; spatial accuracy `fd_order` 2,4,…,20 via tabulated central stencils. |
+| `wave2d_fd` | Same BC model; spatial accuracy `fd_order` 2,4,…,20 via tabulated central stencils. Every advertised order runs: the halo exchange is restricted to the in-plane `±X`/`±Y` faces (`halo::presets::Axes2D()`), because a 1-thick z cannot host a `fd_order/2`-thick send slab and the Laplacian never reads `k±1` anyway. |
 | `wave2d_cuda` | Device path (optional): same positional CLI as `wave2d_fd_manual` plus optional `--vtk` / `--vtk-every`; host orchestrates halos + y-face patch, CUDA kernel for Laplacian + Euler. |
 | `wave2d_hip` | HIP analogue of `wave2d_cuda` (same CLI and VTK options). Halos use `SparseExchange<HIPSpace>` on device Fields; y-face BC patches stay on device. Rank 0 prints `WAVE2D_HIP_HALO_MODE`. |
 

--- a/apps/wave2d/include/wave2d/reporting.hpp
+++ b/apps/wave2d/include/wave2d/reporting.hpp
@@ -3,26 +3,117 @@
 
 #pragma once
 
+/**
+ * @file reporting.hpp
+ * @brief The `global_rms_u_interior` observable and its rank-0 report line.
+ *
+ * @details
+ * "Interior" here means the *global* interior: the cells left after trimming a
+ * `margin`-wide shell off each **global** axis that is thick enough to carry
+ * one. Two properties follow, and both are the point of this file.
+ *
+ * 1. A degenerate axis is never trimmed. `wave2d` is an `nz == 1` slab, so
+ *    trimming `[margin, 1 - margin)` in z leaves nothing and the reduction
+ *    silently summed zero cells — the app advertised an observable that was
+ *    identically `0` for every configuration. z is a dimension the model does
+ *    not have; excluding it from the exclusion is what "the x/y interior of a
+ *    2-D slab" means.
+ * 2. Trimming in *global* index space, not per-rank, makes the number
+ *    independent of the rank count. Trimming each rank's owned box would eat a
+ *    shell at every internal subdomain seam, so the same physics would report
+ *    a different RMS on 1 rank and on 4.
+ *
+ * `InteriorStats` carries the visited cell count alongside the sum so an empty
+ * reduction is reportable rather than indistinguishable from a field that
+ * legitimately summed to zero: `report()` prints `interior_cells=` and returns
+ * `false` when nothing was visited.
+ */
+
+#include <algorithm>
+#include <array>
 #include <cmath>
+#include <cstdint>
 #include <iostream>
 #include <mpi.h>
 #include <string>
 
+#include <openpfc/kernel/data/domain.hpp>
+#include <openpfc/kernel/data/grid_field.hpp>
 #include <openpfc_apps/mpi_report.hpp>
 #include <wave2d/cli.hpp>
 #include <wave2d/wave_model.hpp>
 
 namespace wave2d {
 
-template <class Visitor>
-void report(int rank, int nproc, const RunConfig &cfg, const char *method_tag,
-            const std::string &extra_metadata, double max_elapsed, const char *note,
-            Visitor &&visit_interior) {
-  double sum_u2 = 0.0;
-  visit_interior([&](double /*x*/, double /*y*/, double /*z*/, double u_val) {
-    sum_u2 += u_val * u_val;
-  });
-  const double g_sum = pfc::apps::reduce_sum(sum_u2, MPI_COMM_WORLD);
+/// Sum of `u^2` over the visited cells, and how many cells that was.
+struct InteriorStats {
+  double sum_sq = 0.0;
+  std::int64_t count = 0;
+};
+
+/**
+ * @brief Cells to trim off both ends of one global axis.
+ *
+ * `margin` if the axis can spare two of them and still leave a cell standing,
+ * otherwise `0`. An `nz == 1` slab therefore keeps its single z layer.
+ */
+[[nodiscard]] inline int interior_margin(int global_extent, int margin) noexcept {
+  return (global_extent > 2 * margin) ? margin : 0;
+}
+
+/**
+ * @brief This rank's contribution to the global-interior sum of `u^2`.
+ *
+ * @param u      Owned field; ghost cells are never read.
+ * @param margin Shell width to trim off each non-degenerate global axis
+ *               (the FD stencil half-width, in practice).
+ */
+template <class T>
+[[nodiscard]] inline InteriorStats
+interior_stats(const pfc::data::Field<T, pfc::HostSpace> &u, int margin) {
+  const auto gsize = pfc::domain::get_size(u.domain());
+  const auto lo = u.box().low;
+  const auto sz = u.local_size();
+
+  std::array<int, 3> begin{};
+  std::array<int, 3> end{};
+  for (int d = 0; d < 3; ++d) {
+    const int m = interior_margin(gsize[d], margin);
+    // Intersect the global interior [m, gsize-m) with this rank's owned box.
+    begin[d] = std::max(0, m - lo[d]);
+    end[d] = std::min(sz[d], gsize[d] - m - lo[d]);
+  }
+
+  InteriorStats s;
+  for (int k = begin[2]; k < end[2]; ++k) {
+    for (int j = begin[1]; j < end[1]; ++j) {
+      for (int i = begin[0]; i < end[0]; ++i) {
+        const double val = static_cast<double>(u(i, j, k));
+        s.sum_sq += val * val;
+        ++s.count;
+      }
+    }
+  }
+  return s;
+}
+
+/**
+ * @brief Print the rank-0 run summary.
+ *
+ * @param local Interior reduction for this rank (see `interior_stats`).
+ * @return `false` if the interior was empty on every rank, i.e. the observable
+ *         is not defined for this configuration. Callers should treat that as
+ *         a run failure — a printed `0` that means "nothing was summed" is the
+ *         defect this signature exists to prevent.
+ */
+[[nodiscard]] inline bool report(int rank, int nproc, const RunConfig &cfg,
+                                 const char *method_tag,
+                                 const std::string &extra_metadata,
+                                 double max_elapsed, const char *note,
+                                 const InteriorStats &local) {
+  const double g_sum = pfc::apps::reduce_sum(local.sum_sq, MPI_COMM_WORLD);
+  std::int64_t g_count = 0;
+  MPI_Allreduce(&local.count, &g_count, 1, MPI_INT64_T, MPI_SUM, MPI_COMM_WORLD);
 
   if (rank == 0) {
     const double dx = 1.0;
@@ -33,10 +124,19 @@ void report(int rank, int nproc, const RunConfig &cfg, const char *method_tag,
     if (!extra_metadata.empty()) std::cout << " " << extra_metadata;
     std::cout << "\n";
     pfc::apps::print_timing_line(std::cout, max_elapsed, cfg.n_steps);
-    const double rms_u = std::sqrt(g_sum / static_cast<double>(cfg.Nx * cfg.Ny));
-    std::cout << "global_rms_u_interior=" << rms_u << " cfl_c_dt_dx=" << cfl << " "
-              << note << "\n";
+    if (g_count == 0) {
+      std::cerr << "wave2d: interior reduction visited no cells; "
+                   "global_rms_u_interior is undefined for this configuration\n";
+      std::cout << "global_rms_u_interior=undefined interior_cells=0"
+                << " cfl_c_dt_dx=" << cfl << " " << note << "\n";
+    } else {
+      const double rms_u = std::sqrt(g_sum / static_cast<double>(g_count));
+      std::cout << "global_rms_u_interior=" << rms_u
+                << " interior_cells=" << g_count << " cfl_c_dt_dx=" << cfl << " "
+                << note << "\n";
+    }
   }
+  return g_count > 0;
 }
 
 inline std::string fd_extra_metadata(const RunConfig &cfg) {

--- a/apps/wave2d/src/cpu/wave2d_fd.cpp
+++ b/apps/wave2d/src/cpu/wave2d_fd.cpp
@@ -66,7 +66,14 @@ int run_fd(const RunConfig &cfg, int rank, int nproc) {
   pfc::data::Field<double, pfc::HostSpace> lap =
       pfc::data::field_from_subdomain<double>(decomp, rank, hw);
 
-  comm::HaloExchange<HostSpace, double> halo_u(u, decomp, rank, MPI_COMM_WORLD);
+  // The slab is nz == 1 and the Laplacian never reads k+/-1, so the +/-Z faces
+  // carry nothing. Saying so is not an optimisation: a 1-thick owned z extent
+  // cannot host an hw-thick send slab, and demanding that it could is what
+  // used to abort every fd_order > 2 run before its first step.
+  comm::HaloExchangeOptions halo_opt;
+  halo_opt.directions = pfc::halo::presets::Axes2D();
+  comm::HaloExchange<HostSpace, double> halo_u(u, decomp, rank, MPI_COMM_WORLD,
+                                               halo_opt);
 
   const double inv_den = 1.0 / static_cast<double>(stencil.denom);
   const double sx = model.inv_dx2 * inv_den;
@@ -143,21 +150,11 @@ int run_fd(const RunConfig &cfg, int rank, int nproc) {
   }
   const double max_elapsed = runtime::toc(timer);
 
-  const int skip = hw;
-  const auto local_size = u.local_size();
-  wave2d::report(rank, nproc, cfg, "fd", wave2d::fd_extra_metadata(cfg), max_elapsed,
-                 "(runtime FD order; y physical BC; interior RMS u)",
-                 [&](auto &&cb) {
-                   for (int k = skip; k < local_size[2] - skip; ++k) {
-                     for (int j = skip; j < local_size[1] - skip; ++j) {
-                       for (int i = skip; i < local_size[0] - skip; ++i) {
-                         const auto p = u.coords(i, j, k);
-                         cb(p[0], p[1], p[2], u(i, j, k));
-                       }
-                     }
-                   }
-                 });
-  return EXIT_SUCCESS;
+  const bool observable_ok =
+      wave2d::report(rank, nproc, cfg, "fd", wave2d::fd_extra_metadata(cfg),
+                     max_elapsed, "(runtime FD order; y physical BC; interior RMS u)",
+                     wave2d::interior_stats(u, hw));
+  return observable_ok ? EXIT_SUCCESS : EXIT_FAILURE;
 }
 
 } // namespace

--- a/apps/wave2d/src/cpu/wave2d_fd_manual.cpp
+++ b/apps/wave2d/src/cpu/wave2d_fd_manual.cpp
@@ -37,7 +37,7 @@ using wave2d::YBoundaryKind;
 
 namespace {
 
-void run_fd_manual(const RunConfig &cfg, int rank, int nproc) {
+int run_fd_manual(const RunConfig &cfg, int rank, int nproc) {
   WaveModel model;
   model.inv_dx2 = 1.0;
   model.inv_dy2 = 1.0;
@@ -114,19 +114,11 @@ void run_fd_manual(const RunConfig &cfg, int rank, int nproc) {
   }
   const double max_elapsed = runtime::toc(timer);
 
-  const auto u_sz = u.local_size();
-  const int skip = hw;
-  wave2d::report(rank, nproc, cfg, "fd_manual", "manual 5-point + padded halos",
-                 max_elapsed, "(y physical BC; interior RMS u)", [&](auto &&cb) {
-                   for (int k = skip; k < u_sz[2] - skip; ++k) {
-                     for (int j = skip; j < u_sz[1] - skip; ++j) {
-                       for (int i = skip; i < u_sz[0] - skip; ++i) {
-                         const auto p = u.coords(i, j, k);
-                         cb(p[0], p[1], p[2], u(i, j, k));
-                       }
-                     }
-                   }
-                 });
+  const bool observable_ok =
+      wave2d::report(rank, nproc, cfg, "fd_manual", "manual 5-point + padded halos",
+                     max_elapsed, "(y physical BC; interior RMS u)",
+                     wave2d::interior_stats(u, hw));
+  return observable_ok ? EXIT_SUCCESS : EXIT_FAILURE;
 }
 
 } // namespace
@@ -137,7 +129,6 @@ int main(int argc, char **argv) {
         const auto cfg =
             wave2d::parse_manual_or_print_usage(app_argc, app_argv, rank);
         if (!cfg) return EXIT_FAILURE;
-        run_fd_manual(*cfg, rank, nproc);
-        return EXIT_SUCCESS;
+        return run_fd_manual(*cfg, rank, nproc);
       });
 }

--- a/apps/wave2d/tests/test_wave2d.cpp
+++ b/apps/wave2d/tests/test_wave2d.cpp
@@ -28,12 +28,15 @@
 #include <openpfc/kernel/decomposition/halo_face_layout.hpp>
 #include <openpfc/kernel/decomposition/stage_preparation.hpp>
 #include <openpfc/kernel/field/brick_iteration.hpp>
+#include <openpfc/kernel/field/fd_apply.hpp>
+#include <openpfc/kernel/field/fd_stencils.hpp>
 #include <openpfc/kernel/field/field_factory.hpp>
 #include <openpfc/kernel/simulation/checkpoint_service.hpp>
 #include <openpfc/kernel/simulation/simulation_state.hpp>
 #include <openpfc/kernel/simulation/time.hpp>
 
 #include <wave2d/cli.hpp>
+#include <wave2d/reporting.hpp>
 #include <wave2d/wave_boundary.hpp>
 #include <wave2d/wave_model.hpp>
 #include <wave2d/wave_step_separated.hpp>
@@ -470,6 +473,205 @@ TEST_CASE("wave2d CPU golden matches CPU-vs-CUDA config",
   REQUIRE_THAT(sumsq_u, WithinRel(28.256988690744471, 1e-10));
   REQUIRE_THAT(sum_v, WithinAbs(0.0018563899833072017, 1e-12));
   REQUIRE_THAT(sumsq_v, WithinAbs(0.0042855033181676445, 1e-12));
+}
+
+// ---------------------------------------------------------------------------
+// Defect: `global_rms_u_interior` was identically 0 for every configuration.
+// The interior visitor trimmed the FD half-width off *every* axis of *every*
+// rank's owned box. z has one layer, so `[hw, 1 - hw)` is empty and the
+// reduction summed nothing — a printed `0` that meant "no cells", not "the
+// field is zero". These pin both halves of the fix: the slab's z axis is not
+// trimmed, and the trim happens in global index space so the answer does not
+// depend on how many ranks the run used.
+// ---------------------------------------------------------------------------
+
+TEST_CASE("interior_margin leaves a degenerate axis alone", "[wave2d][reporting]") {
+  REQUIRE(wave2d::interior_margin(64, 2) == 2);
+  REQUIRE(wave2d::interior_margin(5, 2) == 2);
+  // 2*margin would consume the whole axis: trim nothing rather than everything.
+  REQUIRE(wave2d::interior_margin(4, 2) == 0);
+  REQUIRE(wave2d::interior_margin(1, 2) == 0);
+  REQUIRE(wave2d::interior_margin(1, 1) == 0);
+}
+
+TEST_CASE("interior reduction is non-empty on the nz==1 slab wave2d runs",
+          "[wave2d][reporting]") {
+  int nproc = 1;
+  MPI_Comm_size(MPI_COMM_WORLD, &nproc);
+  if (nproc != 1) return;
+
+  constexpr int Nx = 16;
+  constexpr int Ny = 16;
+  constexpr int hw = 2; // fd_order 4
+  auto domain = pfc::domain::create(pfc::GridSize({Nx, Ny, 1}),
+                                    pfc::PhysicalOrigin({0.0, 0.0, 0.0}),
+                                    pfc::GridSpacing({1.0, 1.0, 1.0}));
+  auto decomp = pfc::decomposition::create(domain, 1);
+  auto u = pfc::data::field_from_subdomain<double>(decomp, 0, hw);
+  u.apply([](double, double, double) { return 1.0; });
+
+  const auto s = wave2d::interior_stats(u, hw);
+  // x and y lose a 2-cell shell at each end; the single z layer is kept.
+  REQUIRE(s.count == static_cast<std::int64_t>(Nx - 2 * hw) * (Ny - 2 * hw));
+  REQUIRE(s.count > 0);
+  REQUIRE_THAT(std::sqrt(s.sum_sq / static_cast<double>(s.count)),
+               WithinAbs(1.0, 1e-15));
+}
+
+TEST_CASE("interior reduction does not change with the rank count",
+          "[wave2d][reporting]") {
+  // `interior_stats` is rank-local, so a multi-rank decomposition can be
+  // summed here without any MPI traffic. Trimming each rank's *owned* box
+  // instead of the global one would eat a shell at every subdomain seam and
+  // make this sum shrink as ranks are added.
+  constexpr int Nx = 24;
+  constexpr int Ny = 16;
+  constexpr int hw = 2;
+  auto domain = pfc::domain::create(pfc::GridSize({Nx, Ny, 1}),
+                                    pfc::PhysicalOrigin({0.0, 0.0, 0.0}),
+                                    pfc::GridSpacing({1.0, 1.0, 1.0}));
+  const auto seed = [](double x, double y, double) {
+    return 1.0 + 0.25 * x - 0.5 * y;
+  };
+
+  auto decomp1 = pfc::decomposition::create(domain, 1);
+  auto u1 = pfc::data::field_from_subdomain<double>(decomp1, 0, hw);
+  u1.apply(seed);
+  const auto single = wave2d::interior_stats(u1, hw);
+  REQUIRE(single.count == static_cast<std::int64_t>(Nx - 2 * hw) * (Ny - 2 * hw));
+
+  for (int ranks : {2, 4}) {
+    auto decompN = pfc::decomposition::create(domain, ranks);
+    wave2d::InteriorStats total;
+    for (int r = 0; r < ranks; ++r) {
+      auto ur = pfc::data::field_from_subdomain<double>(decompN, r, hw);
+      ur.apply(seed);
+      const auto s = wave2d::interior_stats(ur, hw);
+      total.sum_sq += s.sum_sq;
+      total.count += s.count;
+    }
+    INFO("ranks = " << ranks);
+    REQUIRE(total.count == single.count);
+    REQUIRE_THAT(total.sum_sq, WithinRel(single.sum_sq, 1e-12));
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Defect: `wave2d_fd` advertised even fd_order 2..20 and aborted at order 4
+// with "owned extents 64x64x1 cannot host halo_width=2 owned send slabs".
+// The +/-Z faces of an nz==1 slab carry nothing the Laplacian reads, so the
+// exchanger should not demand that z be able to host a send slab.
+// ---------------------------------------------------------------------------
+
+TEST_CASE("fd_order > 2 halo exchange constructs on an nz==1 slab",
+          "[wave2d][halo]") {
+  int rank = 0;
+  int nproc = 1;
+  MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+  MPI_Comm_size(MPI_COMM_WORLD, &nproc);
+  if (nproc != 1) return;
+
+  constexpr int Nx = 64;
+  constexpr int Ny = 64;
+  auto domain = pfc::domain::create(pfc::GridSize({Nx, Ny, 1}),
+                                    pfc::PhysicalOrigin({0.0, 0.0, 0.0}),
+                                    pfc::GridSpacing({1.0, 1.0, 1.0}));
+  auto decomp = pfc::decomposition::create(domain, 1);
+
+  comm::HaloExchangeOptions in_plane;
+  in_plane.directions = pfc::halo::presets::Axes2D();
+
+  // Every advertised order, not just the one that used to work.
+  for (int fd_order = 2; fd_order <= 20; fd_order += 2) {
+    pfc::field::fd::EvenCentralD2View stencil{};
+    INFO("fd_order = " << fd_order);
+    REQUIRE(pfc::field::fd::lookup_even_central_d2(fd_order, &stencil));
+    auto u = pfc::data::field_from_subdomain<double>(decomp, rank,
+                                                     stencil.half_width);
+    REQUIRE_NOTHROW(comm::HaloExchange<HostSpace, double>(u, decomp, rank,
+                                                           MPI_COMM_WORLD,
+                                                           in_plane));
+  }
+
+  // Asking for +/-Z on a 1-thick z is still an error, and still says why.
+  auto u4 = pfc::data::field_from_subdomain<double>(decomp, rank, 2);
+  REQUIRE_THROWS_AS((comm::HaloExchange<HostSpace, double>(u4, decomp, rank,
+                                                            MPI_COMM_WORLD)),
+                    std::invalid_argument);
+}
+
+TEST_CASE("fd_order 4 steps the 2-D slab and reports a finite interior RMS",
+          "[wave2d][integration]") {
+  int rank = 0;
+  int nproc = 1;
+  MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+  MPI_Comm_size(MPI_COMM_WORLD, &nproc);
+  if (nproc != 1) return;
+
+  constexpr int Nx = 32;
+  constexpr int Ny = 32;
+  constexpr int n_steps = 20;
+  constexpr double dt = 0.01;
+
+  pfc::field::fd::EvenCentralD2View stencil{};
+  REQUIRE(pfc::field::fd::lookup_even_central_d2(4, &stencil));
+  const int hw = stencil.half_width;
+  REQUIRE(hw == 2);
+
+  auto domain = pfc::domain::create(pfc::GridSize({Nx, Ny, 1}),
+                                    pfc::PhysicalOrigin({0.0, 0.0, 0.0}),
+                                    pfc::GridSpacing({1.0, 1.0, 1.0}));
+  auto decomp = pfc::decomposition::create(domain, 1);
+  auto u = pfc::data::field_from_subdomain<double>(decomp, rank, hw);
+  auto v = pfc::data::field_from_subdomain<double>(decomp, rank, hw);
+  auto lap = pfc::data::field_from_subdomain<double>(decomp, rank, hw);
+
+  comm::HaloExchangeOptions in_plane;
+  in_plane.directions = pfc::halo::presets::Axes2D();
+  comm::HaloExchange<HostSpace, double> halo_u(u, decomp, rank, MPI_COMM_WORLD,
+                                               in_plane);
+
+  const double xc = 0.5 * (Nx - 1);
+  const double yc = 0.5 * (Ny - 1);
+  const double sigma = 0.12 * std::min(Nx, Ny);
+  u.apply([&](double x, double y, double) {
+    const double dxc = x - xc;
+    const double dyc = y - yc;
+    return std::exp(-(dxc * dxc + dyc * dyc) / (2.0 * sigma * sigma));
+  });
+  v.apply([](double, double, double) { return 0.0; });
+
+  const double inv_den = 1.0 / static_cast<double>(stencil.denom);
+  const auto sy_stride = static_cast<std::ptrdiff_t>(u.padded_extent(0));
+  const auto sz_stride = static_cast<std::ptrdiff_t>(u.padded_extent(0)) *
+                         static_cast<std::ptrdiff_t>(u.padded_extent(1));
+
+  for (int step = 0; step < n_steps; ++step) {
+    halo_u.exchange();
+    wave2d::fill_y_physical_ghosts_padded(u, wave2d::YBoundaryKind::Dirichlet, Ny,
+                                          0.0);
+    u.for_each_owned([&](int i, int j, int k) {
+      const double *core = u.data();
+      const auto c = static_cast<std::ptrdiff_t>(u.idx(i, j, k));
+      const double dxx = pfc::field::fd::apply_d2_along<0>(stencil, core, c, 1,
+                                                            sy_stride, sz_stride);
+      const double dyy = pfc::field::fd::apply_d2_along<1>(stencil, core, c, 1,
+                                                            sy_stride, sz_stride);
+      lap(i, j, k) = inv_den * (dxx + dyy);
+    });
+    u.for_each_owned([&](int i, int j, int k) {
+      const double v0 = v(i, j, k);
+      u(i, j, k) += dt * v0;
+      v(i, j, k) += dt * wave2d::kC * wave2d::kC * lap(i, j, k);
+    });
+    wave2d::enforce_dirichlet_y_walls_owned(u, v, Ny, 0.0);
+  }
+
+  const auto s = wave2d::interior_stats(u, hw);
+  REQUIRE(s.count == static_cast<std::int64_t>(Nx - 2 * hw) * (Ny - 2 * hw));
+  const double rms = std::sqrt(s.sum_sq / static_cast<double>(s.count));
+  REQUIRE(std::isfinite(rms));
+  REQUIRE(rms > 0.0);
 }
 
 int main(int argc, char *argv[]) {

--- a/include/openpfc/frontend/io/vtk_writer.hpp
+++ b/include/openpfc/frontend/io/vtk_writer.hpp
@@ -121,6 +121,19 @@ public:
   void set_spacing(const std::array<double, 3> &spacing);
 
   /**
+   * @brief Set origin and spacing in one call (`ResultsWriter` hook)
+   *
+   * Lets `pfc::apply_writer_domain` push the run's real `Domain` geometry into
+   * the `.vti` header without every session having to remember to call
+   * `set_origin` / `set_spacing` itself.
+   */
+  void set_geometry(const std::array<double, 3> &origin,
+                    const std::array<double, 3> &spacing) override {
+    set_origin(origin);
+    set_spacing(spacing);
+  }
+
+  /**
    * @brief Set field name for VTK output
    */
   void set_field_name(const std::string &name) { m_field_name = name; }

--- a/include/openpfc/kernel/decomposition/comm_halo_exchange.hpp
+++ b/include/openpfc/kernel/decomposition/comm_halo_exchange.hpp
@@ -145,14 +145,24 @@ public:
     const int ny = m_subdomain_box.size[1];
     const int nz = m_subdomain_box.size[2];
 
-    m_face_types = halo::create_padded_face_types_6(
-        nx, ny, nz, m_halo_width, exchange::detail::get_mpi_type<T>());
-
-    // Compute neighbors from decomposition
+    // Resolve the active slots *before* building MPI types: a thin axis
+    // (nz == 1 under Axes2D) cannot host an hw-thick send slab, and there is
+    // no reason to demand that it could when no message ever travels along
+    // it. Building only the active slots is what lets a 2-D slab app run at
+    // fd_order > 2.
     const std::array<Int3, 6> dirs_canon = {
         {{1, 0, 0}, {-1, 0, 0}, {0, 1, 0}, {0, -1, 0}, {0, 0, 1}, {0, 0, -1}}};
     for (std::size_t i = 0; i < 6; ++i) {
       m_active[i] = m_dirs.contains(dirs_canon[i]);
+    }
+
+    m_face_types =
+        halo::create_padded_face_types_6(nx, ny, nz, m_halo_width,
+                                         exchange::detail::get_mpi_type<T>(),
+                                         m_active);
+
+    // Compute neighbors from decomposition
+    for (std::size_t i = 0; i < 6; ++i) {
       m_neighbors.push_back(
           decomposition::get_neighbor_rank(decomp, m_rank, dirs_canon[i]));
     }

--- a/include/openpfc/kernel/decomposition/padded_halo_mpi_types.hpp
+++ b/include/openpfc/kernel/decomposition/padded_halo_mpi_types.hpp
@@ -100,18 +100,28 @@ inline int checked_padded_extent(int n, int hw) {
  * appropriate `(hw, ...)` offsets baked into the start vectors.
  *
  * When `halo_width > 0`, each owned extent must be `>= halo_width` so the
- * owned send slab fits inside the core. Same per-axis fit rule as
- * non-padded `create_face_types_6`. The Field `> 2*hw` interior rule
- * does **not** apply here (`pfc::data::Field` with equal storage and
- * iteration halo).
+ * owned send slab fits inside the core — but only along an axis that
+ * actually exchanges. An axis whose two face slots are switched off in
+ * @p active carries no slab and is therefore never measured against
+ * `halo_width`; that is what lets an `Axes2D()` exchanger run on an
+ * `nz == 1` slab with `hw > 1` (a 2-D app raising its FD order). The
+ * Field `> 2*hw` interior rule does **not** apply here
+ * (`pfc::data::Field` with equal storage and iteration halo).
+ *
+ * @param active Per-slot switch in the canonical order +X, -X, +Y, -Y,
+ *        +Z, -Z. Inactive slots are neither validated nor built and come
+ *        back default-constructed (`MPI_DATATYPE_NULL`); the caller must
+ *        not post them. Defaults to all six.
  *
  * @throws std::invalid_argument if `halo_width < 0`, owned extents are
- *         non-positive, or (when `halo_width > 0`) any owned axis is
- *         `< halo_width`
+ *         non-positive, or (when `halo_width > 0`) an owned axis with an
+ *         active face is `< halo_width`
  */
 inline std::array<FaceTypes, 6>
 create_padded_face_types_6(int nx, int ny, int nz, int halo_width,
-                           MPI_Datatype element_type) {
+                           MPI_Datatype element_type,
+                           const std::array<bool, 6> &active = {true, true, true,
+                                                                true, true, true}) {
   if (halo_width < 0) {
     throw std::invalid_argument(
         "pfc::halo::create_padded_face_types_6: halo_width must be "
@@ -125,12 +135,24 @@ create_padded_face_types_6(int nx, int ny, int nz, int halo_width,
         std::to_string(nx) + "x" + std::to_string(ny) + "x" + std::to_string(nz) +
         ")");
   }
-  if (halo_width > 0 && (nx < halo_width || ny < halo_width || nz < halo_width)) {
-    throw std::invalid_argument(
-        std::string("pfc::halo::create_padded_face_types_6: owned extents ") +
-        std::to_string(nx) + "x" + std::to_string(ny) + "x" + std::to_string(nz) +
-        " cannot host halo_width=" + std::to_string(halo_width) +
-        " owned send slabs (need >= halo_width points per owned dimension)");
+  if (halo_width > 0) {
+    // Slot i sits on axis i/2, so an axis is only load-bearing when at
+    // least one of its two slots is active.
+    const std::array<int, 3> extent = {nx, ny, nz};
+    for (int slot = 0; slot < 6; ++slot) {
+      const auto s = static_cast<std::size_t>(slot);
+      if (!active[s] || extent[static_cast<std::size_t>(slot / 2)] >= halo_width) {
+        continue;
+      }
+      throw std::invalid_argument(
+          std::string("pfc::halo::create_padded_face_types_6: owned extents ") +
+          std::to_string(nx) + "x" + std::to_string(ny) + "x" + std::to_string(nz) +
+          " cannot host halo_width=" + std::to_string(halo_width) +
+          " owned send slabs on axis " + std::to_string(slot / 2) +
+          " (need >= halo_width points per exchanging owned dimension; drop "
+          "that axis from the halo direction set if the stencil never reads "
+          "it, e.g. Axes2D() for an nz == 1 slab)");
+    }
   }
 
   const int hw = halo_width;

--- a/include/openpfc/kernel/simulation/results_writer.hpp
+++ b/include/openpfc/kernel/simulation/results_writer.hpp
@@ -227,6 +227,30 @@ public:
                           const std::array<int, 3> &arr_offset) = 0;
 
   /**
+   * @brief Configure the physical geometry of the grid
+   *
+   * `set_domain()` says how many cells there are and who owns which; this
+   * says how big a cell is and where the grid starts. Formats that record
+   * physical coordinates need both — a `.vti` whose `Spacing` does not match
+   * the run's `dx` renders at the wrong scale in ParaView, and every length
+   * measured off it is wrong by the same factor.
+   *
+   * The default is a deliberate no-op so that index-only sinks
+   * (`BinaryWriter`, in-memory writers) need not implement it. Override it
+   * wherever the file format has a place to put the numbers.
+   *
+   * @param[in] origin Physical coordinate of global grid index (0, 0, 0)
+   * @param[in] spacing Physical cell size along each axis
+   *
+   * @see pfc::apply_writer_domain - forwards `Domain` geometry to both calls
+   */
+  virtual void set_geometry(const std::array<double, 3> &origin,
+                            const std::array<double, 3> &spacing) {
+    (void)origin;
+    (void)spacing;
+  }
+
+  /**
    * @brief Write a real-valued field to file at specified time step
    *
    * Writes the local portion of a real field view (double precision) to the output

--- a/include/openpfc/kernel/simulation/results_writer_domain.hpp
+++ b/include/openpfc/kernel/simulation/results_writer_domain.hpp
@@ -13,6 +13,13 @@
  * the field's geometry (`Domain` + owned `Box3i`), not from an FFT inbox;
  * prefer the `Field` overload so the writer and the data it receives share one
  * geometry source.
+ *
+ * The `Domain` also carries the physical spacing and origin, and those are
+ * forwarded too. They used to be dropped, so every `.vti` written through a
+ * JSON session claimed `Spacing="1 1 1"` no matter what `dx` the run used —
+ * invisible for the `dx = 1` presets and wrong by 4x for a `dx = 0.25` one.
+ * Geometry that the writer already knows how to record should not have to be
+ * set a second time by hand at every call site.
  */
 
 #include <array>
@@ -30,6 +37,10 @@ inline void apply_writer_domain(ResultsWriter &writer, const Domain &domain,
   writer.set_domain({gs[0], gs[1], gs[2]},
                     {owned.size[0], owned.size[1], owned.size[2]},
                     {owned.low[0], owned.low[1], owned.low[2]});
+  const auto origin = domain::get_origin(domain);
+  const auto spacing = domain::get_spacing(domain);
+  writer.set_geometry({origin[0], origin[1], origin[2]},
+                      {spacing[0], spacing[1], spacing[2]});
 }
 
 template <typename T, typename MemorySpace = HostSpace>

--- a/tests/unit/frontend/io/test_vtk_writer.cpp
+++ b/tests/unit/frontend/io/test_vtk_writer.cpp
@@ -7,7 +7,11 @@
 #include <catch2/matchers/catch_matchers_floating_point.hpp>
 
 #include <openpfc/frontend/io/vtk_writer.hpp>
+#include <openpfc/kernel/data/box3i.hpp>
+#include <openpfc/kernel/data/domain.hpp>
+#include <openpfc/kernel/data/grid_field.hpp>
 #include <openpfc/kernel/mpi/mpi.hpp>
+#include <openpfc/kernel/simulation/results_writer_domain.hpp>
 
 #include <algorithm>
 #include <cmath>
@@ -1007,4 +1011,63 @@ TEST_CASE("test_vtk_writer_complexfield_collective_error_agreement",
   // ALL ranks should throw std::runtime_error due to collective error agreement
   // This verifies that the collective error agreement prevents deadlock
   REQUIRE_THROWS_AS(writer.write(1, data), std::runtime_error);
+}
+
+// ---------------------------------------------------------------------------
+// Defect: `pfc::apply_writer_domain` set only the index geometry, so every
+// `.vti` written through a JSON session claimed `Spacing="1 1 1"` whatever the
+// run's dx was. Harmless at dx = 1, wrong by 4x for a dx = 0.25 run — and the
+// error is invisible in the file, which just renders at the wrong scale.
+// ---------------------------------------------------------------------------
+TEST_CASE("apply_writer_domain writes the run's spacing and origin into the .vti",
+          "[vtk_writer][io][geometry]") {
+  VTKWriterTestFixture fixture;
+
+  if (fixture.m_num_ranks > 1) {
+    SKIP("Geometry forwarding test requires single MPI rank");
+  }
+
+  constexpr int n = 4;
+  auto domain = pfc::domain::create(pfc::GridSize({n, n, n}),
+                                    pfc::PhysicalOrigin({-1.5, -1.5, -1.5}),
+                                    pfc::GridSpacing({0.25, 0.25, 0.25}));
+  const pfc::Box3i owned = pfc::Box3i::from_bounds({0, 0, 0}, {n - 1, n - 1, n - 1});
+
+  VTKWriter writer("test_domain_spacing_0001.vti");
+  pfc::apply_writer_domain(writer, domain, owned);
+
+  auto data = fixture.create_test_data(static_cast<std::size_t>(n * n * n));
+  writer.write(1, data);
+
+  REQUIRE(fixture.file_exists("test_domain_spacing_0001.vti"));
+  REQUIRE(fixture.file_contains("test_domain_spacing_0001.vti",
+                                "Spacing=\"0.25 0.25 0.25\""));
+  REQUIRE(fixture.file_contains("test_domain_spacing_0001.vti",
+                                "Origin=\"-1.5 -1.5 -1.5\""));
+}
+
+TEST_CASE("apply_writer_domain forwards Field geometry too",
+          "[vtk_writer][io][geometry]") {
+  VTKWriterTestFixture fixture;
+
+  if (fixture.m_num_ranks > 1) {
+    SKIP("Geometry forwarding test requires single MPI rank");
+  }
+
+  constexpr int n = 4;
+  auto domain = pfc::domain::create(pfc::GridSize({n, n, n}),
+                                    pfc::PhysicalOrigin({0.0, 0.0, 0.0}),
+                                    pfc::GridSpacing({0.5, 0.5, 0.5}));
+  const pfc::Box3i owned = pfc::Box3i::from_bounds({0, 0, 0}, {n - 1, n - 1, n - 1});
+  pfc::data::Field<double> field(domain, owned, 0);
+
+  VTKWriter writer("test_field_spacing_0001.vti");
+  pfc::apply_writer_domain(writer, field);
+
+  auto data = fixture.create_test_data(static_cast<std::size_t>(n * n * n));
+  writer.write(1, data);
+
+  REQUIRE(fixture.file_exists("test_field_spacing_0001.vti"));
+  REQUIRE(fixture.file_contains("test_field_spacing_0001.vti",
+                                "Spacing=\"0.5 0.5 0.5\""));
 }

--- a/tests/unit/kernel/simulation/test_results_writer_domain.cpp
+++ b/tests/unit/kernel/simulation/test_results_writer_domain.cpp
@@ -19,7 +19,10 @@ public:
   std::array<int, 3> global{};
   std::array<int, 3> local{};
   std::array<int, 3> offset{};
+  std::array<double, 3> origin{};
+  std::array<double, 3> spacing{};
   bool set = false;
+  bool geometry_set = false;
 
   void set_domain(const std::array<int, 3> &arr_global,
                   const std::array<int, 3> &arr_local,
@@ -29,6 +32,12 @@ public:
     offset = arr_offset;
     set = true;
   }
+  void set_geometry(const std::array<double, 3> &arr_origin,
+                    const std::array<double, 3> &arr_spacing) override {
+    origin = arr_origin;
+    spacing = arr_spacing;
+    geometry_set = true;
+  }
   MPI_Status write(int, pfc::field::FieldView<double>) override { return MPI_Status{}; }
   MPI_Status write(int, pfc::field::FieldView<std::complex<double>>) override { return MPI_Status{}; }
 };
@@ -37,9 +46,11 @@ public:
 
 TEST_CASE("apply_writer_domain uses Domain and owned Box3i",
           "[simulation][io][unit]") {
+  // Non-unit spacing and a shifted origin: the geometry a `dx = 1` run
+  // cannot distinguish from the writer's defaults.
   auto domain = pfc::domain::create(pfc::GridSize({16, 8, 4}),
-                                    pfc::PhysicalOrigin({0.0, 0.0, 0.0}),
-                                    pfc::GridSpacing({1.0, 1.0, 1.0}));
+                                    pfc::PhysicalOrigin({-2.0, 0.5, 7.0}),
+                                    pfc::GridSpacing({0.25, 0.5, 2.0}));
   const pfc::Box3i owned = pfc::Box3i::from_bounds({4, 0, 0}, {11, 7, 3});
   RecordingWriter writer;
   pfc::apply_writer_domain(writer, domain, owned);
@@ -47,12 +58,15 @@ TEST_CASE("apply_writer_domain uses Domain and owned Box3i",
   REQUIRE(writer.global == std::array<int, 3>{16, 8, 4});
   REQUIRE(writer.local == std::array<int, 3>{8, 8, 4});
   REQUIRE(writer.offset == std::array<int, 3>{4, 0, 0});
+  REQUIRE(writer.geometry_set);
+  REQUIRE(writer.origin == std::array<double, 3>{-2.0, 0.5, 7.0});
+  REQUIRE(writer.spacing == std::array<double, 3>{0.25, 0.5, 2.0});
 }
 
 TEST_CASE("apply_writer_domain uses Field geometry", "[simulation][io][unit]") {
   auto domain = pfc::domain::create(pfc::GridSize({8, 8, 8}),
                                     pfc::PhysicalOrigin({0.0, 0.0, 0.0}),
-                                    pfc::GridSpacing({1.0, 1.0, 1.0}));
+                                    pfc::GridSpacing({0.125, 0.125, 0.125}));
   const pfc::Box3i owned = pfc::Box3i::from_bounds({0, 0, 0}, {7, 7, 7});
   pfc::data::Field<double> field(domain, owned, 0);
   RecordingWriter writer;
@@ -61,4 +75,6 @@ TEST_CASE("apply_writer_domain uses Field geometry", "[simulation][io][unit]") {
   REQUIRE(writer.global == std::array<int, 3>{8, 8, 8});
   REQUIRE(writer.local == std::array<int, 3>{8, 8, 8});
   REQUIRE(writer.offset == std::array<int, 3>{0, 0, 0});
+  REQUIRE(writer.geometry_set);
+  REQUIRE(writer.spacing == std::array<double, 3>{0.125, 0.125, 0.125});
 }


### PR DESCRIPTION
Four defects surfaced by running the shipped presets for the report figures.
Branched off `origin/master`. Nothing under `docs/report/` is touched.

Built and tested on a LUMI login node, single rank, no allocation:
`./scripts/build.sh --machine=lumi --cpu --no-submit --no-test --jobs=16
--cmake-arg=-DOpenPFC_BUILD_TESTS=ON`.

`ctest` on the login node: 44 of 52 pass. The 8 that do not are the
`srun -n {2,4}` suites (`tungsten-golden-4rank`, `aluminum-golden-4rank`,
`cahn-hilliard-mpi-tests`, `higher-order-pfc-mpi-tests`,
`tungsten-moving-restart-2rank`, `halo-microtiming-host-2rank`,
`cahn-hilliard-diagnostics-workflow`, `environment_error_handling`); every one
of them fails with `srun: error: Unable to allocate resources`, none of them
with an assertion. I did not call `salloc` or `sbatch`. The `srun -n 1`
suites were run directly instead: `test_vtk_writer` 58/58, `test_binary_writer`
142/142, `test_png_writer` 2/2, plus the whole `openpfc-tests` binary. Every
suite named in the task passes: `wave2d-all-tests`, `wave2d-cpu-golden`,
`wave2d-operator-evaluation`, `wave2d-rhs-pattern`, `wave2d-rk-convergence`,
`allen-cahn-cpu-golden`, `allen-cahn-interface-kinetics`,
`results_writer_domain` and the VTK writer suite. **Those 8 still need a
multi-rank run before merge.**

---

## 1. `wave2d`'s advertised observable was identically zero

**What was wrong.** `global_rms_u_interior` printed `0` for every
configuration on both CPU drivers. The interior visitor in
`wave2d_fd.cpp` / `wave2d_fd_manual.cpp` trimmed the stencil half-width off
each axis of each rank's owned box; the app is an `nz == 1` slab, so
`[hw, 1 - hw)` in z is empty and the reduction visited no cells. An empty sum
and a genuinely zero field printed the same thing.

**How I know.** Baseline binary:

```
$ ./wave2d_fd 64 64 50 0.01 2 dirichlet
global_rms_u_interior=0 cfl_c_dt_dx=0.01
$ ./wave2d_fd_manual 64 64 50 0.01 dirichlet
global_rms_u_interior=0 cfl_c_dt_dx=0.01
```

**What I changed.** The reduction moved out of the two drivers into
`wave2d::interior_stats` in `apps/wave2d/include/wave2d/reporting.hpp`, with
two properties it did not have:

* an axis is trimmed only if it can spare two margins and still leave a cell,
  so the slab's single z layer is kept. "Interior" for a 2-D slab is the x/y
  interior, which is the natural reading;
* the trim happens in **global** index space intersected with the rank's owned
  box, not per rank. Trimming each owned box ate a shell at every internal
  subdomain seam, so the same physics reported a different RMS on 1 rank and
  on 4. It no longer does.

`InteriorStats` carries the visited count next to the sum, `report()` returns
`false` when the global count is zero, and both drivers propagate that to the
exit status. The run line now prints `interior_cells=`, and an empty interior
prints `global_rms_u_interior=undefined interior_cells=0` and exits non-zero —
a reduction that summed nothing is no longer indistinguishable from one that
summed to zero.

After:

```
$ ./wave2d_fd 64 64 50 0.01 2 dirichlet
global_rms_u_interior=0.219101 interior_cells=3844 cfl_c_dt_dx=0.01
$ ./wave2d_fd_manual 64 64 50 0.01 dirichlet
global_rms_u_interior=0.219101 interior_cells=3844 cfl_c_dt_dx=0.01
```

The two drivers agreeing to the last digit is the cross-check this observable
was supposed to provide.

**Test.** `[reporting]` in `apps/wave2d/tests/test_wave2d.cpp`, three cases:
`interior_margin` leaves a degenerate axis alone; the reduction over the
`nz == 1` slab visits `(Nx-2hw)*(Ny-2hw)` cells and gives RMS 1 for a field of
ones; and the sum of the per-rank stats over 2- and 4-rank decompositions
equals the 1-rank answer exactly. **Seen to fail first:** with
`interior_margin` reverted to trimming unconditionally, 3 of 3 cases fail
(the count is 0). With the trim done per-rank instead of globally, the
rank-independence case fails.

**Report/README statements this invalidates.**

* `apps/wave2d/README.md` "Observable" row — updated here; the observable now
  also reports `interior_cells`, is defined as the *global* interior, and is
  rank-count independent.
* Any chapter text quoting a `global_rms_u_interior` value for `wave2d`: every
  previously recorded value was `0` and every new one is not.
* Note for the chapter: the trimmed shell is the stencil half-width, so
  `interior_cells` differs between FD orders (3844 at order 2, 3600 at order 4,
  1936 at order 20 for `64x64`). Comparing the RMS across orders compares
  slightly different regions; the count is now printed so that is visible.

---

## 2. `wave2d_fd` advertised even FD orders 2–20 and only order 2 ran

**What was wrong.** Order 4 aborted before the first step:

```
$ ./wave2d_fd 64 64 50 0.01 4 dirichlet
pfc::halo::create_padded_face_types_6: owned extents 64x64x1 cannot host
halo_width=2 owned send slabs (need >= halo_width points per owned dimension)
MPI_Abort(MPI_COMM_WORLD, 1)
```

A 1-thick owned z extent cannot provide a 2-thick send slab. It was never
asked to — the Laplacian reads x and y only — but the face-type builder
validated all three axes regardless of the direction set, contradicting its
own documented contract in `halo_mpi_types.hpp` ("orthogonal thin axes
(e.g. `nz == 1` for Axes2D) remain valid") and the `Axes2D()` preset's own
docstring ("use for fields whose `nz == 1`").

**Which option I chose and why.** I made the higher orders work rather than
rejecting them at parse time. The obstacle was one over-broad validation, not
the numerics: the y-ghost fill (`fill_y_physical_ghosts_padded`) was already
general in the halo width and mirrors every ghost row correctly, so nothing
else stood between the app and the accuracy its usage line promised. Rejecting
2–20 would have removed a capability the library already claims to support.

**What I changed.** `create_padded_face_types_6` takes an active-slot mask
(defaulting to all six, so existing callers are unaffected) and builds and
validates only the slots that will carry a message; slot `i` lives on axis
`i/2`, so an axis is measured against `halo_width` only when one of its two
slots is active. `HostFacesHalo` resolves `m_active` before asking for the
types instead of after. `wave2d_fd` asks for `halo::presets::Axes2D()`.
`wave2d_fd_manual` is left alone (`hw = 1`, so nothing was broken and it is a
parity reference).

All ten advertised orders now run; order 20 on `64x64x50` gives
`global_rms_u_interior=0.308716 interior_cells=1936`.

**Test.** `[halo]` in `test_wave2d.cpp`: constructs the exchanger at every
advertised order 2–20 on a `64x64x1` slab and requires no throw, still
requires that asking for `Axes3D` on a 1-thick z throws `invalid_argument`,
and separately steps a `32x32x1` slab 20 times at order 4 and requires a
finite, non-zero interior RMS over the full expected cell count. **Seen to
fail first:** with the per-slot check reverted to the old unconditional
three-axis rule (`active` ignored), the case fails on the first order above 2.

**Report/README statements this invalidates.**

* `apps/wave2d/README.md` binaries table — updated here to say the exchange is
  restricted to the in-plane faces and why.
* Any chapter statement that `wave2d_fd` is effectively second-order-only, or
  that the `fd_order` argument is aspirational. It is not any more.

---

## 3. No `.vti` written through the JSON session carried the run's spacing

**What was wrong.** `pfc::apply_writer_domain` called only the three-argument
`set_domain` — global size, local size, offset — and dropped the physical
geometry the `Domain` was carrying right next to it, even though
`VTKWriter::set_spacing` / `set_origin` existed and every hand-written call
site (`examples/11`, `examples/12`, `wave2d/vtk_snapshot.hpp`) already used
them. Every session-written file therefore said `Spacing="1 1 1"`.

**How I know.** `apply_writer_domain`'s body had no geometry call at all; its
two callers are `json_spectral_etd_session.hpp` and
`gradient_elasticity_session.hpp`, so both were affected. Harmless where
`dx == 1`, wrong by 4x for a `dx = 0.25` run, and invisible in the file — the
page just renders at the wrong scale.

**Whether anything depended on the wrong value.** Checked before changing it:
no `.vti` or `.pvti` golden files are committed anywhere in the tree, and the
only two `Spacing=` assertions in the suite
(`tests/unit/frontend/io/test_vtk_writer.cpp:331,729`) call `set_spacing`
themselves and are unaffected. `docs/report/figures/field_io.py` *reads*
`Spacing`, so it was reading the wrong number; that file is not touched here.

**What I changed.** `ResultsWriter` gains a virtual
`set_geometry(origin, spacing)` with a no-op default, so index-only sinks such
as `BinaryWriter` need not implement it; `VTKWriter` overrides it as
`set_origin` + `set_spacing`; `apply_writer_domain` forwards
`domain::get_origin` / `domain::get_spacing`.

**Test.** Two `[geometry]` cases in `test_vtk_writer.cpp` write a real `.vti`
through `apply_writer_domain` — one from a `Domain` + `Box3i` at `dx = 0.25`
with origin `(-1.5,-1.5,-1.5)`, one from a `Field` at `dx = 0.5` — and read
the header back. `test_results_writer_domain.cpp` also records the geometry
calls and its two existing cases now use non-unit spacing, so a `dx = 1`
domain can no longer hide the bug behind the writer's defaults. **Seen to fail
first:** with the two forwarding lines removed, both `[geometry]` cases fail
(`Spacing="1 1 1"` in the file).

**Report/README statements this invalidates.**

* Any chapter statement about `.vti` output geometry, and any figure caption
  that quotes a physical length read off a session-written `.vti` for a run
  with `dx != 1`. Files written *before* this change still carry
  `Spacing="1 1 1"` and must be regenerated before their lengths are trusted.

---

## 4. `allen_cahn`'s pass criterion was grid-dependent and doubled as the exit status

**What was wrong.** The check required the superlevel area to reach 5x its
initial value. The seed radius scales with the grid
(`sigma = 0.055*min(nx,ny)`) but the interface speed does not, so
`((R0 + v t)/R0)^2` shrinks as the box grows.

**How I know.** Baseline binary, default parameters, 5000 steps:

| grid | `N1/N0` | old verdict |
|---|---|---|
| 64² | 6.077 | PASS |
| 128² | 3.500 | FAIL |
| 256² | 2.546 | FAIL |

Same physics, three verdicts. The exit status was that verdict, so a
deliberately short run also "failed".

**What I changed.** The criterion is now the interface velocity `dR/dt`, with
`R = sqrt(A/pi)` the equivalent radius of the same superlevel area, measured
over the **second half** of the run and compared with the sharp-interface
solvability result `v = (3/2) F eps sqrt(2M)` (derivation in the docstring of
`sharp_interface_velocity`).

The second half, not the whole run, because the Gaussian initial condition is
far from the equilibrium `tanh` and its collapse moves the contour by a
distance that scales with the seed — a whole-run average inherits exactly the
grid dependence the area ratio had. Measured over the last half instead:

| grid | `v_late` | `v_theory` | verdict |
|---|---|---|---|
| 64² | 12.46 | 11.4 | PASS |
| 128² | 12.43 | 11.4 | PASS |
| 256² | 13.11 | 11.4 | PASS |

The area is sampled at `t = 0, t/2, 3t/4, t`; the two quarter velocities must
agree to 25% before `v_late` is judged, so a run that has not reached steady
propagation reports `SKIPPED` rather than a number it cannot support.

The accepted band is a factor of two either way rather than a percentage,
which is deliberate and documented: the shipped preset's interface is
`eps*sqrt(2M) = 0.76` cells wide — under one grid spacing — so the front is
lattice-limited rather than continuum-limited and sits tens of percent off the
continuum law (`+11%` at the defaults, `-35%` at `driving_force = 5`). A
factor of two still separates "a front propagates at roughly the predicted
speed" from no growth, the wrong sign, and the whole box flipping.

**Verdict and exit status are now separate.** The run prints
`physics_check=PASS|FAIL|SKIPPED (reason)` and exits 0 whenever the run
finished. `--strict` opts back in to letting a `FAIL` (never a `SKIPPED`) set
the exit status.

**Test.** New `allen-cahn-interface-kinetics` ctest — the app previously had
none that ran the criterion at all. Unit cases cover `equivalent_radius`,
`sharp_interface_velocity`, `interface_width_cells`, the bistability limit,
and each verdict branch (too-short run → SKIPPED; a stalled front that was
predicted to move → FAIL; a steady front at under half the predicted speed →
FAIL; an empty seed → FAIL). The headline integration case runs the shipped
update at 64² and 128² and requires the same verdict and speeds within 10%
(they agree to 0.3%). **Seen to fail first:** with the criterion replaced by
the old `N1 >= 5*N0` rule, the integration case fails on the 128² verdict.

**Report/README statements this invalidates.** `apps/allen_cahn/README.md` is
updated here; for the chapter:

* the observable is no longer "`N1/N0`, used as the exit status"; it is
  `dR/dt` against a sharp-interface prediction, and the exit status no longer
  carries it;
* "The 5x criterion is a coarse growth check, not a measurement of interface
  velocity" is gone — it now is one;
* "no ctest runs this binary" is still true of the binary, but the criterion
  is now covered by a ctest;
* the model-maturity row said "no analytical or manufactured-solution check
  anywhere in this app". There is now a (loose) analytical one.

---

## Two things worse than described

* **The `allen_cahn` preset sits 6% below the bistability limit.** A front
  exists only while `F eps^2 < 2/(3 sqrt 3) = 0.3849`. The shipped
  `F = 10, eps = 0.19` gives `0.361`. Cross it — `driving_force = 20`, or
  `epsilon = 0.3` — and there is no metastable `phi < 0` phase at all: the
  whole domain decays. Both of those settings flip all 16384 cells of a 128²
  box, which the *old* criterion scored as `N1/N0 = 75.85`, "PASS". The app
  now prints the limit and says when it is crossed.
* **The `allen_cahn` interface is not resolved.** `eps*sqrt(2M) = 0.76` cells.
  Everything this app reports is lattice-limited, which is why the velocity
  band has to be as loose as it is. The app now prints the width and warns.
  Worth a sentence in the chapter: the model is canonical, the discretisation
  of it is not converged.
