### PR TITLE
docs(report): scaling to 16 nodes and a spectral-vs-FD comparison

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,27 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 
 ### Added
 
+- Scaling to 16 nodes, and a spectral-versus-finite-difference comparison, in
+  the scalability chapter. Weak scaling of `tungsten_hip` at exactly 67.1 M
+  cells per GCD from 1 to 16 nodes, ending on 8.59 billion cells at 49.6%
+  efficiency -- the curve is flat inside a node (95.6% at 2), pays ~30 points
+  crossing onto the fabric, then loses only 15 more over a further 4x in
+  ranks. Strong scaling at 1280^3 reaches 82% at 16 nodes, against a 768^3
+  curve that fell below 50% by four; the earlier curves were grid-limited, not
+  code-limited. A 12-node point sits at 38% because 1280/96 = 13.33 and
+  OpenPFC decomposes into z-slabs -- a 10-node run (1280/80 = 16 exactly) was
+  added to test that and lands back on the curve at 84.1%, so the rule is to
+  pick a rank count that divides the slab axis. 2048^3 is recorded as needing
+  at least 16 nodes: it was OOM-killed host-side at 32, 64 and 96 GCDs.
+  For heat3d, the only app with both solvers on one PDE: at equal grid the
+  spectral step costs 32x a second-order FD step and 8.7x a twelfth-order one,
+  yet all three strong-scale to 80-85% at 16 nodes, so parallel efficiency is
+  not a reason to prefer either in this range. The chapter deliberately
+  declines to turn cost, scaling and accuracy into a single verdict: the
+  convergence study evolves one smooth Fourier mode, the most favourable case
+  a high-order stencil can get, and that ranking does not transfer to fields
+  with content near the grid scale.
+
 - Field figures for the two application chapters that had none, rendered from
   real single-rank runs of the shipped science presets: `07_surface_diffusion`
   gets the isotropic-against-anisotropic nanosurface anneal (the same crossed

--- a/docs/report/16_scalability.qmd
+++ b/docs/report/16_scalability.qmd
@@ -145,28 +145,182 @@ that is a different PDE with a different operator and a different amount of
 work per step.
 :::
 
-## Where the curves stop being useful
+## Where the 768³ curves stop being useful
 
 All three fall below 50% efficiency by 24–32 GCDs. At $768^3$ on 32 GCDs each
 rank holds roughly $14$ million cells, and for the spectral models the
 transpose has become a substantial share of the step.
 
-The practical readings are:
+That is a statement about the grid, not about the code. The sections below
+repeat the exercise at grids large enough to keep 16 nodes busy, and the
+curves look quite different.
 
-* **Up to one node (8 GCDs)** every model is worth the resources.
-* **Two to four nodes** remain worthwhile for the largest grids, especially for
-  the FD path.
-* **Beyond that**, at these grid sizes, further ranks buy progressively less.
-  Extending the curve is better spent on a larger grid — weak scaling — than on
-  more ranks at fixed size.
+## Sixteen nodes {#sec-scal-16n}
+
+Two studies at 128 GCDs, both on `tungsten_hip`, both with I/O off and
+`wall_step` taken as the median over accepted steps after five warm-up steps,
+using the **slowest rank** at each step — a step is not finished until every
+rank is, so a mean across ranks would flatter an imbalanced run.
+
+### Weak scaling: constant work per GCD {#sec-scal-weak}
+
+The local block is held at exactly $2048\times2048\times16$ cells — 67.1
+million per GCD — and $L_z$ grows with the rank count. OpenPFC decomposes into
+$z$-slabs, so growing only $L_z$ keeps the local shape *exactly* constant
+rather than approximately; a cubic ladder would need $N\propto P^{1/3}$ and
+land on non-power-of-two transform sizes with unequal local blocks. The final
+point is $2048^3$: **8.59 billion cells on 16 nodes**.
+
+| nodes | GCDs | grid | wall/step | weak efficiency |
+|---|---|---|---|---|
+| 1 | 8 | $2048^2\times128$ | 204.5 ms | 100% |
+| 2 | 16 | $2048^2\times256$ | 214.1 ms | 95.6% |
+| 4 | 32 | $2048^2\times512$ | 315.9 ms | 64.7% |
+| 8 | 64 | $2048^2\times1024$ | 398.1 ms | 51.4% |
+| 16 | 128 | $2048^3$ | 412.4 ms | **49.6%** |
+
+![Weak scaling of the tungsten PFC model to 16 nodes at constant 67.1 M cells
+per GCD. Perfect weak scaling is the flat dashed line. The cost is paid almost
+entirely between 2 and 4 nodes, where the all-to-all leaves the node and enters
+the fabric; from 4 to 16 nodes a further $4\times$ in ranks costs only 15
+percentage points.](figures/tungsten_weak_16n.svg){#fig-weak-16n}
+
+The shape is more informative than the endpoint. Inside one node the transpose
+is nearly free (95.6% at 2 nodes). Crossing onto the interconnect costs about
+30 percentage points in one step. After that the curve is almost flat —
+64.7% → 51.4% → 49.6% while the rank count quadruples — which is the
+behaviour a distributed FFT should have once its all-to-all is already
+inter-node.
+
+### Strong scaling, and a divisibility trap {#sec-scal-strong16}
+
+Fixed $1280^3$, 4 → 16 nodes.
+
+| nodes | GCDs | $z$-planes per rank | wall/step | speedup | efficiency |
+|---|---|---|---|---|---|
+| 4 | 32 | 40 | 296.8 ms | 1.00× | 100% |
+| 8 | 64 | 20 | 174.5 ms | 1.70× | 85.0% |
+| 10 | 80 | 16 | 141.2 ms | 2.10× | 84.1% |
+| 12 | 96 | **13.33** | 258.7 ms | 1.15× | **38.3%** |
+| 16 | 128 | 10 | 90.5 ms | 3.28× | **82.0%** |
+
+![Strong scaling at $1280^3$. Filled points are rank counts that divide the
+1280 $z$-planes evenly; the hollow point is the one that does not. Twelve
+nodes is slower than eight *and* than ten — the same problem runs 1.8× faster
+on 10 nodes than on 12.](figures/tungsten_strong_1280.svg){#fig-strong-1280}
+
+**82% efficiency at 16 nodes** over a $4\times$ range in ranks, against a
+$768^3$ curve that fell below 50% by four nodes. The model was simply too
+small before.
+
+The 12-node point is not noise. $1280 = 2^8\cdot5$ divides 32, 64, 80 and 128
+exactly, giving 40, 20, 16 and 10 planes per rank, but $1280/96 = 13.33$: some
+ranks get 13 planes and some 14, and every step waits for the slowest. The
+10-node run was added specifically to test that explanation — $1280/80 = 16$
+exactly — and it lands back on the curve at 84.1%. **On a slab-decomposed
+spectral code, choose a rank count that divides the slab axis.** It is worth
+more than a node.
+
+### A memory boundary worth knowing {#sec-scal-memory}
+
+$2048^3$ **cannot run below 16 nodes at all.** The strong-scaling ladder was
+first attempted at that size and was OOM-killed at 32, 64 and 96 GCDs,
+surviving only at 128. The kill is host-side rather than device-side: sampled
+`MaxRSS` per task was 6.7–7.1 GB for the runs that died against 5.5 GB for the
+one that lived, which points at a transient spike during transform setup that
+the sampler does not catch. The practical rule from the sizing sweep is about
+115 bytes per cell for this stack, and roughly 67 million cells per GCD is the
+largest that reliably fits — which is exactly the weak-scaling design point
+above.
+
+## Spectral against finite difference {#sec-scal-methods}
+
+@sec-heat3d is the one application carrying both a spectral and a
+finite-difference solver for the same PDE, with a GPU twin of each and a
+runtime `fd_order`. That makes it the only place in this report where the two
+methods can be compared without changing anything else.
+
+![Left: what one step costs on the same grid and hardware, the only difference
+being the spatial operator. Right: how each method strong-scales to 16 nodes.
+The panels answer different questions — cheap per step is not the same as
+cheap per unit accuracy.](figures/heat3d_method_comparison.svg){#fig-method-comparison}
+
+### Cost at equal grid
+
+$1024^3$ on one node:
+
+| method | wall/step | relative to FD-2 |
+|---|---|---|
+| FD, order 2 | 6.73 ms | 1.0× |
+| FD, order 4 | 11.46 ms | 1.7× |
+| FD, order 6 | 15.01 ms | 2.2× |
+| FD, order 8 | 18.64 ms | 2.8× |
+| FD, order 12 | 24.69 ms | 3.7× |
+| **spectral** | **213.82 ms** | **31.8×** |
+
+Finite-difference cost grows roughly linearly in stencil width, as the flop
+count and halo depth do. The spectral step costs 32 times a second-order step
+and still 8.7 times a twelfth-order one, which is the price of two global
+transforms and the all-to-all between them.
+
+### Scaling at equal grid
+
+$1536^3$, 4 → 16 nodes. $1536 = 2^9\cdot3$ divides 32, 64, 96 and 128 exactly,
+so the divisibility effect of @sec-scal-strong16 cannot contaminate this
+comparison.
+
+| method | 4 nodes | 8 | 12 | 16 | efficiency at 16 |
+|---|---|---|---|---|---|
+| spectral | 283.4 ms | 168.0 | 112.8 | 85.0 | 83.3% |
+| FD-2 | 5.91 ms | 2.99 | 2.11 | 1.73 | **85.3%** |
+| FD-8 | 15.66 ms | 8.45 | 6.07 | 4.86 | 80.5% |
+
+The expected result was that the spectral all-to-all would scale visibly worse
+than a local stencil. **It does not.** All three land within five percentage
+points of each other at 16 nodes. At $1536^3$ on 128 GCDs each rank still
+holds 28 million cells, so the transpose has not yet become the dominant term;
+the crossover where it would is beyond the range measured here. FD-8 scales
+slightly *worse* than FD-2, which is the wider halo showing up.
+
+### Accuracy, and why the three axes do not combine into a verdict
+
+@sec-heat3d's convergence study measures the third axis: every design order
+from 2 to 12 recovers its order, and the spectral operator is exact to
+round-off for a resolved smooth field.
+
+It is tempting to combine the three into a single recommendation, and the
+arithmetic looks decisive. Taking the measured error constants and asking what
+grid each method needs for an $L^2$ error of $10^{-6}$: FD-2 needs $N=2445$
+and 92 ms per step, FD-4 needs $N=129$ and 0.02 ms, while spectral reaches
+round-off at $N=1024$ for 214 ms. On that basis high-order finite differences
+win by orders of magnitude.
+
+**That comparison should not be trusted as a general result.** The convergence
+study evolves a *single Fourier mode* — the smoothest field there is, and the
+most favourable possible case for a high-order stencil, whose error constant
+depends on derivatives the mode simply does not have. It says nothing about a
+PFC crystal carrying real content at $2k_0$ and $3k_0$ (@sec-tungsten-dealias),
+or a dendrite tip, or a rupturing film. For fields with content near the grid
+scale the required resolution, and therefore the ranking, changes.
+
+What the measurements do support, without qualification:
+
+* At **equal grid**, finite differences are one to two orders of magnitude
+  cheaper per step, and higher order costs roughly linearly in stencil width.
+* At **equal grid**, both methods strong-scale to 16 nodes at 80–85%, so
+  parallel efficiency is not a reason to prefer one over the other in this
+  range.
+* **Which is cheaper for a given accuracy depends on the spectral content of
+  the solution**, and this report measures that only for a single smooth mode.
+  A broadband-field version of the same study is the obvious next measurement.
 
 ## Coverage and gaps
 
 | Application | Scaling measured |
 |---|---|
-| @sec-tungsten | **Yes** — 1–32 GCDs, $768^3$ |
-| @sec-heat3d (spectral HIP) | **Yes** — 1–32 GCDs, $768^3$ |
-| @sec-heat3d (FD HIP) | **Yes** — 1–32 GCDs, $512^3$ |
+| @sec-tungsten | **Yes** — strong 1–128 GCDs ($768^3$, $1280^3$); weak 8–128 GCDs to $2048^3$ |
+| @sec-heat3d (spectral HIP) | **Yes** — 1–32 GCDs ($768^3$); 32–128 GCDs ($1536^3$) |
+| @sec-heat3d (FD HIP) | **Yes** — 1–32 GCDs ($512^3$); 32–128 GCDs ($1536^3$, orders 2 and 8) |
 | @sec-aluminum | No |
 | @sec-cahn-hilliard, @sec-thin-film, @sec-surface-diffusion, @sec-kawahara, @sec-ehd-film | No |
 | @sec-higher-order-pfc | No — CPU/GPU agreement checked at 1 and 2 GCDs only |
@@ -177,8 +331,18 @@ The unmeasured spectral applications share the ETD stack with @sec-tungsten
 and would be expected to behave similarly at equal grid size, but that
 expectation has not been tested and no curve is claimed for them.
 
-Two gaps are worth naming explicitly. There is **no LUMI-C CPU control**, so
-the report cannot say what the GPU path buys over CPU at equal node count. And
-there is **no weak-scaling study**: every curve here holds the problem fixed,
-which is the harder test but not the one that matters for running a bigger
-simulation.
+The weak-scaling gap this section used to name is now closed
+(@sec-scal-weak): the tungsten model is measured to 16 nodes at constant work
+per GCD, ending on 8.59 billion cells.
+
+Three gaps remain, named explicitly:
+
+* There is **no LUMI-C CPU control**, so the report still cannot say what the
+  GPU path buys over CPU at equal node count.
+* The **method comparison is accuracy-limited to a single smooth mode**
+  (@sec-scal-methods). Cost at equal grid and scaling at equal grid are
+  measured; cost at equal accuracy for a broadband field is not.
+* The **memory boundary is characterised but not diagnosed**
+  (@sec-scal-memory). $2048^3$ is known to need 16 nodes, and the failure is
+  known to be host-side, but the transient allocation responsible has not been
+  traced.

--- a/docs/report/data/heat3d_method_cost.csv
+++ b/docs/report/data/heat3d_method_cost.csv
@@ -1,0 +1,11 @@
+# Cost per step at equal grid, heat3d on LUMI-G, N=1024, 8 GCDs (one node),
+# 25 steps, dt=0.01 (2026-09-10). Same PDE, same grid, same hardware: the only
+# difference is the spatial operator. fd_order 0 denotes the spectral path.
+# wall_step_ms is the median over accepted steps after 5 warm-up.
+method,fd_order,job,wall_step_ms
+spectral,0,21887744,213.82
+fd,2,21887745,6.73
+fd,4,21887746,11.46
+fd,6,21887747,15.01
+fd,8,21887748,18.64
+fd,12,21887749,24.69

--- a/docs/report/data/heat3d_method_strong_1536.csv
+++ b/docs/report/data/heat3d_method_strong_1536.csv
@@ -1,0 +1,17 @@
+# Strong scaling by method, heat3d on LUMI-G standard-g, 1536^3, 25 steps
+# (2026-09-10). 1536 = 2^9 * 3 divides 32, 64, 96 and 128 exactly, so the
+# divisibility effect seen in the tungsten curve cannot contaminate this
+# comparison. fd_order 0 denotes the spectral path.
+method,fd_order,gcds,nodes,job,wall_step_ms
+spectral,0,32,4,21887758,283.38
+spectral,0,64,8,21887762,167.96
+spectral,0,96,12,21887765,112.83
+spectral,0,128,16,21887768,85.01
+fd,2,32,4,21887760,5.91
+fd,2,64,8,21887763,2.99
+fd,2,96,12,21887766,2.11
+fd,2,128,16,21887769,1.73
+fd,8,32,4,21887761,15.66
+fd,8,64,8,21887764,8.45
+fd,8,96,12,21887767,6.07
+fd,8,128,16,21887770,4.86

--- a/docs/report/data/tungsten_hip_strong_1280.csv
+++ b/docs/report/data/tungsten_hip_strong_1280.csv
@@ -1,0 +1,11 @@
+# Strong scaling, tungsten_hip, 1280^3, LUMI-G standard-g, 25 steps (2026-09-10).
+# 1280 = 2^8 * 5. It divides 32, 64, 80 and 128 exactly (40, 20, 16 and 10
+# z-planes per rank) but not 96 (13.33), and OpenPFC decomposes into z-slabs.
+# The 96-GCD point is kept because that is the finding: the same problem runs
+# 1.8x faster on 10 nodes than on 12.
+gcds,nodes,job,planes_per_rank,divides,wall_step_ms
+32,4,21887398,40,1,296.83
+64,8,21887399,20,1,174.51
+80,10,21887750,16,1,141.19
+96,12,21887400,13.33,0,258.67
+128,16,21887401,10,1,90.49

--- a/docs/report/data/tungsten_hip_weak_16n.csv
+++ b/docs/report/data/tungsten_hip_weak_16n.csv
@@ -1,0 +1,12 @@
+# Weak scaling, tungsten_hip, LUMI-G standard-g, 25 steps, dt=1 (2026-09-10).
+# Constant local block: 2048 x 2048 x 16 planes per GCD, so Lz = 16 * gcds.
+# The last point (2048^3 on 128 GCDs) is the same problem strong scaling ends
+# on; the two studies meet there and agree to 1.1%.
+# wall_step_ms is the median over accepted steps after 5 warm-up, taking the
+# slowest rank per step.
+gcds,nodes,job,lx,ly,lz,cells_per_rank,wall_step_ms
+8,1,21886645,2048,2048,128,67108864,204.55
+16,2,21886646,2048,2048,256,67108864,214.08
+32,4,21886648,2048,2048,512,67108864,315.92
+64,8,21886649,2048,2048,1024,67108864,398.06
+128,16,21886650,2048,2048,2048,67108864,412.39

--- a/docs/report/figures/heat3d_method_comparison.svg
+++ b/docs/report/figures/heat3d_method_comparison.svg
@@ -1,0 +1,2022 @@
+<?xml version="1.0" encoding="utf-8" standalone="no"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN"
+  "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="611.000781pt" height="295.528781pt" viewBox="0 0 611.000781 295.528781" xmlns="http://www.w3.org/2000/svg" version="1.1">
+ <metadata>
+  <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+   <cc:Work>
+    <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
+    <dc:date>2026-09-10T16:41:06.995625</dc:date>
+    <dc:format>image/svg+xml</dc:format>
+    <dc:creator>
+     <cc:Agent>
+      <dc:title>Matplotlib v3.11.1, https://matplotlib.org/</dc:title>
+     </cc:Agent>
+    </dc:creator>
+   </cc:Work>
+  </rdf:RDF>
+ </metadata>
+ <defs>
+  <style type="text/css">*{stroke-linejoin: round; stroke-linecap: butt}</style>
+ </defs>
+ <g id="figure_1">
+  <g id="patch_1">
+   <path d="M 0 295.528781 
+L 611.000781 295.528781 
+L 611.000781 0 
+L 0 0 
+z
+" style="fill: #ffffff"/>
+  </g>
+  <g id="axes_1">
+   <g id="patch_2">
+    <path d="M 45.800781 257.328 
+L 299.437145 257.328 
+L 299.437145 24.48 
+L 45.800781 24.48 
+z
+" style="fill: #ffffff"/>
+   </g>
+   <g id="matplotlib.axis_1">
+    <g id="xtick_1">
+     <g id="line2d_1">
+      <path d="M 57.329707 257.328 
+L 57.329707 24.48 
+" clip-path="url(#p588fc3669c)" style="fill: none; stroke: #d5d8dc; stroke-width: 0.6; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_2">
+      <defs>
+       <path id="mcc3d023c21" d="M 0 0 
+L 0 3.5 
+" style="stroke: #000000; stroke-width: 0.8"/>
+      </defs>
+      <g>
+       <use xlink:href="#mcc3d023c21" x="57.329707" y="257.328" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_1">
+      <!-- 2 -->
+      <g transform="translate(54.148457 271.925656) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-15" d="M 1228 531 
+L 3431 531 
+L 3431 0 
+L 469 0 
+L 469 531 
+Q 828 903 1448 1529 
+Q 2069 2156 2228 2338 
+Q 2531 2678 2651 2914 
+Q 2772 3150 2772 3378 
+Q 2772 3750 2511 3984 
+Q 2250 4219 1831 4219 
+Q 1534 4219 1204 4116 
+Q 875 4013 500 3803 
+L 500 4441 
+Q 881 4594 1212 4672 
+Q 1544 4750 1819 4750 
+Q 2544 4750 2975 4387 
+Q 3406 4025 3406 3419 
+Q 3406 3131 3298 2873 
+Q 3191 2616 2906 2266 
+Q 2828 2175 2409 1742 
+Q 1991 1309 1228 531 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-15"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_2">
+     <g id="line2d_3">
+      <path d="M 103.445409 257.328 
+L 103.445409 24.48 
+" clip-path="url(#p588fc3669c)" style="fill: none; stroke: #d5d8dc; stroke-width: 0.6; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_4">
+      <g>
+       <use xlink:href="#mcc3d023c21" x="103.445409" y="257.328" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_2">
+      <!-- 4 -->
+      <g transform="translate(100.264159 271.925656) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-17" d="M 2419 4116 
+L 825 1625 
+L 2419 1625 
+L 2419 4116 
+z
+M 2253 4666 
+L 3047 4666 
+L 3047 1625 
+L 3713 1625 
+L 3713 1100 
+L 3047 1100 
+L 3047 0 
+L 2419 0 
+L 2419 1100 
+L 313 1100 
+L 313 1709 
+L 2253 4666 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-17"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_3">
+     <g id="line2d_5">
+      <path d="M 149.561112 257.328 
+L 149.561112 24.48 
+" clip-path="url(#p588fc3669c)" style="fill: none; stroke: #d5d8dc; stroke-width: 0.6; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_6">
+      <g>
+       <use xlink:href="#mcc3d023c21" x="149.561112" y="257.328" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_3">
+      <!-- 6 -->
+      <g transform="translate(146.379862 271.925656) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-19" d="M 2113 2584 
+Q 1688 2584 1439 2293 
+Q 1191 2003 1191 1497 
+Q 1191 994 1439 701 
+Q 1688 409 2113 409 
+Q 2538 409 2786 701 
+Q 3034 994 3034 1497 
+Q 3034 2003 2786 2293 
+Q 2538 2584 2113 2584 
+z
+M 3366 4563 
+L 3366 3988 
+Q 3128 4100 2886 4159 
+Q 2644 4219 2406 4219 
+Q 1781 4219 1451 3797 
+Q 1122 3375 1075 2522 
+Q 1259 2794 1537 2939 
+Q 1816 3084 2150 3084 
+Q 2853 3084 3261 2657 
+Q 3669 2231 3669 1497 
+Q 3669 778 3244 343 
+Q 2819 -91 2113 -91 
+Q 1303 -91 875 529 
+Q 447 1150 447 2328 
+Q 447 3434 972 4092 
+Q 1497 4750 2381 4750 
+Q 2619 4750 2861 4703 
+Q 3103 4656 3366 4563 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-19"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_4">
+     <g id="line2d_7">
+      <path d="M 195.676814 257.328 
+L 195.676814 24.48 
+" clip-path="url(#p588fc3669c)" style="fill: none; stroke: #d5d8dc; stroke-width: 0.6; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_8">
+      <g>
+       <use xlink:href="#mcc3d023c21" x="195.676814" y="257.328" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_4">
+      <!-- 8 -->
+      <g transform="translate(192.495564 271.925656) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-1b" d="M 2034 2216 
+Q 1584 2216 1326 1975 
+Q 1069 1734 1069 1313 
+Q 1069 891 1326 650 
+Q 1584 409 2034 409 
+Q 2484 409 2743 651 
+Q 3003 894 3003 1313 
+Q 3003 1734 2745 1975 
+Q 2488 2216 2034 2216 
+z
+M 1403 2484 
+Q 997 2584 770 2862 
+Q 544 3141 544 3541 
+Q 544 4100 942 4425 
+Q 1341 4750 2034 4750 
+Q 2731 4750 3128 4425 
+Q 3525 4100 3525 3541 
+Q 3525 3141 3298 2862 
+Q 3072 2584 2669 2484 
+Q 3125 2378 3379 2068 
+Q 3634 1759 3634 1313 
+Q 3634 634 3220 271 
+Q 2806 -91 2034 -91 
+Q 1263 -91 848 271 
+Q 434 634 434 1313 
+Q 434 1759 690 2068 
+Q 947 2378 1403 2484 
+z
+M 1172 3481 
+Q 1172 3119 1398 2916 
+Q 1625 2713 2034 2713 
+Q 2441 2713 2670 2916 
+Q 2900 3119 2900 3481 
+Q 2900 3844 2670 4047 
+Q 2441 4250 2034 4250 
+Q 1625 4250 1398 4047 
+Q 1172 3844 1172 3481 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-1b"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_5">
+     <g id="line2d_9">
+      <path d="M 287.908219 257.328 
+L 287.908219 24.48 
+" clip-path="url(#p588fc3669c)" style="fill: none; stroke: #d5d8dc; stroke-width: 0.6; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_10">
+      <g>
+       <use xlink:href="#mcc3d023c21" x="287.908219" y="257.328" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_5">
+      <!-- 12 -->
+      <g transform="translate(281.545719 271.925656) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-14" d="M 794 531 
+L 1825 531 
+L 1825 4091 
+L 703 3866 
+L 703 4441 
+L 1819 4666 
+L 2450 4666 
+L 2450 531 
+L 3481 531 
+L 3481 0 
+L 794 0 
+L 794 531 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-14"/>
+       <use xlink:href="#DejaVuSans-15" transform="translate(63.625 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="text_6">
+     <!-- finite-difference order -->
+     <g transform="translate(118.047869 285.926437) scale(0.1 -0.1)">
+      <defs>
+       <path id="DejaVuSans-13af" d="M 3431 3500 
+L 3431 0 
+L 2853 0 
+L 2853 3053 
+L 1275 3053 
+L 1275 0 
+L 697 0 
+L 697 3053 
+L 147 3053 
+L 147 3500 
+L 697 3500 
+L 697 3744 
+Q 697 4316 967 4589 
+Q 1238 4863 1797 4863 
+L 2375 4863 
+L 2375 4384 
+L 1825 4384 
+Q 1516 4384 1395 4259 
+Q 1275 4134 1275 3809 
+L 1275 3500 
+L 3431 3500 
+z
+M 2853 4856 
+L 3431 4856 
+L 3431 4128 
+L 2853 4128 
+L 2853 4856 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-51" d="M 3513 2113 
+L 3513 0 
+L 2938 0 
+L 2938 2094 
+Q 2938 2591 2744 2837 
+Q 2550 3084 2163 3084 
+Q 1697 3084 1428 2787 
+Q 1159 2491 1159 1978 
+L 1159 0 
+L 581 0 
+L 581 3500 
+L 1159 3500 
+L 1159 2956 
+Q 1366 3272 1645 3428 
+Q 1925 3584 2291 3584 
+Q 2894 3584 3203 3211 
+Q 3513 2838 3513 2113 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-4c" d="M 603 3500 
+L 1178 3500 
+L 1178 0 
+L 603 0 
+L 603 3500 
+z
+M 603 4863 
+L 1178 4863 
+L 1178 4134 
+L 603 4134 
+L 603 4863 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-57" d="M 1172 4494 
+L 1172 3500 
+L 2356 3500 
+L 2356 3053 
+L 1172 3053 
+L 1172 1153 
+Q 1172 725 1289 603 
+Q 1406 481 1766 481 
+L 2356 481 
+L 2356 0 
+L 1766 0 
+Q 1100 0 847 248 
+Q 594 497 594 1153 
+L 594 3053 
+L 172 3053 
+L 172 3500 
+L 594 3500 
+L 594 4494 
+L 1172 4494 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-48" d="M 3597 1894 
+L 3597 1613 
+L 953 1613 
+Q 991 1019 1311 708 
+Q 1631 397 2203 397 
+Q 2534 397 2845 478 
+Q 3156 559 3463 722 
+L 3463 178 
+Q 3153 47 2828 -22 
+Q 2503 -91 2169 -91 
+Q 1331 -91 842 396 
+Q 353 884 353 1716 
+Q 353 2575 817 3079 
+Q 1281 3584 2069 3584 
+Q 2775 3584 3186 3129 
+Q 3597 2675 3597 1894 
+z
+M 3022 2063 
+Q 3016 2534 2758 2815 
+Q 2500 3097 2075 3097 
+Q 1594 3097 1305 2825 
+Q 1016 2553 972 2059 
+L 3022 2063 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-10" d="M 313 2009 
+L 1997 2009 
+L 1997 1497 
+L 313 1497 
+L 313 2009 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-47" d="M 2906 2969 
+L 2906 4863 
+L 3481 4863 
+L 3481 0 
+L 2906 0 
+L 2906 525 
+Q 2725 213 2448 61 
+Q 2172 -91 1784 -91 
+Q 1150 -91 751 415 
+Q 353 922 353 1747 
+Q 353 2572 751 3078 
+Q 1150 3584 1784 3584 
+Q 2172 3584 2448 3432 
+Q 2725 3281 2906 2969 
+z
+M 947 1747 
+Q 947 1113 1208 752 
+Q 1469 391 1925 391 
+Q 2381 391 2643 752 
+Q 2906 1113 2906 1747 
+Q 2906 2381 2643 2742 
+Q 2381 3103 1925 3103 
+Q 1469 3103 1208 2742 
+Q 947 2381 947 1747 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-13ae" d="M 4531 4863 
+L 4531 4384 
+L 3981 4384 
+Q 3672 4384 3551 4259 
+Q 3431 4134 3431 3809 
+L 3431 3500 
+L 4378 3500 
+L 4378 3053 
+L 3431 3053 
+L 3431 0 
+L 2853 0 
+L 2853 3053 
+L 1275 3053 
+L 1275 0 
+L 697 0 
+L 697 3053 
+L 147 3053 
+L 147 3500 
+L 697 3500 
+L 697 3744 
+Q 697 4328 969 4595 
+Q 1241 4863 1831 4863 
+L 2375 4863 
+L 2375 4384 
+L 1825 4384 
+Q 1516 4384 1394 4259 
+Q 1275 4134 1275 3809 
+L 1275 3500 
+L 2853 3500 
+L 2853 3744 
+Q 2853 4328 3125 4595 
+Q 3397 4863 3988 4863 
+L 4531 4863 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-55" d="M 2631 2963 
+Q 2534 3019 2420 3045 
+Q 2306 3072 2169 3072 
+Q 1681 3072 1420 2755 
+Q 1159 2438 1159 1844 
+L 1159 0 
+L 581 0 
+L 581 3500 
+L 1159 3500 
+L 1159 2956 
+Q 1341 3275 1631 3429 
+Q 1922 3584 2338 3584 
+Q 2397 3584 2469 3576 
+Q 2541 3569 2628 3553 
+L 2631 2963 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-46" d="M 3122 3366 
+L 3122 2828 
+Q 2878 2963 2633 3030 
+Q 2388 3097 2138 3097 
+Q 1578 3097 1268 2742 
+Q 959 2388 959 1747 
+Q 959 1106 1268 751 
+Q 1578 397 2138 397 
+Q 2388 397 2633 464 
+Q 2878 531 3122 666 
+L 3122 134 
+Q 2881 22 2623 -34 
+Q 2366 -91 2075 -91 
+Q 1284 -91 818 406 
+Q 353 903 353 1747 
+Q 353 2603 823 3093 
+Q 1294 3584 2113 3584 
+Q 2378 3584 2631 3529 
+Q 2884 3475 3122 3366 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-3" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-52" d="M 1959 3097 
+Q 1497 3097 1228 2736 
+Q 959 2375 959 1747 
+Q 959 1119 1226 758 
+Q 1494 397 1959 397 
+Q 2419 397 2687 759 
+Q 2956 1122 2956 1747 
+Q 2956 2369 2687 2733 
+Q 2419 3097 1959 3097 
+z
+M 1959 3584 
+Q 2709 3584 3137 3096 
+Q 3566 2609 3566 1747 
+Q 3566 888 3137 398 
+Q 2709 -91 1959 -91 
+Q 1206 -91 779 398 
+Q 353 888 353 1747 
+Q 353 2609 779 3096 
+Q 1206 3584 1959 3584 
+z
+" transform="scale(0.015625)"/>
+      </defs>
+      <use xlink:href="#DejaVuSans-13af"/>
+      <use xlink:href="#DejaVuSans-51" transform="translate(62.984375 0)"/>
+      <use xlink:href="#DejaVuSans-4c" transform="translate(126.359375 0)"/>
+      <use xlink:href="#DejaVuSans-57" transform="translate(154.140625 0)"/>
+      <use xlink:href="#DejaVuSans-48" transform="translate(193.34375 0)"/>
+      <use xlink:href="#DejaVuSans-10" transform="translate(254.875 0)"/>
+      <use xlink:href="#DejaVuSans-47" transform="translate(290.953125 0)"/>
+      <use xlink:href="#DejaVuSans-4c" transform="translate(354.4375 0)"/>
+      <use xlink:href="#DejaVuSans-13ae" transform="translate(382.21875 0)"/>
+      <use xlink:href="#DejaVuSans-48" transform="translate(451.109375 0)"/>
+      <use xlink:href="#DejaVuSans-55" transform="translate(512.640625 0)"/>
+      <use xlink:href="#DejaVuSans-48" transform="translate(551.546875 0)"/>
+      <use xlink:href="#DejaVuSans-51" transform="translate(613.078125 0)"/>
+      <use xlink:href="#DejaVuSans-46" transform="translate(676.453125 0)"/>
+      <use xlink:href="#DejaVuSans-48" transform="translate(731.4375 0)"/>
+      <use xlink:href="#DejaVuSans-3" transform="translate(792.96875 0)"/>
+      <use xlink:href="#DejaVuSans-52" transform="translate(824.75 0)"/>
+      <use xlink:href="#DejaVuSans-55" transform="translate(885.9375 0)"/>
+      <use xlink:href="#DejaVuSans-47" transform="translate(925.296875 0)"/>
+      <use xlink:href="#DejaVuSans-48" transform="translate(988.78125 0)"/>
+      <use xlink:href="#DejaVuSans-55" transform="translate(1050.3125 0)"/>
+     </g>
+    </g>
+   </g>
+   <g id="matplotlib.axis_2">
+    <g id="ytick_1">
+     <g id="line2d_11">
+      <path d="M 45.800781 222.50634 
+L 299.437145 222.50634 
+" clip-path="url(#p588fc3669c)" style="fill: none; stroke: #d5d8dc; stroke-width: 0.6; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_12">
+      <defs>
+       <path id="m93eb56bc25" d="M 0 0 
+L -3.5 0 
+" style="stroke: #000000; stroke-width: 0.8"/>
+      </defs>
+      <g>
+       <use xlink:href="#m93eb56bc25" x="45.800781" y="222.50634" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_7">
+      <!-- $\mathdefault{10^{1}}$ -->
+      <g transform="translate(21.200781 227.15634) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-13" d="M 2034 4250 
+Q 1547 4250 1301 3770 
+Q 1056 3291 1056 2328 
+Q 1056 1369 1301 889 
+Q 1547 409 2034 409 
+Q 2525 409 2770 889 
+Q 3016 1369 3016 2328 
+Q 3016 3291 2770 3770 
+Q 2525 4250 2034 4250 
+z
+M 2034 4750 
+Q 2819 4750 3233 4129 
+Q 3647 3509 3647 2328 
+Q 3647 1150 3233 529 
+Q 2819 -91 2034 -91 
+Q 1250 -91 836 529 
+Q 422 1150 422 2328 
+Q 422 3509 836 4129 
+Q 1250 4750 2034 4750 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-14" transform="translate(0 0.665625)"/>
+       <use xlink:href="#DejaVuSans-13" transform="translate(63.623047 0.665625)"/>
+       <use xlink:href="#DejaVuSans-14" transform="translate(128.203125 41.965625) scale(0.7)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_2">
+     <g id="line2d_13">
+      <path d="M 45.800781 81.57737 
+L 299.437145 81.57737 
+" clip-path="url(#p588fc3669c)" style="fill: none; stroke: #d5d8dc; stroke-width: 0.6; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_14">
+      <g>
+       <use xlink:href="#m93eb56bc25" x="45.800781" y="81.57737" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_8">
+      <!-- $\mathdefault{10^{2}}$ -->
+      <g transform="translate(21.200781 86.27737) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-14" transform="translate(0 0.746875)"/>
+       <use xlink:href="#DejaVuSans-13" transform="translate(63.623047 0.746875)"/>
+       <use xlink:href="#DejaVuSans-15" transform="translate(128.203125 42.046875) scale(0.7)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_3">
+     <g id="line2d_15">
+      <path d="M 45.800781 253.771256 
+L 299.437145 253.771256 
+" clip-path="url(#p588fc3669c)" style="fill: none; stroke: #d5d8dc; stroke-width: 0.6; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_16">
+      <defs>
+       <path id="mf999cd2969" d="M 0 0 
+L -2 0 
+" style="stroke: #000000; stroke-width: 0.6"/>
+      </defs>
+      <g>
+       <use xlink:href="#mf999cd2969" x="45.800781" y="253.771256" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_4">
+     <g id="line2d_17">
+      <path d="M 45.800781 244.336514 
+L 299.437145 244.336514 
+" clip-path="url(#p588fc3669c)" style="fill: none; stroke: #d5d8dc; stroke-width: 0.6; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_18">
+      <g>
+       <use xlink:href="#mf999cd2969" x="45.800781" y="244.336514" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_5">
+     <g id="line2d_19">
+      <path d="M 45.800781 236.163768 
+L 299.437145 236.163768 
+" clip-path="url(#p588fc3669c)" style="fill: none; stroke: #d5d8dc; stroke-width: 0.6; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_20">
+      <g>
+       <use xlink:href="#mf999cd2969" x="45.800781" y="236.163768" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_6">
+     <g id="line2d_21">
+      <path d="M 45.800781 228.954896 
+L 299.437145 228.954896 
+" clip-path="url(#p588fc3669c)" style="fill: none; stroke: #d5d8dc; stroke-width: 0.6; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_22">
+      <g>
+       <use xlink:href="#mf999cd2969" x="45.800781" y="228.954896" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_7">
+     <g id="line2d_23">
+      <path d="M 45.800781 180.082493 
+L 299.437145 180.082493 
+" clip-path="url(#p588fc3669c)" style="fill: none; stroke: #d5d8dc; stroke-width: 0.6; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_24">
+      <g>
+       <use xlink:href="#mf999cd2969" x="45.800781" y="180.082493" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_8">
+     <g id="line2d_25">
+      <path d="M 45.800781 155.266133 
+L 299.437145 155.266133 
+" clip-path="url(#p588fc3669c)" style="fill: none; stroke: #d5d8dc; stroke-width: 0.6; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_26">
+      <g>
+       <use xlink:href="#mf999cd2969" x="45.800781" y="155.266133" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_9">
+     <g id="line2d_27">
+      <path d="M 45.800781 137.658646 
+L 299.437145 137.658646 
+" clip-path="url(#p588fc3669c)" style="fill: none; stroke: #d5d8dc; stroke-width: 0.6; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_28">
+      <g>
+       <use xlink:href="#mf999cd2969" x="45.800781" y="137.658646" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_10">
+     <g id="line2d_29">
+      <path d="M 45.800781 124.001218 
+L 299.437145 124.001218 
+" clip-path="url(#p588fc3669c)" style="fill: none; stroke: #d5d8dc; stroke-width: 0.6; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_30">
+      <g>
+       <use xlink:href="#mf999cd2969" x="45.800781" y="124.001218" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_11">
+     <g id="line2d_31">
+      <path d="M 45.800781 112.842286 
+L 299.437145 112.842286 
+" clip-path="url(#p588fc3669c)" style="fill: none; stroke: #d5d8dc; stroke-width: 0.6; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_32">
+      <g>
+       <use xlink:href="#mf999cd2969" x="45.800781" y="112.842286" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_12">
+     <g id="line2d_33">
+      <path d="M 45.800781 103.407544 
+L 299.437145 103.407544 
+" clip-path="url(#p588fc3669c)" style="fill: none; stroke: #d5d8dc; stroke-width: 0.6; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_34">
+      <g>
+       <use xlink:href="#mf999cd2969" x="45.800781" y="103.407544" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_13">
+     <g id="line2d_35">
+      <path d="M 45.800781 95.234799 
+L 299.437145 95.234799 
+" clip-path="url(#p588fc3669c)" style="fill: none; stroke: #d5d8dc; stroke-width: 0.6; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_36">
+      <g>
+       <use xlink:href="#mf999cd2969" x="45.800781" y="95.234799" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_14">
+     <g id="line2d_37">
+      <path d="M 45.800781 88.025926 
+L 299.437145 88.025926 
+" clip-path="url(#p588fc3669c)" style="fill: none; stroke: #d5d8dc; stroke-width: 0.6; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_38">
+      <g>
+       <use xlink:href="#mf999cd2969" x="45.800781" y="88.025926" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_15">
+     <g id="line2d_39">
+      <path d="M 45.800781 39.153523 
+L 299.437145 39.153523 
+" clip-path="url(#p588fc3669c)" style="fill: none; stroke: #d5d8dc; stroke-width: 0.6; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_40">
+      <g>
+       <use xlink:href="#mf999cd2969" x="45.800781" y="39.153523" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="text_9">
+     <!-- wall time per step [ms] -->
+     <g transform="translate(14.798437 198.986031) rotate(-90) scale(0.1 -0.1)">
+      <defs>
+       <path id="DejaVuSans-5a" d="M 269 3500 
+L 844 3500 
+L 1563 769 
+L 2278 3500 
+L 2956 3500 
+L 3675 769 
+L 4391 3500 
+L 4966 3500 
+L 4050 0 
+L 3372 0 
+L 2619 2869 
+L 1863 0 
+L 1184 0 
+L 269 3500 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-44" d="M 2194 1759 
+Q 1497 1759 1228 1600 
+Q 959 1441 959 1056 
+Q 959 750 1161 570 
+Q 1363 391 1709 391 
+Q 2188 391 2477 730 
+Q 2766 1069 2766 1631 
+L 2766 1759 
+L 2194 1759 
+z
+M 3341 1997 
+L 3341 0 
+L 2766 0 
+L 2766 531 
+Q 2569 213 2275 61 
+Q 1981 -91 1556 -91 
+Q 1019 -91 701 211 
+Q 384 513 384 1019 
+Q 384 1609 779 1909 
+Q 1175 2209 1959 2209 
+L 2766 2209 
+L 2766 2266 
+Q 2766 2663 2505 2880 
+Q 2244 3097 1772 3097 
+Q 1472 3097 1187 3025 
+Q 903 2953 641 2809 
+L 641 3341 
+Q 956 3463 1253 3523 
+Q 1550 3584 1831 3584 
+Q 2591 3584 2966 3190 
+Q 3341 2797 3341 1997 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-4f" d="M 603 4863 
+L 1178 4863 
+L 1178 0 
+L 603 0 
+L 603 4863 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-50" d="M 3328 2828 
+Q 3544 3216 3844 3400 
+Q 4144 3584 4550 3584 
+Q 5097 3584 5394 3201 
+Q 5691 2819 5691 2113 
+L 5691 0 
+L 5113 0 
+L 5113 2094 
+Q 5113 2597 4934 2840 
+Q 4756 3084 4391 3084 
+Q 3944 3084 3684 2787 
+Q 3425 2491 3425 1978 
+L 3425 0 
+L 2847 0 
+L 2847 2094 
+Q 2847 2600 2669 2842 
+Q 2491 3084 2119 3084 
+Q 1678 3084 1418 2786 
+Q 1159 2488 1159 1978 
+L 1159 0 
+L 581 0 
+L 581 3500 
+L 1159 3500 
+L 1159 2956 
+Q 1356 3278 1631 3431 
+Q 1906 3584 2284 3584 
+Q 2666 3584 2933 3390 
+Q 3200 3197 3328 2828 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-53" d="M 1159 525 
+L 1159 -1331 
+L 581 -1331 
+L 581 3500 
+L 1159 3500 
+L 1159 2969 
+Q 1341 3281 1617 3432 
+Q 1894 3584 2278 3584 
+Q 2916 3584 3314 3078 
+Q 3713 2572 3713 1747 
+Q 3713 922 3314 415 
+Q 2916 -91 2278 -91 
+Q 1894 -91 1617 61 
+Q 1341 213 1159 525 
+z
+M 3116 1747 
+Q 3116 2381 2855 2742 
+Q 2594 3103 2138 3103 
+Q 1681 3103 1420 2742 
+Q 1159 2381 1159 1747 
+Q 1159 1113 1420 752 
+Q 1681 391 2138 391 
+Q 2594 391 2855 752 
+Q 3116 1113 3116 1747 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-56" d="M 2834 3397 
+L 2834 2853 
+Q 2591 2978 2328 3040 
+Q 2066 3103 1784 3103 
+Q 1356 3103 1142 2972 
+Q 928 2841 928 2578 
+Q 928 2378 1081 2264 
+Q 1234 2150 1697 2047 
+L 1894 2003 
+Q 2506 1872 2764 1633 
+Q 3022 1394 3022 966 
+Q 3022 478 2636 193 
+Q 2250 -91 1575 -91 
+Q 1294 -91 989 -36 
+Q 684 19 347 128 
+L 347 722 
+Q 666 556 975 473 
+Q 1284 391 1588 391 
+Q 1994 391 2212 530 
+Q 2431 669 2431 922 
+Q 2431 1156 2273 1281 
+Q 2116 1406 1581 1522 
+L 1381 1569 
+Q 847 1681 609 1914 
+Q 372 2147 372 2553 
+Q 372 3047 722 3315 
+Q 1072 3584 1716 3584 
+Q 2034 3584 2315 3537 
+Q 2597 3491 2834 3397 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-3e" d="M 550 4863 
+L 1875 4863 
+L 1875 4416 
+L 1125 4416 
+L 1125 -397 
+L 1875 -397 
+L 1875 -844 
+L 550 -844 
+L 550 4863 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-40" d="M 1947 4863 
+L 1947 -844 
+L 622 -844 
+L 622 -397 
+L 1369 -397 
+L 1369 4416 
+L 622 4416 
+L 622 4863 
+L 1947 4863 
+z
+" transform="scale(0.015625)"/>
+      </defs>
+      <use xlink:href="#DejaVuSans-5a"/>
+      <use xlink:href="#DejaVuSans-44" transform="translate(81.78125 0)"/>
+      <use xlink:href="#DejaVuSans-4f" transform="translate(143.0625 0)"/>
+      <use xlink:href="#DejaVuSans-4f" transform="translate(170.84375 0)"/>
+      <use xlink:href="#DejaVuSans-3" transform="translate(198.625 0)"/>
+      <use xlink:href="#DejaVuSans-57" transform="translate(230.40625 0)"/>
+      <use xlink:href="#DejaVuSans-4c" transform="translate(269.609375 0)"/>
+      <use xlink:href="#DejaVuSans-50" transform="translate(297.390625 0)"/>
+      <use xlink:href="#DejaVuSans-48" transform="translate(394.796875 0)"/>
+      <use xlink:href="#DejaVuSans-3" transform="translate(456.328125 0)"/>
+      <use xlink:href="#DejaVuSans-53" transform="translate(488.109375 0)"/>
+      <use xlink:href="#DejaVuSans-48" transform="translate(551.59375 0)"/>
+      <use xlink:href="#DejaVuSans-55" transform="translate(613.125 0)"/>
+      <use xlink:href="#DejaVuSans-3" transform="translate(654.234375 0)"/>
+      <use xlink:href="#DejaVuSans-56" transform="translate(686.015625 0)"/>
+      <use xlink:href="#DejaVuSans-57" transform="translate(738.109375 0)"/>
+      <use xlink:href="#DejaVuSans-48" transform="translate(777.3125 0)"/>
+      <use xlink:href="#DejaVuSans-53" transform="translate(838.84375 0)"/>
+      <use xlink:href="#DejaVuSans-3" transform="translate(902.328125 0)"/>
+      <use xlink:href="#DejaVuSans-3e" transform="translate(934.109375 0)"/>
+      <use xlink:href="#DejaVuSans-50" transform="translate(973.125 0)"/>
+      <use xlink:href="#DejaVuSans-56" transform="translate(1070.53125 0)"/>
+      <use xlink:href="#DejaVuSans-40" transform="translate(1122.625 0)"/>
+     </g>
+    </g>
+   </g>
+   <g id="line2d_41">
+    <path d="M 57.329707 246.744 
+L 103.445409 214.165513 
+L 149.561112 197.649191 
+L 195.676814 184.392677 
+L 287.908219 167.188747 
+" clip-path="url(#p588fc3669c)" style="fill: none; stroke: #c1662f; stroke-width: 1.8; stroke-linecap: square"/>
+    <defs>
+     <path id="m05c75e815b" d="M 0 3 
+C 0.795609 3 1.55874 2.683901 2.12132 2.12132 
+C 2.683901 1.55874 3 0.795609 3 0 
+C 3 -0.795609 2.683901 -1.55874 2.12132 -2.12132 
+C 1.55874 -2.683901 0.795609 -3 0 -3 
+C -0.795609 -3 -1.55874 -2.683901 -2.12132 -2.12132 
+C -2.683901 -1.55874 -3 -0.795609 -3 0 
+C -3 0.795609 -2.683901 1.55874 -2.12132 2.12132 
+C -1.55874 2.683901 -0.795609 3 0 3 
+z
+" style="stroke: #c1662f"/>
+    </defs>
+    <g clip-path="url(#p588fc3669c)">
+     <use xlink:href="#m05c75e815b" x="57.329707" y="246.744" style="fill: #c1662f; stroke: #c1662f"/>
+     <use xlink:href="#m05c75e815b" x="103.445409" y="214.165513" style="fill: #c1662f; stroke: #c1662f"/>
+     <use xlink:href="#m05c75e815b" x="149.561112" y="197.649191" style="fill: #c1662f; stroke: #c1662f"/>
+     <use xlink:href="#m05c75e815b" x="195.676814" y="184.392677" style="fill: #c1662f; stroke: #c1662f"/>
+     <use xlink:href="#m05c75e815b" x="287.908219" y="167.188747" style="fill: #c1662f; stroke: #c1662f"/>
+    </g>
+   </g>
+   <g id="line2d_42">
+    <path d="M 45.800781 35.064 
+L 299.437145 35.064 
+" clip-path="url(#p588fc3669c)" style="fill: none; stroke-dasharray: 5.92,2.56; stroke-dashoffset: 0; stroke: #3f8a5c; stroke-width: 1.6"/>
+   </g>
+   <g id="patch_3">
+    <path d="M 45.800781 257.328 
+L 45.800781 24.48 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_4">
+    <path d="M 299.437145 257.328 
+L 299.437145 24.48 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_5">
+    <path d="M 45.800781 257.328 
+L 299.437145 257.328 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_6">
+    <path d="M 45.800781 24.48 
+L 299.437145 24.48 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="text_10">
+    <!-- spectral 214 ms -->
+    <g style="fill: #4a4a4a" transform="translate(223.475719 78.557527) scale(0.08 -0.08)">
+     <use xlink:href="#DejaVuSans-56"/>
+     <use xlink:href="#DejaVuSans-53" transform="translate(52.09375 0)"/>
+     <use xlink:href="#DejaVuSans-48" transform="translate(115.578125 0)"/>
+     <use xlink:href="#DejaVuSans-46" transform="translate(177.109375 0)"/>
+     <use xlink:href="#DejaVuSans-57" transform="translate(232.09375 0)"/>
+     <use xlink:href="#DejaVuSans-55" transform="translate(271.296875 0)"/>
+     <use xlink:href="#DejaVuSans-44" transform="translate(312.40625 0)"/>
+     <use xlink:href="#DejaVuSans-4f" transform="translate(373.6875 0)"/>
+     <use xlink:href="#DejaVuSans-3" transform="translate(401.46875 0)"/>
+     <use xlink:href="#DejaVuSans-15" transform="translate(433.25 0)"/>
+     <use xlink:href="#DejaVuSans-14" transform="translate(496.875 0)"/>
+     <use xlink:href="#DejaVuSans-17" transform="translate(560.5 0)"/>
+     <use xlink:href="#DejaVuSans-3" transform="translate(624.125 0)"/>
+     <use xlink:href="#DejaVuSans-50" transform="translate(655.90625 0)"/>
+     <use xlink:href="#DejaVuSans-56" transform="translate(753.3125 0)"/>
+    </g>
+    <!-- = 32x FD-2 -->
+    <g style="fill: #4a4a4a" transform="translate(242.466969 88.159089) scale(0.08 -0.08)">
+     <defs>
+      <path id="DejaVuSans-20" d="M 678 2906 
+L 4684 2906 
+L 4684 2381 
+L 678 2381 
+L 678 2906 
+z
+M 678 1631 
+L 4684 1631 
+L 4684 1100 
+L 678 1100 
+L 678 1631 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-16" d="M 2597 2516 
+Q 3050 2419 3304 2112 
+Q 3559 1806 3559 1356 
+Q 3559 666 3084 287 
+Q 2609 -91 1734 -91 
+Q 1441 -91 1130 -33 
+Q 819 25 488 141 
+L 488 750 
+Q 750 597 1062 519 
+Q 1375 441 1716 441 
+Q 2309 441 2620 675 
+Q 2931 909 2931 1356 
+Q 2931 1769 2642 2001 
+Q 2353 2234 1838 2234 
+L 1294 2234 
+L 1294 2753 
+L 1863 2753 
+Q 2328 2753 2575 2939 
+Q 2822 3125 2822 3475 
+Q 2822 3834 2567 4026 
+Q 2313 4219 1838 4219 
+Q 1578 4219 1281 4162 
+Q 984 4106 628 3988 
+L 628 4550 
+Q 988 4650 1302 4700 
+Q 1616 4750 1894 4750 
+Q 2613 4750 3031 4423 
+Q 3450 4097 3450 3541 
+Q 3450 3153 3228 2886 
+Q 3006 2619 2597 2516 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-5b" d="M 3513 3500 
+L 2247 1797 
+L 3578 0 
+L 2900 0 
+L 1881 1375 
+L 863 0 
+L 184 0 
+L 1544 1831 
+L 300 3500 
+L 978 3500 
+L 1906 2253 
+L 2834 3500 
+L 3513 3500 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-29" d="M 628 4666 
+L 3309 4666 
+L 3309 4134 
+L 1259 4134 
+L 1259 2759 
+L 3109 2759 
+L 3109 2228 
+L 1259 2228 
+L 1259 0 
+L 628 0 
+L 628 4666 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-27" d="M 1259 4147 
+L 1259 519 
+L 2022 519 
+Q 2988 519 3436 956 
+Q 3884 1394 3884 2338 
+Q 3884 3275 3436 3711 
+Q 2988 4147 2022 4147 
+L 1259 4147 
+z
+M 628 4666 
+L 1925 4666 
+Q 3281 4666 3915 4102 
+Q 4550 3538 4550 2338 
+Q 4550 1131 3912 565 
+Q 3275 0 1925 0 
+L 628 0 
+L 628 4666 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-20"/>
+     <use xlink:href="#DejaVuSans-3" transform="translate(83.796875 0)"/>
+     <use xlink:href="#DejaVuSans-16" transform="translate(115.578125 0)"/>
+     <use xlink:href="#DejaVuSans-15" transform="translate(179.203125 0)"/>
+     <use xlink:href="#DejaVuSans-5b" transform="translate(242.828125 0)"/>
+     <use xlink:href="#DejaVuSans-3" transform="translate(302.015625 0)"/>
+     <use xlink:href="#DejaVuSans-29" transform="translate(333.796875 0)"/>
+     <use xlink:href="#DejaVuSans-27" transform="translate(391.3125 0)"/>
+     <use xlink:href="#DejaVuSans-10" transform="translate(468.3125 0)"/>
+     <use xlink:href="#DejaVuSans-15" transform="translate(504.390625 0)"/>
+    </g>
+   </g>
+   <g id="text_11">
+    <!-- Cost at equal grid ($1024^3$, 8 GCDs) -->
+    <g transform="translate(68.218963 18.48) scale(0.12 -0.12)">
+     <defs>
+      <path id="DejaVuSans-26" d="M 4122 4306 
+L 4122 3641 
+Q 3803 3938 3442 4084 
+Q 3081 4231 2675 4231 
+Q 1875 4231 1450 3742 
+Q 1025 3253 1025 2328 
+Q 1025 1406 1450 917 
+Q 1875 428 2675 428 
+Q 3081 428 3442 575 
+Q 3803 722 4122 1019 
+L 4122 359 
+Q 3791 134 3420 21 
+Q 3050 -91 2638 -91 
+Q 1578 -91 968 557 
+Q 359 1206 359 2328 
+Q 359 3453 968 4101 
+Q 1578 4750 2638 4750 
+Q 3056 4750 3426 4639 
+Q 3797 4528 4122 4306 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-54" d="M 947 1747 
+Q 947 1113 1208 752 
+Q 1469 391 1925 391 
+Q 2381 391 2643 752 
+Q 2906 1113 2906 1747 
+Q 2906 2381 2643 2742 
+Q 2381 3103 1925 3103 
+Q 1469 3103 1208 2742 
+Q 947 2381 947 1747 
+z
+M 2906 525 
+Q 2725 213 2448 61 
+Q 2172 -91 1784 -91 
+Q 1150 -91 751 415 
+Q 353 922 353 1747 
+Q 353 2572 751 3078 
+Q 1150 3584 1784 3584 
+Q 2172 3584 2448 3432 
+Q 2725 3281 2906 2969 
+L 2906 3500 
+L 3481 3500 
+L 3481 -1331 
+L 2906 -1331 
+L 2906 525 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-58" d="M 544 1381 
+L 544 3500 
+L 1119 3500 
+L 1119 1403 
+Q 1119 906 1312 657 
+Q 1506 409 1894 409 
+Q 2359 409 2629 706 
+Q 2900 1003 2900 1516 
+L 2900 3500 
+L 3475 3500 
+L 3475 0 
+L 2900 0 
+L 2900 538 
+Q 2691 219 2414 64 
+Q 2138 -91 1772 -91 
+Q 1169 -91 856 284 
+Q 544 659 544 1381 
+z
+M 1991 3584 
+L 1991 3584 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-4a" d="M 2906 1791 
+Q 2906 2416 2648 2759 
+Q 2391 3103 1925 3103 
+Q 1463 3103 1205 2759 
+Q 947 2416 947 1791 
+Q 947 1169 1205 825 
+Q 1463 481 1925 481 
+Q 2391 481 2648 825 
+Q 2906 1169 2906 1791 
+z
+M 3481 434 
+Q 3481 -459 3084 -895 
+Q 2688 -1331 1869 -1331 
+Q 1566 -1331 1297 -1286 
+Q 1028 -1241 775 -1147 
+L 775 -588 
+Q 1028 -725 1275 -790 
+Q 1522 -856 1778 -856 
+Q 2344 -856 2625 -561 
+Q 2906 -266 2906 331 
+L 2906 616 
+Q 2728 306 2450 153 
+Q 2172 0 1784 0 
+Q 1141 0 747 490 
+Q 353 981 353 1791 
+Q 353 2603 747 3093 
+Q 1141 3584 1784 3584 
+Q 2172 3584 2450 3431 
+Q 2728 3278 2906 2969 
+L 2906 3500 
+L 3481 3500 
+L 3481 434 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-b" d="M 1984 4856 
+Q 1566 4138 1362 3434 
+Q 1159 2731 1159 2009 
+Q 1159 1288 1364 580 
+Q 1569 -128 1984 -844 
+L 1484 -844 
+Q 1016 -109 783 600 
+Q 550 1309 550 2009 
+Q 550 2706 781 3412 
+Q 1013 4119 1484 4856 
+L 1984 4856 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-f" d="M 750 794 
+L 1409 794 
+L 1409 256 
+L 897 -744 
+L 494 -744 
+L 750 256 
+L 750 794 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-2a" d="M 3809 666 
+L 3809 1919 
+L 2778 1919 
+L 2778 2438 
+L 4434 2438 
+L 4434 434 
+Q 4069 175 3628 42 
+Q 3188 -91 2688 -91 
+Q 1594 -91 976 548 
+Q 359 1188 359 2328 
+Q 359 3472 976 4111 
+Q 1594 4750 2688 4750 
+Q 3144 4750 3555 4637 
+Q 3966 4525 4313 4306 
+L 4313 3634 
+Q 3963 3931 3569 4081 
+Q 3175 4231 2741 4231 
+Q 1884 4231 1454 3753 
+Q 1025 3275 1025 2328 
+Q 1025 1384 1454 906 
+Q 1884 428 2741 428 
+Q 3075 428 3337 486 
+Q 3600 544 3809 666 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-c" d="M 513 4856 
+L 1013 4856 
+Q 1481 4119 1714 3412 
+Q 1947 2706 1947 2009 
+Q 1947 1309 1714 600 
+Q 1481 -109 1013 -844 
+L 513 -844 
+Q 928 -128 1133 580 
+Q 1338 1288 1338 2009 
+Q 1338 2731 1133 3434 
+Q 928 4138 513 4856 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-26" transform="translate(0 0.746875)"/>
+     <use xlink:href="#DejaVuSans-52" transform="translate(69.824219 0.746875)"/>
+     <use xlink:href="#DejaVuSans-56" transform="translate(131.005859 0.746875)"/>
+     <use xlink:href="#DejaVuSans-57" transform="translate(183.105469 0.746875)"/>
+     <use xlink:href="#DejaVuSans-3" transform="translate(222.314453 0.746875)"/>
+     <use xlink:href="#DejaVuSans-44" transform="translate(254.101562 0.746875)"/>
+     <use xlink:href="#DejaVuSans-57" transform="translate(315.380859 0.746875)"/>
+     <use xlink:href="#DejaVuSans-3" transform="translate(354.589844 0.746875)"/>
+     <use xlink:href="#DejaVuSans-48" transform="translate(386.376953 0.746875)"/>
+     <use xlink:href="#DejaVuSans-54" transform="translate(447.900391 0.746875)"/>
+     <use xlink:href="#DejaVuSans-58" transform="translate(511.376953 0.746875)"/>
+     <use xlink:href="#DejaVuSans-44" transform="translate(574.755859 0.746875)"/>
+     <use xlink:href="#DejaVuSans-4f" transform="translate(636.035156 0.746875)"/>
+     <use xlink:href="#DejaVuSans-3" transform="translate(663.818359 0.746875)"/>
+     <use xlink:href="#DejaVuSans-4a" transform="translate(695.605469 0.746875)"/>
+     <use xlink:href="#DejaVuSans-55" transform="translate(759.082031 0.746875)"/>
+     <use xlink:href="#DejaVuSans-4c" transform="translate(800.195312 0.746875)"/>
+     <use xlink:href="#DejaVuSans-47" transform="translate(827.978516 0.746875)"/>
+     <use xlink:href="#DejaVuSans-3" transform="translate(891.455078 0.746875)"/>
+     <use xlink:href="#DejaVuSans-b" transform="translate(923.242188 0.746875)"/>
+     <use xlink:href="#DejaVuSans-14" transform="translate(962.255859 0.746875)"/>
+     <use xlink:href="#DejaVuSans-13" transform="translate(1025.878906 0.746875)"/>
+     <use xlink:href="#DejaVuSans-15" transform="translate(1089.501953 0.746875)"/>
+     <use xlink:href="#DejaVuSans-17" transform="translate(1153.125 0.746875)"/>
+     <use xlink:href="#DejaVuSans-16" transform="translate(1217.705078 42.046875) scale(0.7)"/>
+     <use xlink:href="#DejaVuSans-f" transform="translate(1264.975586 0.746875)"/>
+     <use xlink:href="#DejaVuSans-3" transform="translate(1296.762695 0.746875)"/>
+     <use xlink:href="#DejaVuSans-1b" transform="translate(1328.549805 0.746875)"/>
+     <use xlink:href="#DejaVuSans-3" transform="translate(1392.172852 0.746875)"/>
+     <use xlink:href="#DejaVuSans-2a" transform="translate(1423.959961 0.746875)"/>
+     <use xlink:href="#DejaVuSans-26" transform="translate(1501.450195 0.746875)"/>
+     <use xlink:href="#DejaVuSans-27" transform="translate(1571.274414 0.746875)"/>
+     <use xlink:href="#DejaVuSans-56" transform="translate(1648.276367 0.746875)"/>
+     <use xlink:href="#DejaVuSans-c" transform="translate(1700.375977 0.746875)"/>
+    </g>
+   </g>
+   <g id="legend_1">
+    <g id="line2d_43">
+     <path d="M 206.743395 134.182125 
+L 214.743395 134.182125 
+L 222.743395 134.182125 
+" style="fill: none; stroke: #c1662f; stroke-width: 1.8; stroke-linecap: square"/>
+     <g>
+      <use xlink:href="#m05c75e815b" x="214.743395" y="134.182125" style="fill: #c1662f; stroke: #c1662f"/>
+     </g>
+    </g>
+    <g id="text_12">
+     <!-- finite difference -->
+     <g transform="translate(229.143395 136.982125) scale(0.08 -0.08)">
+      <use xlink:href="#DejaVuSans-13af"/>
+      <use xlink:href="#DejaVuSans-51" transform="translate(62.984375 0)"/>
+      <use xlink:href="#DejaVuSans-4c" transform="translate(126.359375 0)"/>
+      <use xlink:href="#DejaVuSans-57" transform="translate(154.140625 0)"/>
+      <use xlink:href="#DejaVuSans-48" transform="translate(193.34375 0)"/>
+      <use xlink:href="#DejaVuSans-3" transform="translate(254.875 0)"/>
+      <use xlink:href="#DejaVuSans-47" transform="translate(286.65625 0)"/>
+      <use xlink:href="#DejaVuSans-4c" transform="translate(350.140625 0)"/>
+      <use xlink:href="#DejaVuSans-13ae" transform="translate(377.921875 0)"/>
+      <use xlink:href="#DejaVuSans-48" transform="translate(446.8125 0)"/>
+      <use xlink:href="#DejaVuSans-55" transform="translate(508.34375 0)"/>
+      <use xlink:href="#DejaVuSans-48" transform="translate(547.25 0)"/>
+      <use xlink:href="#DejaVuSans-51" transform="translate(608.78125 0)"/>
+      <use xlink:href="#DejaVuSans-46" transform="translate(672.15625 0)"/>
+      <use xlink:href="#DejaVuSans-48" transform="translate(727.140625 0)"/>
+     </g>
+    </g>
+    <g id="line2d_44">
+     <path d="M 206.743395 146.18275 
+L 214.743395 146.18275 
+L 222.743395 146.18275 
+" style="fill: none; stroke-dasharray: 5.92,2.56; stroke-dashoffset: 0; stroke: #3f8a5c; stroke-width: 1.6"/>
+    </g>
+    <g id="text_13">
+     <!-- spectral -->
+     <g transform="translate(229.143395 148.98275) scale(0.08 -0.08)">
+      <use xlink:href="#DejaVuSans-56"/>
+      <use xlink:href="#DejaVuSans-53" transform="translate(52.09375 0)"/>
+      <use xlink:href="#DejaVuSans-48" transform="translate(115.578125 0)"/>
+      <use xlink:href="#DejaVuSans-46" transform="translate(177.109375 0)"/>
+      <use xlink:href="#DejaVuSans-57" transform="translate(232.09375 0)"/>
+      <use xlink:href="#DejaVuSans-55" transform="translate(271.296875 0)"/>
+      <use xlink:href="#DejaVuSans-44" transform="translate(312.40625 0)"/>
+      <use xlink:href="#DejaVuSans-4f" transform="translate(373.6875 0)"/>
+     </g>
+    </g>
+   </g>
+  </g>
+  <g id="axes_2">
+   <g id="patch_7">
+    <path d="M 350.164418 257.328 
+L 603.800781 257.328 
+L 603.800781 24.48 
+L 350.164418 24.48 
+z
+" style="fill: #ffffff"/>
+   </g>
+   <g id="matplotlib.axis_3">
+    <g id="xtick_6">
+     <g id="line2d_45">
+      <path d="M 361.693343 257.328 
+L 361.693343 24.48 
+" clip-path="url(#pa95b13f88f)" style="fill: none; stroke: #d5d8dc; stroke-width: 0.6; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_46">
+      <g>
+       <use xlink:href="#mcc3d023c21" x="361.693343" y="257.328" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_14">
+      <!-- 4 -->
+      <g transform="translate(358.512093 271.925656) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-17"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_7">
+     <g id="line2d_47">
+      <path d="M 476.982599 257.328 
+L 476.982599 24.48 
+" clip-path="url(#pa95b13f88f)" style="fill: none; stroke: #d5d8dc; stroke-width: 0.6; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_48">
+      <g>
+       <use xlink:href="#mcc3d023c21" x="476.982599" y="257.328" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_15">
+      <!-- 8 -->
+      <g transform="translate(473.801349 271.925656) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-1b"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_8">
+     <g id="line2d_49">
+      <path d="M 544.422491 257.328 
+L 544.422491 24.48 
+" clip-path="url(#pa95b13f88f)" style="fill: none; stroke: #d5d8dc; stroke-width: 0.6; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_50">
+      <g>
+       <use xlink:href="#mcc3d023c21" x="544.422491" y="257.328" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_16">
+      <!-- 12 -->
+      <g transform="translate(538.059991 271.925656) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-14"/>
+       <use xlink:href="#DejaVuSans-15" transform="translate(63.625 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_9">
+     <g id="line2d_51">
+      <path d="M 592.271856 257.328 
+L 592.271856 24.48 
+" clip-path="url(#pa95b13f88f)" style="fill: none; stroke: #d5d8dc; stroke-width: 0.6; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_52">
+      <g>
+       <use xlink:href="#mcc3d023c21" x="592.271856" y="257.328" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_17">
+      <!-- 16 -->
+      <g transform="translate(585.909356 271.925656) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-14"/>
+       <use xlink:href="#DejaVuSans-19" transform="translate(63.625 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="text_18">
+     <!-- nodes -->
+     <g transform="translate(461.899006 285.926437) scale(0.1 -0.1)">
+      <use xlink:href="#DejaVuSans-51"/>
+      <use xlink:href="#DejaVuSans-52" transform="translate(63.375 0)"/>
+      <use xlink:href="#DejaVuSans-47" transform="translate(124.5625 0)"/>
+      <use xlink:href="#DejaVuSans-48" transform="translate(188.046875 0)"/>
+      <use xlink:href="#DejaVuSans-56" transform="translate(249.578125 0)"/>
+     </g>
+    </g>
+   </g>
+   <g id="matplotlib.axis_4">
+    <g id="ytick_16">
+     <g id="line2d_53">
+      <path d="M 350.164418 257.328 
+L 603.800781 257.328 
+" clip-path="url(#pa95b13f88f)" style="fill: none; stroke: #d5d8dc; stroke-width: 0.6; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_54">
+      <g>
+       <use xlink:href="#m93eb56bc25" x="350.164418" y="257.328" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_19">
+      <!-- 0 -->
+      <g transform="translate(336.801918 261.126828) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-13"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_17">
+     <g id="line2d_55">
+      <path d="M 350.164418 216.832696 
+L 603.800781 216.832696 
+" clip-path="url(#pa95b13f88f)" style="fill: none; stroke: #d5d8dc; stroke-width: 0.6; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_56">
+      <g>
+       <use xlink:href="#m93eb56bc25" x="350.164418" y="216.832696" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_20">
+      <!-- 20 -->
+      <g transform="translate(330.439418 220.631524) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-15"/>
+       <use xlink:href="#DejaVuSans-13" transform="translate(63.625 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_18">
+     <g id="line2d_57">
+      <path d="M 350.164418 176.337391 
+L 603.800781 176.337391 
+" clip-path="url(#pa95b13f88f)" style="fill: none; stroke: #d5d8dc; stroke-width: 0.6; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_58">
+      <g>
+       <use xlink:href="#m93eb56bc25" x="350.164418" y="176.337391" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_21">
+      <!-- 40 -->
+      <g transform="translate(330.439418 180.136219) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-17"/>
+       <use xlink:href="#DejaVuSans-13" transform="translate(63.625 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_19">
+     <g id="line2d_59">
+      <path d="M 350.164418 135.842087 
+L 603.800781 135.842087 
+" clip-path="url(#pa95b13f88f)" style="fill: none; stroke: #d5d8dc; stroke-width: 0.6; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_60">
+      <g>
+       <use xlink:href="#m93eb56bc25" x="350.164418" y="135.842087" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_22">
+      <!-- 60 -->
+      <g transform="translate(330.439418 139.640915) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-19"/>
+       <use xlink:href="#DejaVuSans-13" transform="translate(63.625 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_20">
+     <g id="line2d_61">
+      <path d="M 350.164418 95.346783 
+L 603.800781 95.346783 
+" clip-path="url(#pa95b13f88f)" style="fill: none; stroke: #d5d8dc; stroke-width: 0.6; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_62">
+      <g>
+       <use xlink:href="#m93eb56bc25" x="350.164418" y="95.346783" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_23">
+      <!-- 80 -->
+      <g transform="translate(330.439418 99.145611) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-1b"/>
+       <use xlink:href="#DejaVuSans-13" transform="translate(63.625 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_21">
+     <g id="line2d_63">
+      <path d="M 350.164418 54.851478 
+L 603.800781 54.851478 
+" clip-path="url(#pa95b13f88f)" style="fill: none; stroke: #d5d8dc; stroke-width: 0.6; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_64">
+      <g>
+       <use xlink:href="#m93eb56bc25" x="350.164418" y="54.851478" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_24">
+      <!-- 100 -->
+      <g transform="translate(324.076918 58.650306) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-14"/>
+       <use xlink:href="#DejaVuSans-13" transform="translate(63.625 0)"/>
+       <use xlink:href="#DejaVuSans-13" transform="translate(127.25 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="text_25">
+     <!-- strong-scaling efficiency [%] -->
+     <g transform="translate(317.674574 211.993062) rotate(-90) scale(0.1 -0.1)">
+      <defs>
+       <path id="DejaVuSans-13b1" d="M 2375 4863 
+L 2375 4384 
+L 1825 4384 
+Q 1516 4384 1394 4259 
+Q 1275 4134 1275 3809 
+L 1275 3500 
+L 2853 3500 
+L 2853 3744 
+Q 2853 4328 3125 4594 
+Q 3213 4681 3334 4741 
+Q 3578 4863 3988 4863 
+L 4531 4863 
+L 4531 4384 
+L 3981 4384 
+Q 3672 4384 3551 4259 
+Q 3431 4134 3431 3809 
+L 3431 3500 
+L 5588 3500 
+L 5588 0 
+L 5009 0 
+L 5009 3053 
+L 3431 3053 
+L 3431 0 
+L 2853 0 
+L 2853 3053 
+L 1275 3053 
+L 1275 0 
+L 697 0 
+L 697 3053 
+L 147 3053 
+L 147 3500 
+L 697 3500 
+L 697 3744 
+Q 697 4328 969 4595 
+Q 1241 4863 1831 4863 
+L 2375 4863 
+z
+M 5009 4856 
+L 5588 4856 
+L 5588 4128 
+L 5009 4128 
+L 5009 4856 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-5c" d="M 2059 -325 
+Q 1816 -950 1584 -1140 
+Q 1353 -1331 966 -1331 
+L 506 -1331 
+L 506 -850 
+L 844 -850 
+Q 1081 -850 1212 -737 
+Q 1344 -625 1503 -206 
+L 1606 56 
+L 191 3500 
+L 800 3500 
+L 1894 763 
+L 2988 3500 
+L 3597 3500 
+L 2059 -325 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-8" d="M 4653 2053 
+Q 4381 2053 4226 1822 
+Q 4072 1591 4072 1178 
+Q 4072 772 4226 539 
+Q 4381 306 4653 306 
+Q 4919 306 5073 539 
+Q 5228 772 5228 1178 
+Q 5228 1588 5073 1820 
+Q 4919 2053 4653 2053 
+z
+M 4653 2450 
+Q 5147 2450 5437 2106 
+Q 5728 1763 5728 1178 
+Q 5728 594 5436 251 
+Q 5144 -91 4653 -91 
+Q 4153 -91 3862 251 
+Q 3572 594 3572 1178 
+Q 3572 1766 3864 2108 
+Q 4156 2450 4653 2450 
+z
+M 1428 4353 
+Q 1159 4353 1004 4120 
+Q 850 3888 850 3481 
+Q 850 3069 1003 2837 
+Q 1156 2606 1428 2606 
+Q 1700 2606 1854 2837 
+Q 2009 3069 2009 3481 
+Q 2009 3884 1853 4118 
+Q 1697 4353 1428 4353 
+z
+M 4250 4750 
+L 4750 4750 
+L 1831 -91 
+L 1331 -91 
+L 4250 4750 
+z
+M 1428 4750 
+Q 1922 4750 2215 4408 
+Q 2509 4066 2509 3481 
+Q 2509 2891 2217 2550 
+Q 1925 2209 1428 2209 
+Q 931 2209 642 2551 
+Q 353 2894 353 3481 
+Q 353 4063 643 4406 
+Q 934 4750 1428 4750 
+z
+" transform="scale(0.015625)"/>
+      </defs>
+      <use xlink:href="#DejaVuSans-56"/>
+      <use xlink:href="#DejaVuSans-57" transform="translate(52.09375 0)"/>
+      <use xlink:href="#DejaVuSans-55" transform="translate(91.296875 0)"/>
+      <use xlink:href="#DejaVuSans-52" transform="translate(130.203125 0)"/>
+      <use xlink:href="#DejaVuSans-51" transform="translate(191.390625 0)"/>
+      <use xlink:href="#DejaVuSans-4a" transform="translate(254.765625 0)"/>
+      <use xlink:href="#DejaVuSans-10" transform="translate(318.25 0)"/>
+      <use xlink:href="#DejaVuSans-56" transform="translate(354.328125 0)"/>
+      <use xlink:href="#DejaVuSans-46" transform="translate(406.421875 0)"/>
+      <use xlink:href="#DejaVuSans-44" transform="translate(461.40625 0)"/>
+      <use xlink:href="#DejaVuSans-4f" transform="translate(522.6875 0)"/>
+      <use xlink:href="#DejaVuSans-4c" transform="translate(550.46875 0)"/>
+      <use xlink:href="#DejaVuSans-51" transform="translate(578.25 0)"/>
+      <use xlink:href="#DejaVuSans-4a" transform="translate(641.625 0)"/>
+      <use xlink:href="#DejaVuSans-3" transform="translate(705.109375 0)"/>
+      <use xlink:href="#DejaVuSans-48" transform="translate(736.890625 0)"/>
+      <use xlink:href="#DejaVuSans-13b1" transform="translate(798.421875 0)"/>
+      <use xlink:href="#DejaVuSans-46" transform="translate(895.109375 0)"/>
+      <use xlink:href="#DejaVuSans-4c" transform="translate(950.09375 0)"/>
+      <use xlink:href="#DejaVuSans-48" transform="translate(977.875 0)"/>
+      <use xlink:href="#DejaVuSans-51" transform="translate(1039.40625 0)"/>
+      <use xlink:href="#DejaVuSans-46" transform="translate(1102.78125 0)"/>
+      <use xlink:href="#DejaVuSans-5c" transform="translate(1157.765625 0)"/>
+      <use xlink:href="#DejaVuSans-3" transform="translate(1216.953125 0)"/>
+      <use xlink:href="#DejaVuSans-3e" transform="translate(1248.734375 0)"/>
+      <use xlink:href="#DejaVuSans-8" transform="translate(1287.75 0)"/>
+      <use xlink:href="#DejaVuSans-40" transform="translate(1382.765625 0)"/>
+     </g>
+    </g>
+   </g>
+   <g id="line2d_65">
+    <path d="M 361.693343 54.851478 
+L 476.982599 86.520079 
+L 544.422491 87.816946 
+L 592.271856 88.589626 
+" clip-path="url(#pa95b13f88f)" style="fill: none; stroke: #3f8a5c; stroke-width: 1.7; stroke-linecap: square"/>
+    <defs>
+     <path id="mc8772fced7" d="M 0 3 
+C 0.795609 3 1.55874 2.683901 2.12132 2.12132 
+C 2.683901 1.55874 3 0.795609 3 0 
+C 3 -0.795609 2.683901 -1.55874 2.12132 -2.12132 
+C 1.55874 -2.683901 0.795609 -3 0 -3 
+C -0.795609 -3 -1.55874 -2.683901 -2.12132 -2.12132 
+C -2.683901 -1.55874 -3 -0.795609 -3 0 
+C -3 0.795609 -2.683901 1.55874 -2.12132 2.12132 
+C -1.55874 2.683901 -0.795609 3 0 3 
+z
+" style="stroke: #3f8a5c"/>
+    </defs>
+    <g clip-path="url(#pa95b13f88f)">
+     <use xlink:href="#mc8772fced7" x="361.693343" y="54.851478" style="fill: #3f8a5c; stroke: #3f8a5c"/>
+     <use xlink:href="#mc8772fced7" x="476.982599" y="86.520079" style="fill: #3f8a5c; stroke: #3f8a5c"/>
+     <use xlink:href="#mc8772fced7" x="544.422491" y="87.816946" style="fill: #3f8a5c; stroke: #3f8a5c"/>
+     <use xlink:href="#mc8772fced7" x="592.271856" y="88.589626" style="fill: #3f8a5c; stroke: #3f8a5c"/>
+    </g>
+   </g>
+   <g id="line2d_66">
+    <path d="M 361.693343 54.851478 
+L 476.982599 57.221605 
+L 544.422491 68.285939 
+L 592.271856 84.403687 
+" clip-path="url(#pa95b13f88f)" style="fill: none; stroke: #c1662f; stroke-width: 1.7; stroke-linecap: square"/>
+    <defs>
+     <path id="mdfdb734841" d="M -3 3 
+L 3 3 
+L 3 -3 
+L -3 -3 
+z
+" style="stroke: #c1662f; stroke-linejoin: miter"/>
+    </defs>
+    <g clip-path="url(#pa95b13f88f)">
+     <use xlink:href="#mdfdb734841" x="361.693343" y="54.851478" style="fill: #c1662f; stroke: #c1662f; stroke-linejoin: miter"/>
+     <use xlink:href="#mdfdb734841" x="476.982599" y="57.221605" style="fill: #c1662f; stroke: #c1662f; stroke-linejoin: miter"/>
+     <use xlink:href="#mdfdb734841" x="544.422491" y="68.285939" style="fill: #c1662f; stroke: #c1662f; stroke-linejoin: miter"/>
+     <use xlink:href="#mdfdb734841" x="592.271856" y="84.403687" style="fill: #c1662f; stroke: #c1662f; stroke-linejoin: miter"/>
+    </g>
+   </g>
+   <g id="line2d_67">
+    <path d="M 361.693343 54.851478 
+L 476.982599 69.707744 
+L 544.422491 83.204863 
+L 592.271856 94.221913 
+" clip-path="url(#pa95b13f88f)" style="fill: none; stroke: #1f6fb4; stroke-width: 1.7; stroke-linecap: square"/>
+    <defs>
+     <path id="m15eebee5d8" d="M 0 -3 
+L -3 3 
+L 3 3 
+z
+" style="stroke: #1f6fb4; stroke-linejoin: miter"/>
+    </defs>
+    <g clip-path="url(#pa95b13f88f)">
+     <use xlink:href="#m15eebee5d8" x="361.693343" y="54.851478" style="fill: #1f6fb4; stroke: #1f6fb4; stroke-linejoin: miter"/>
+     <use xlink:href="#m15eebee5d8" x="476.982599" y="69.707744" style="fill: #1f6fb4; stroke: #1f6fb4; stroke-linejoin: miter"/>
+     <use xlink:href="#m15eebee5d8" x="544.422491" y="83.204863" style="fill: #1f6fb4; stroke: #1f6fb4; stroke-linejoin: miter"/>
+     <use xlink:href="#m15eebee5d8" x="592.271856" y="94.221913" style="fill: #1f6fb4; stroke: #1f6fb4; stroke-linejoin: miter"/>
+    </g>
+   </g>
+   <g id="line2d_68">
+    <path d="M 350.164418 54.851478 
+L 603.800781 54.851478 
+" clip-path="url(#pa95b13f88f)" style="fill: none; stroke-dasharray: 3.7,1.6; stroke-dashoffset: 0; stroke: #7a7a7a"/>
+   </g>
+   <g id="patch_8">
+    <path d="M 350.164418 257.328 
+L 350.164418 24.48 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_9">
+    <path d="M 603.800781 257.328 
+L 603.800781 24.48 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_10">
+    <path d="M 350.164418 257.328 
+L 603.800781 257.328 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_11">
+    <path d="M 350.164418 24.48 
+L 603.800781 24.48 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="text_26">
+    <!-- Strong scaling, $1536^3$, 4$\to$16 nodes -->
+    <g transform="translate(369.582599 18.48) scale(0.12 -0.12)">
+     <defs>
+      <path id="DejaVuSans-36" d="M 3425 4513 
+L 3425 3897 
+Q 3066 4069 2747 4153 
+Q 2428 4238 2131 4238 
+Q 1616 4238 1336 4038 
+Q 1056 3838 1056 3469 
+Q 1056 3159 1242 3001 
+Q 1428 2844 1947 2747 
+L 2328 2669 
+Q 3034 2534 3370 2195 
+Q 3706 1856 3706 1288 
+Q 3706 609 3251 259 
+Q 2797 -91 1919 -91 
+Q 1588 -91 1214 -16 
+Q 841 59 441 206 
+L 441 856 
+Q 825 641 1194 531 
+Q 1563 422 1919 422 
+Q 2459 422 2753 634 
+Q 3047 847 3047 1241 
+Q 3047 1584 2836 1778 
+Q 2625 1972 2144 2069 
+L 1759 2144 
+Q 1053 2284 737 2584 
+Q 422 2884 422 3419 
+Q 422 4038 858 4394 
+Q 1294 4750 2059 4750 
+Q 2388 4750 2728 4690 
+Q 3069 4631 3425 4513 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-18" d="M 691 4666 
+L 3169 4666 
+L 3169 4134 
+L 1269 4134 
+L 1269 2991 
+Q 1406 3038 1543 3061 
+Q 1681 3084 1819 3084 
+Q 2600 3084 3056 2656 
+Q 3513 2228 3513 1497 
+Q 3513 744 3044 326 
+Q 2575 -91 1722 -91 
+Q 1428 -91 1123 -41 
+Q 819 9 494 109 
+L 494 744 
+Q 775 591 1075 516 
+Q 1375 441 1709 441 
+Q 2250 441 2565 725 
+Q 2881 1009 2881 1497 
+Q 2881 1984 2565 2268 
+Q 2250 2553 1709 2553 
+Q 1456 2553 1204 2497 
+Q 953 2441 691 2322 
+L 691 4666 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-c1c" d="M 5050 2147 
+L 5050 1866 
+L 3822 638 
+L 3447 1013 
+L 4175 1741 
+L 366 1741 
+L 366 2272 
+L 4175 2272 
+L 3447 3000 
+L 3822 3375 
+L 5050 2147 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-36" transform="translate(0 0.746875)"/>
+     <use xlink:href="#DejaVuSans-57" transform="translate(63.476562 0.746875)"/>
+     <use xlink:href="#DejaVuSans-55" transform="translate(102.685547 0.746875)"/>
+     <use xlink:href="#DejaVuSans-52" transform="translate(141.798828 0.746875)"/>
+     <use xlink:href="#DejaVuSans-51" transform="translate(202.980469 0.746875)"/>
+     <use xlink:href="#DejaVuSans-4a" transform="translate(266.359375 0.746875)"/>
+     <use xlink:href="#DejaVuSans-3" transform="translate(329.835938 0.746875)"/>
+     <use xlink:href="#DejaVuSans-56" transform="translate(361.623047 0.746875)"/>
+     <use xlink:href="#DejaVuSans-46" transform="translate(413.722656 0.746875)"/>
+     <use xlink:href="#DejaVuSans-44" transform="translate(468.703125 0.746875)"/>
+     <use xlink:href="#DejaVuSans-4f" transform="translate(529.982422 0.746875)"/>
+     <use xlink:href="#DejaVuSans-4c" transform="translate(557.765625 0.746875)"/>
+     <use xlink:href="#DejaVuSans-51" transform="translate(585.548828 0.746875)"/>
+     <use xlink:href="#DejaVuSans-4a" transform="translate(648.927734 0.746875)"/>
+     <use xlink:href="#DejaVuSans-f" transform="translate(712.404297 0.746875)"/>
+     <use xlink:href="#DejaVuSans-3" transform="translate(744.191406 0.746875)"/>
+     <use xlink:href="#DejaVuSans-14" transform="translate(775.978516 0.746875)"/>
+     <use xlink:href="#DejaVuSans-18" transform="translate(839.601562 0.746875)"/>
+     <use xlink:href="#DejaVuSans-16" transform="translate(903.224609 0.746875)"/>
+     <use xlink:href="#DejaVuSans-19" transform="translate(966.847656 0.746875)"/>
+     <use xlink:href="#DejaVuSans-16" transform="translate(1031.427734 42.046875) scale(0.7)"/>
+     <use xlink:href="#DejaVuSans-f" transform="translate(1078.698242 0.746875)"/>
+     <use xlink:href="#DejaVuSans-3" transform="translate(1110.485352 0.746875)"/>
+     <use xlink:href="#DejaVuSans-17" transform="translate(1142.272461 0.746875)"/>
+     <use xlink:href="#DejaVuSans-c1c" transform="translate(1225.37793 0.746875)"/>
+     <use xlink:href="#DejaVuSans-14" transform="translate(1328.649414 0.746875)"/>
+     <use xlink:href="#DejaVuSans-19" transform="translate(1392.272461 0.746875)"/>
+     <use xlink:href="#DejaVuSans-3" transform="translate(1455.895508 0.746875)"/>
+     <use xlink:href="#DejaVuSans-51" transform="translate(1487.682617 0.746875)"/>
+     <use xlink:href="#DejaVuSans-52" transform="translate(1551.061523 0.746875)"/>
+     <use xlink:href="#DejaVuSans-47" transform="translate(1612.243164 0.746875)"/>
+     <use xlink:href="#DejaVuSans-48" transform="translate(1675.719727 0.746875)"/>
+     <use xlink:href="#DejaVuSans-56" transform="translate(1737.243164 0.746875)"/>
+    </g>
+   </g>
+   <g id="legend_2">
+    <g id="line2d_69">
+     <path d="M 357.364418 221.404875 
+L 365.364418 221.404875 
+L 373.364418 221.404875 
+" style="fill: none; stroke: #3f8a5c; stroke-width: 1.7; stroke-linecap: square"/>
+     <g>
+      <use xlink:href="#mc8772fced7" x="365.364418" y="221.404875" style="fill: #3f8a5c; stroke: #3f8a5c"/>
+     </g>
+    </g>
+    <g id="text_27">
+     <!-- spectral -->
+     <g transform="translate(379.764418 224.204875) scale(0.08 -0.08)">
+      <use xlink:href="#DejaVuSans-56"/>
+      <use xlink:href="#DejaVuSans-53" transform="translate(52.09375 0)"/>
+      <use xlink:href="#DejaVuSans-48" transform="translate(115.578125 0)"/>
+      <use xlink:href="#DejaVuSans-46" transform="translate(177.109375 0)"/>
+      <use xlink:href="#DejaVuSans-57" transform="translate(232.09375 0)"/>
+      <use xlink:href="#DejaVuSans-55" transform="translate(271.296875 0)"/>
+      <use xlink:href="#DejaVuSans-44" transform="translate(312.40625 0)"/>
+      <use xlink:href="#DejaVuSans-4f" transform="translate(373.6875 0)"/>
+     </g>
+    </g>
+    <g id="line2d_70">
+     <path d="M 357.364418 233.4055 
+L 365.364418 233.4055 
+L 373.364418 233.4055 
+" style="fill: none; stroke: #c1662f; stroke-width: 1.7; stroke-linecap: square"/>
+     <g>
+      <use xlink:href="#mdfdb734841" x="365.364418" y="233.4055" style="fill: #c1662f; stroke: #c1662f; stroke-linejoin: miter"/>
+     </g>
+    </g>
+    <g id="text_28">
+     <!-- FD-2 -->
+     <g transform="translate(379.764418 236.2055) scale(0.08 -0.08)">
+      <use xlink:href="#DejaVuSans-29"/>
+      <use xlink:href="#DejaVuSans-27" transform="translate(57.515625 0)"/>
+      <use xlink:href="#DejaVuSans-10" transform="translate(134.515625 0)"/>
+      <use xlink:href="#DejaVuSans-15" transform="translate(170.59375 0)"/>
+     </g>
+    </g>
+    <g id="line2d_71">
+     <path d="M 357.364418 245.406125 
+L 365.364418 245.406125 
+L 373.364418 245.406125 
+" style="fill: none; stroke: #1f6fb4; stroke-width: 1.7; stroke-linecap: square"/>
+     <g>
+      <use xlink:href="#m15eebee5d8" x="365.364418" y="245.406125" style="fill: #1f6fb4; stroke: #1f6fb4; stroke-linejoin: miter"/>
+     </g>
+    </g>
+    <g id="text_29">
+     <!-- FD-8 -->
+     <g transform="translate(379.764418 248.206125) scale(0.08 -0.08)">
+      <use xlink:href="#DejaVuSans-29"/>
+      <use xlink:href="#DejaVuSans-27" transform="translate(57.515625 0)"/>
+      <use xlink:href="#DejaVuSans-10" transform="translate(134.515625 0)"/>
+      <use xlink:href="#DejaVuSans-1b" transform="translate(170.59375 0)"/>
+     </g>
+    </g>
+   </g>
+  </g>
+ </g>
+ <defs>
+  <clipPath id="p588fc3669c">
+   <rect x="45.800781" y="24.48" width="253.636364" height="232.848"/>
+  </clipPath>
+  <clipPath id="pa95b13f88f">
+   <rect x="350.164418" y="24.48" width="253.636364" height="232.848"/>
+  </clipPath>
+ </defs>
+</svg>

--- a/docs/report/figures/make_figures.py
+++ b/docs/report/figures/make_figures.py
@@ -265,9 +265,160 @@ def figure_tungsten_dealias_resolution():
     return out
 
 
+def figure_tungsten_weak_16n():
+    """Weak scaling to 16 nodes: constant work per GCD, growing problem.
+
+    Reads `tungsten_hip_weak_16n.csv`. The local block is exactly
+    2048 x 2048 x 16 at every point -- OpenPFC decomposes into z-slabs, so
+    growing only Lz keeps it constant rather than approximately constant,
+    which is what a cubic ladder would give. Perfect weak scaling is a flat
+    line at the 1-node time.
+    """
+    rows = sorted(read("tungsten_hip_weak_16n.csv"), key=lambda r: int(r["gcds"]))
+    nodes = [int(r["nodes"]) for r in rows]
+    t = [float(r["wall_step_ms"]) for r in rows]
+    eff = [100.0 * t[0] / v for v in t]
+
+    fig, (ax, ax2) = plt.subplots(1, 2, figsize=(9.6, 4.0))
+    ax.plot(nodes, t, "o-", color=COLORS["tungsten"], linewidth=1.8)
+    ax.axhline(t[0], color="#7a7a7a", linestyle="--", linewidth=1.0)
+    ax.annotate("ideal (flat)", xy=(nodes[0], t[0]), xytext=(6, 6),
+                textcoords="offset points", fontsize=8, color="#4a4a4a")
+    ax.set_xscale("log", base=2); ax.set_xticks(nodes); ax.set_xticklabels(nodes)
+    ax.set_xlabel("nodes (8 GCDs each)"); ax.set_ylabel("wall time per step [ms]")
+    ax.set_title("Constant 67.1M cells per GCD")
+    ax.grid(True, which="both", **GRID)
+
+    ax2.plot(nodes, eff, "o-", color=COLORS["tungsten"], linewidth=1.8)
+    for x, y, r in zip(nodes, eff, rows):
+        ax2.annotate(f"{y:.0f}%", xy=(x, y), xytext=(0, -14),
+                     textcoords="offset points", fontsize=7.5, ha="center")
+    ax2.set_xscale("log", base=2); ax2.set_xticks(nodes); ax2.set_xticklabels(nodes)
+    ax2.set_ylim(0, 110)
+    ax2.set_xlabel("nodes"); ax2.set_ylabel("weak-scaling efficiency [%]")
+    ax2.set_title(r"$8.59\times10^{9}$ cells at 16 nodes")
+    ax2.grid(True, which="both", **GRID)
+    fig.suptitle("Tungsten PFC weak scaling, LUMI-G", y=1.02)
+
+    out = HERE / "tungsten_weak_16n.svg"
+    fig.savefig(out, format="svg", bbox_inches="tight")
+    plt.close(fig)
+    return out
+
+
+def figure_tungsten_strong_1280():
+    """Strong scaling at 1280^3, and what happens when the grid does not divide.
+
+    Reads `tungsten_hip_strong_1280.csv`. Points where the z-planes divide
+    evenly among the ranks are filled; the one that does not (96 GCDs,
+    1280/96 = 13.33) is hollow and annotated, because it is slower than both
+    its neighbours and that is the point of the figure.
+    """
+    rows = sorted(read("tungsten_hip_strong_1280.csv"), key=lambda r: int(r["gcds"]))
+    g = [int(r["gcds"]) for r in rows]
+    t = [float(r["wall_step_ms"]) for r in rows]
+    ok = [r["divides"] == "1" for r in rows]
+    base_t, base_g = t[0], g[0]
+    speedup = [base_t / v for v in t]
+
+    fig, ax = plt.subplots(figsize=(6.4, 4.6))
+    ideal = [x / base_g for x in g]
+    ax.plot(g, ideal, "--", color="#7a7a7a", linewidth=1.0, label="ideal")
+    good = [(x, y) for x, y, k in zip(g, speedup, ok) if k]
+    bad = [(x, y) for x, y, k in zip(g, speedup, ok) if not k]
+    ax.plot([p[0] for p in good], [p[1] for p in good], "o-",
+            color=COLORS["tungsten"], linewidth=1.8, label="z-planes divide evenly")
+    if bad:
+        ax.plot([p[0] for p in bad], [p[1] for p in bad], "o", markersize=9,
+                markerfacecolor="white", markeredgecolor=COLORS["fd"],
+                markeredgewidth=1.8, label="does not divide")
+        bx, by = bad[0]
+        ax.annotate("1280/96 = 13.33:\nranks get 13 or 14 planes,\nevery step waits for the slowest",
+                    xy=(bx, by), xytext=(bx * 0.62, by * 1.9), fontsize=7.5,
+                    color="#4a4a4a",
+                    arrowprops=dict(arrowstyle="->", color="#7a7a7a", linewidth=0.8))
+    for x, y, k in zip(g, speedup, ok):
+        if k:
+            ax.annotate(f"{100 * y / (x / base_g):.0f}%", xy=(x, y), xytext=(4, -10),
+                        textcoords="offset points", fontsize=7.5)
+    ax.set_xscale("log", base=2); ax.set_xticks(g)
+    ax.set_xticklabels([f"{x}\n({x // 8}n)" for x in g])
+    ax.set_xlabel("GCDs (nodes)"); ax.set_ylabel(f"speedup vs {base_g} GCDs")
+    ax.set_title(r"Tungsten PFC strong scaling, $1280^3$, LUMI-G")
+    ax.grid(True, which="both", **GRID)
+    ax.legend(frameon=False, fontsize=8, loc="upper left")
+
+    out = HERE / "tungsten_strong_1280.svg"
+    fig.savefig(out, format="svg", bbox_inches="tight")
+    plt.close(fig)
+    return out
+
+
+def figure_heat3d_method_comparison():
+    """Spectral against finite difference: cost at equal grid, and scaling.
+
+    Reads `heat3d_method_cost.csv` and `heat3d_method_strong_1536.csv`. Left:
+    what one step costs on the same grid and hardware, the only difference
+    being the spatial operator. Right: how each method strong-scales to 16
+    nodes. The two panels answer different questions and the chapter is
+    careful not to conflate them -- cheap per step is not the same as cheap
+    per unit accuracy.
+    """
+    cost = read("heat3d_method_cost.csv")
+    spec_cost = next(float(r["wall_step_ms"]) for r in cost if r["method"] == "spectral")
+    fd = sorted((r for r in cost if r["method"] == "fd"), key=lambda r: int(r["fd_order"]))
+    orders = [int(r["fd_order"]) for r in fd]
+    times = [float(r["wall_step_ms"]) for r in fd]
+
+    fig, (ax, ax2) = plt.subplots(1, 2, figsize=(10.0, 4.2))
+    ax.plot(orders, times, "o-", color=COLORS["fd"], linewidth=1.8,
+            label="finite difference")
+    ax.axhline(spec_cost, color=COLORS["spectral"], linestyle="--", linewidth=1.6,
+               label="spectral")
+    ax.annotate(f"spectral {spec_cost:.0f} ms\n= {spec_cost / times[0]:.0f}x FD-2",
+                xy=(orders[-1], spec_cost), xytext=(orders[-1], spec_cost * 0.42),
+                fontsize=8, color="#4a4a4a", ha="right")
+    ax.set_yscale("log")
+    ax.set_xticks(orders)
+    ax.set_xlabel("finite-difference order"); ax.set_ylabel("wall time per step [ms]")
+    ax.set_title(r"Cost at equal grid ($1024^3$, 8 GCDs)")
+    ax.grid(True, which="both", **GRID)
+    ax.legend(frameon=False, fontsize=8, loc="center right")
+
+    strong = read("heat3d_method_strong_1536.csv")
+    series = {}
+    for r in strong:
+        key = "spectral" if r["method"] == "spectral" else f"FD-{r['fd_order']}"
+        series.setdefault(key, []).append((int(r["gcds"]), float(r["wall_step_ms"])))
+    style = {"spectral": (COLORS["spectral"], "o-"), "FD-2": (COLORS["fd"], "s-"),
+             "FD-8": (COLORS["tungsten"], "^-")}
+    for key in ("spectral", "FD-2", "FD-8"):
+        pts = sorted(series[key])
+        g = [p[0] for p in pts]; t = [p[1] for p in pts]
+        eff = [100.0 * t[0] / v / (x / g[0]) for x, v in zip(g, t)]
+        c, m = style[key]
+        ax2.plot([x // 8 for x in g], eff, m, color=c, linewidth=1.7, label=key)
+    ax2.axhline(100, color="#7a7a7a", linestyle="--", linewidth=1.0)
+    ax2.set_xscale("log", base=2)
+    ax2.set_xticks([4, 8, 12, 16]); ax2.set_xticklabels([4, 8, 12, 16])
+    ax2.set_ylim(0, 115)
+    ax2.set_xlabel("nodes"); ax2.set_ylabel("strong-scaling efficiency [%]")
+    ax2.set_title(r"Strong scaling, $1536^3$, 4$\to$16 nodes")
+    ax2.grid(True, which="both", **GRID)
+    ax2.legend(frameon=False, fontsize=8, loc="lower left")
+
+    out = HERE / "heat3d_method_comparison.svg"
+    fig.savefig(out, format="svg", bbox_inches="tight")
+    plt.close(fig)
+    return out
+
+
 if __name__ == "__main__":
     figures = (figure_speedup(), figure_sizing(),
                figure_heat3d_fd_order_convergence(),
-               figure_tungsten_dealias_resolution())
+               figure_tungsten_dealias_resolution(),
+               figure_tungsten_weak_16n(),
+               figure_tungsten_strong_1280(),
+               figure_heat3d_method_comparison())
     for path in figures:
         print("wrote", path.relative_to(HERE.parent.parent.parent))

--- a/docs/report/figures/tungsten_strong_1280.svg
+++ b/docs/report/figures/tungsten_strong_1280.svg
@@ -1,0 +1,1683 @@
+<?xml version="1.0" encoding="utf-8" standalone="no"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN"
+  "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="412.861101pt" height="331.708687pt" viewBox="0 0 412.861101 331.708687" xmlns="http://www.w3.org/2000/svg" version="1.1">
+ <metadata>
+  <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+   <cc:Work>
+    <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
+    <dc:date>2026-09-10T16:41:06.702914</dc:date>
+    <dc:format>image/svg+xml</dc:format>
+    <dc:creator>
+     <cc:Agent>
+      <dc:title>Matplotlib v3.11.1, https://matplotlib.org/</dc:title>
+     </cc:Agent>
+    </dc:creator>
+   </cc:Work>
+  </rdf:RDF>
+ </metadata>
+ <defs>
+  <style type="text/css">*{stroke-linejoin: round; stroke-linecap: butt}</style>
+ </defs>
+ <g id="figure_1">
+  <g id="patch_1">
+   <path d="M 0 331.708687 
+L 412.861101 331.708687 
+L 412.861101 0 
+L 0 0 
+z
+" style="fill: #ffffff"/>
+  </g>
+  <g id="axes_1">
+   <g id="patch_2">
+    <path d="M 44.103906 279.504 
+L 401.223906 279.504 
+L 401.223906 24.48 
+L 44.103906 24.48 
+z
+" style="fill: #ffffff"/>
+   </g>
+   <g id="matplotlib.axis_1">
+    <g id="xtick_1">
+     <g id="line2d_1">
+      <path d="M 60.336634 279.504 
+L 60.336634 24.48 
+" clip-path="url(#p001f968744)" style="fill: none; stroke: #d5d8dc; stroke-width: 0.6; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_2">
+      <defs>
+       <path id="mf315b8920d" d="M 0 0 
+L 0 3.5 
+" style="stroke: #000000; stroke-width: 0.8"/>
+      </defs>
+      <g>
+       <use xlink:href="#mf315b8920d" x="60.336634" y="279.504" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_1">
+      <!-- 32 -->
+      <g transform="translate(53.974134 295.102633) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-16" d="M 2597 2516 
+Q 3050 2419 3304 2112 
+Q 3559 1806 3559 1356 
+Q 3559 666 3084 287 
+Q 2609 -91 1734 -91 
+Q 1441 -91 1130 -33 
+Q 819 25 488 141 
+L 488 750 
+Q 750 597 1062 519 
+Q 1375 441 1716 441 
+Q 2309 441 2620 675 
+Q 2931 909 2931 1356 
+Q 2931 1769 2642 2001 
+Q 2353 2234 1838 2234 
+L 1294 2234 
+L 1294 2753 
+L 1863 2753 
+Q 2328 2753 2575 2939 
+Q 2822 3125 2822 3475 
+Q 2822 3834 2567 4026 
+Q 2313 4219 1838 4219 
+Q 1578 4219 1281 4162 
+Q 984 4106 628 3988 
+L 628 4550 
+Q 988 4650 1302 4700 
+Q 1616 4750 1894 4750 
+Q 2613 4750 3031 4423 
+Q 3450 4097 3450 3541 
+Q 3450 3153 3228 2886 
+Q 3006 2619 2597 2516 
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-15" d="M 1228 531 
+L 3431 531 
+L 3431 0 
+L 469 0 
+L 469 531 
+Q 828 903 1448 1529 
+Q 2069 2156 2228 2338 
+Q 2531 2678 2651 2914 
+Q 2772 3150 2772 3378 
+Q 2772 3750 2511 3984 
+Q 2250 4219 1831 4219 
+Q 1534 4219 1204 4116 
+Q 875 4013 500 3803 
+L 500 4441 
+Q 881 4594 1212 4672 
+Q 1544 4750 1819 4750 
+Q 2544 4750 2975 4387 
+Q 3406 4025 3406 3419 
+Q 3406 3131 3298 2873 
+Q 3191 2616 2906 2266 
+Q 2828 2175 2409 1742 
+Q 1991 1309 1228 531 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-16"/>
+       <use xlink:href="#DejaVuSans-15" transform="translate(63.625 0)"/>
+      </g>
+      <!-- (4n) -->
+      <g transform="translate(50.085071 307.104586) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-b" d="M 1984 4856 
+Q 1566 4138 1362 3434 
+Q 1159 2731 1159 2009 
+Q 1159 1288 1364 580 
+Q 1569 -128 1984 -844 
+L 1484 -844 
+Q 1016 -109 783 600 
+Q 550 1309 550 2009 
+Q 550 2706 781 3412 
+Q 1013 4119 1484 4856 
+L 1984 4856 
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-17" d="M 2419 4116 
+L 825 1625 
+L 2419 1625 
+L 2419 4116 
+z
+M 2253 4666 
+L 3047 4666 
+L 3047 1625 
+L 3713 1625 
+L 3713 1100 
+L 3047 1100 
+L 3047 0 
+L 2419 0 
+L 2419 1100 
+L 313 1100 
+L 313 1709 
+L 2253 4666 
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-51" d="M 3513 2113 
+L 3513 0 
+L 2938 0 
+L 2938 2094 
+Q 2938 2591 2744 2837 
+Q 2550 3084 2163 3084 
+Q 1697 3084 1428 2787 
+Q 1159 2491 1159 1978 
+L 1159 0 
+L 581 0 
+L 581 3500 
+L 1159 3500 
+L 1159 2956 
+Q 1366 3272 1645 3428 
+Q 1925 3584 2291 3584 
+Q 2894 3584 3203 3211 
+Q 3513 2838 3513 2113 
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-c" d="M 513 4856 
+L 1013 4856 
+Q 1481 4119 1714 3412 
+Q 1947 2706 1947 2009 
+Q 1947 1309 1714 600 
+Q 1481 -109 1013 -844 
+L 513 -844 
+Q 928 -128 1133 580 
+Q 1338 1288 1338 2009 
+Q 1338 2731 1133 3434 
+Q 928 4138 513 4856 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-b"/>
+       <use xlink:href="#DejaVuSans-17" transform="translate(39.015625 0)"/>
+       <use xlink:href="#DejaVuSans-51" transform="translate(102.640625 0)"/>
+       <use xlink:href="#DejaVuSans-c" transform="translate(166.015625 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_2">
+     <g id="line2d_3">
+      <path d="M 222.663906 279.504 
+L 222.663906 24.48 
+" clip-path="url(#p001f968744)" style="fill: none; stroke: #d5d8dc; stroke-width: 0.6; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_4">
+      <g>
+       <use xlink:href="#mf315b8920d" x="222.663906" y="279.504" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_2">
+      <!-- 64 -->
+      <g transform="translate(216.301406 295.102633) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-19" d="M 2113 2584 
+Q 1688 2584 1439 2293 
+Q 1191 2003 1191 1497 
+Q 1191 994 1439 701 
+Q 1688 409 2113 409 
+Q 2538 409 2786 701 
+Q 3034 994 3034 1497 
+Q 3034 2003 2786 2293 
+Q 2538 2584 2113 2584 
+z
+M 3366 4563 
+L 3366 3988 
+Q 3128 4100 2886 4159 
+Q 2644 4219 2406 4219 
+Q 1781 4219 1451 3797 
+Q 1122 3375 1075 2522 
+Q 1259 2794 1537 2939 
+Q 1816 3084 2150 3084 
+Q 2853 3084 3261 2657 
+Q 3669 2231 3669 1497 
+Q 3669 778 3244 343 
+Q 2819 -91 2113 -91 
+Q 1303 -91 875 529 
+Q 447 1150 447 2328 
+Q 447 3434 972 4092 
+Q 1497 4750 2381 4750 
+Q 2619 4750 2861 4703 
+Q 3103 4656 3366 4563 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-19"/>
+       <use xlink:href="#DejaVuSans-17" transform="translate(63.625 0)"/>
+      </g>
+      <!-- (8n) -->
+      <g transform="translate(212.412344 307.104586) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-1b" d="M 2034 2216 
+Q 1584 2216 1326 1975 
+Q 1069 1734 1069 1313 
+Q 1069 891 1326 650 
+Q 1584 409 2034 409 
+Q 2484 409 2743 651 
+Q 3003 894 3003 1313 
+Q 3003 1734 2745 1975 
+Q 2488 2216 2034 2216 
+z
+M 1403 2484 
+Q 997 2584 770 2862 
+Q 544 3141 544 3541 
+Q 544 4100 942 4425 
+Q 1341 4750 2034 4750 
+Q 2731 4750 3128 4425 
+Q 3525 4100 3525 3541 
+Q 3525 3141 3298 2862 
+Q 3072 2584 2669 2484 
+Q 3125 2378 3379 2068 
+Q 3634 1759 3634 1313 
+Q 3634 634 3220 271 
+Q 2806 -91 2034 -91 
+Q 1263 -91 848 271 
+Q 434 634 434 1313 
+Q 434 1759 690 2068 
+Q 947 2378 1403 2484 
+z
+M 1172 3481 
+Q 1172 3119 1398 2916 
+Q 1625 2713 2034 2713 
+Q 2441 2713 2670 2916 
+Q 2900 3119 2900 3481 
+Q 2900 3844 2670 4047 
+Q 2441 4250 2034 4250 
+Q 1625 4250 1398 4047 
+Q 1172 3844 1172 3481 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-b"/>
+       <use xlink:href="#DejaVuSans-1b" transform="translate(39.015625 0)"/>
+       <use xlink:href="#DejaVuSans-51" transform="translate(102.640625 0)"/>
+       <use xlink:href="#DejaVuSans-c" transform="translate(166.015625 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_3">
+     <g id="line2d_5">
+      <path d="M 274.921616 279.504 
+L 274.921616 24.48 
+" clip-path="url(#p001f968744)" style="fill: none; stroke: #d5d8dc; stroke-width: 0.6; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_6">
+      <g>
+       <use xlink:href="#mf315b8920d" x="274.921616" y="279.504" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_3">
+      <!-- 80 -->
+      <g transform="translate(268.559116 295.102633) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-13" d="M 2034 4250 
+Q 1547 4250 1301 3770 
+Q 1056 3291 1056 2328 
+Q 1056 1369 1301 889 
+Q 1547 409 2034 409 
+Q 2525 409 2770 889 
+Q 3016 1369 3016 2328 
+Q 3016 3291 2770 3770 
+Q 2525 4250 2034 4250 
+z
+M 2034 4750 
+Q 2819 4750 3233 4129 
+Q 3647 3509 3647 2328 
+Q 3647 1150 3233 529 
+Q 2819 -91 2034 -91 
+Q 1250 -91 836 529 
+Q 422 1150 422 2328 
+Q 422 3509 836 4129 
+Q 1250 4750 2034 4750 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-1b"/>
+       <use xlink:href="#DejaVuSans-13" transform="translate(63.625 0)"/>
+      </g>
+      <!-- (10n) -->
+      <g transform="translate(261.488803 307.104586) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-14" d="M 794 531 
+L 1825 531 
+L 1825 4091 
+L 703 3866 
+L 703 4441 
+L 1819 4666 
+L 2450 4666 
+L 2450 531 
+L 3481 531 
+L 3481 0 
+L 794 0 
+L 794 531 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-b"/>
+       <use xlink:href="#DejaVuSans-14" transform="translate(39.015625 0)"/>
+       <use xlink:href="#DejaVuSans-13" transform="translate(102.640625 0)"/>
+       <use xlink:href="#DejaVuSans-51" transform="translate(166.265625 0)"/>
+       <use xlink:href="#DejaVuSans-c" transform="translate(229.640625 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_4">
+     <g id="line2d_7">
+      <path d="M 317.619274 279.504 
+L 317.619274 24.48 
+" clip-path="url(#p001f968744)" style="fill: none; stroke: #d5d8dc; stroke-width: 0.6; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_8">
+      <g>
+       <use xlink:href="#mf315b8920d" x="317.619274" y="279.504" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_4">
+      <!-- 96 -->
+      <g transform="translate(311.256774 295.102633) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-1c" d="M 703 97 
+L 703 672 
+Q 941 559 1184 500 
+Q 1428 441 1663 441 
+Q 2288 441 2617 861 
+Q 2947 1281 2994 2138 
+Q 2813 1869 2534 1725 
+Q 2256 1581 1919 1581 
+Q 1219 1581 811 2004 
+Q 403 2428 403 3163 
+Q 403 3881 828 4315 
+Q 1253 4750 1959 4750 
+Q 2769 4750 3195 4129 
+Q 3622 3509 3622 2328 
+Q 3622 1225 3098 567 
+Q 2575 -91 1691 -91 
+Q 1453 -91 1209 -44 
+Q 966 3 703 97 
+z
+M 1959 2075 
+Q 2384 2075 2632 2365 
+Q 2881 2656 2881 3163 
+Q 2881 3666 2632 3958 
+Q 2384 4250 1959 4250 
+Q 1534 4250 1286 3958 
+Q 1038 3666 1038 3163 
+Q 1038 2656 1286 2365 
+Q 1534 2075 1959 2075 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-1c"/>
+       <use xlink:href="#DejaVuSans-19" transform="translate(63.625 0)"/>
+      </g>
+      <!-- (12n) -->
+      <g transform="translate(304.186461 307.104586) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-b"/>
+       <use xlink:href="#DejaVuSans-14" transform="translate(39.015625 0)"/>
+       <use xlink:href="#DejaVuSans-15" transform="translate(102.640625 0)"/>
+       <use xlink:href="#DejaVuSans-51" transform="translate(166.265625 0)"/>
+       <use xlink:href="#DejaVuSans-c" transform="translate(229.640625 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_5">
+     <g id="line2d_9">
+      <path d="M 384.991179 279.504 
+L 384.991179 24.48 
+" clip-path="url(#p001f968744)" style="fill: none; stroke: #d5d8dc; stroke-width: 0.6; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_10">
+      <g>
+       <use xlink:href="#mf315b8920d" x="384.991179" y="279.504" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_5">
+      <!-- 128 -->
+      <g transform="translate(375.447429 295.102633) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-14"/>
+       <use xlink:href="#DejaVuSans-15" transform="translate(63.625 0)"/>
+       <use xlink:href="#DejaVuSans-1b" transform="translate(127.25 0)"/>
+      </g>
+      <!-- (16n) -->
+      <g transform="translate(371.558366 307.104586) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-b"/>
+       <use xlink:href="#DejaVuSans-14" transform="translate(39.015625 0)"/>
+       <use xlink:href="#DejaVuSans-19" transform="translate(102.640625 0)"/>
+       <use xlink:href="#DejaVuSans-51" transform="translate(166.265625 0)"/>
+       <use xlink:href="#DejaVuSans-c" transform="translate(229.640625 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="text_6">
+     <!-- GCDs (nodes) -->
+     <g transform="translate(188.269375 322.106344) scale(0.1 -0.1)">
+      <defs>
+       <path id="DejaVuSans-2a" d="M 3809 666 
+L 3809 1919 
+L 2778 1919 
+L 2778 2438 
+L 4434 2438 
+L 4434 434 
+Q 4069 175 3628 42 
+Q 3188 -91 2688 -91 
+Q 1594 -91 976 548 
+Q 359 1188 359 2328 
+Q 359 3472 976 4111 
+Q 1594 4750 2688 4750 
+Q 3144 4750 3555 4637 
+Q 3966 4525 4313 4306 
+L 4313 3634 
+Q 3963 3931 3569 4081 
+Q 3175 4231 2741 4231 
+Q 1884 4231 1454 3753 
+Q 1025 3275 1025 2328 
+Q 1025 1384 1454 906 
+Q 1884 428 2741 428 
+Q 3075 428 3337 486 
+Q 3600 544 3809 666 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-26" d="M 4122 4306 
+L 4122 3641 
+Q 3803 3938 3442 4084 
+Q 3081 4231 2675 4231 
+Q 1875 4231 1450 3742 
+Q 1025 3253 1025 2328 
+Q 1025 1406 1450 917 
+Q 1875 428 2675 428 
+Q 3081 428 3442 575 
+Q 3803 722 4122 1019 
+L 4122 359 
+Q 3791 134 3420 21 
+Q 3050 -91 2638 -91 
+Q 1578 -91 968 557 
+Q 359 1206 359 2328 
+Q 359 3453 968 4101 
+Q 1578 4750 2638 4750 
+Q 3056 4750 3426 4639 
+Q 3797 4528 4122 4306 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-27" d="M 1259 4147 
+L 1259 519 
+L 2022 519 
+Q 2988 519 3436 956 
+Q 3884 1394 3884 2338 
+Q 3884 3275 3436 3711 
+Q 2988 4147 2022 4147 
+L 1259 4147 
+z
+M 628 4666 
+L 1925 4666 
+Q 3281 4666 3915 4102 
+Q 4550 3538 4550 2338 
+Q 4550 1131 3912 565 
+Q 3275 0 1925 0 
+L 628 0 
+L 628 4666 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-56" d="M 2834 3397 
+L 2834 2853 
+Q 2591 2978 2328 3040 
+Q 2066 3103 1784 3103 
+Q 1356 3103 1142 2972 
+Q 928 2841 928 2578 
+Q 928 2378 1081 2264 
+Q 1234 2150 1697 2047 
+L 1894 2003 
+Q 2506 1872 2764 1633 
+Q 3022 1394 3022 966 
+Q 3022 478 2636 193 
+Q 2250 -91 1575 -91 
+Q 1294 -91 989 -36 
+Q 684 19 347 128 
+L 347 722 
+Q 666 556 975 473 
+Q 1284 391 1588 391 
+Q 1994 391 2212 530 
+Q 2431 669 2431 922 
+Q 2431 1156 2273 1281 
+Q 2116 1406 1581 1522 
+L 1381 1569 
+Q 847 1681 609 1914 
+Q 372 2147 372 2553 
+Q 372 3047 722 3315 
+Q 1072 3584 1716 3584 
+Q 2034 3584 2315 3537 
+Q 2597 3491 2834 3397 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-3" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-52" d="M 1959 3097 
+Q 1497 3097 1228 2736 
+Q 959 2375 959 1747 
+Q 959 1119 1226 758 
+Q 1494 397 1959 397 
+Q 2419 397 2687 759 
+Q 2956 1122 2956 1747 
+Q 2956 2369 2687 2733 
+Q 2419 3097 1959 3097 
+z
+M 1959 3584 
+Q 2709 3584 3137 3096 
+Q 3566 2609 3566 1747 
+Q 3566 888 3137 398 
+Q 2709 -91 1959 -91 
+Q 1206 -91 779 398 
+Q 353 888 353 1747 
+Q 353 2609 779 3096 
+Q 1206 3584 1959 3584 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-47" d="M 2906 2969 
+L 2906 4863 
+L 3481 4863 
+L 3481 0 
+L 2906 0 
+L 2906 525 
+Q 2725 213 2448 61 
+Q 2172 -91 1784 -91 
+Q 1150 -91 751 415 
+Q 353 922 353 1747 
+Q 353 2572 751 3078 
+Q 1150 3584 1784 3584 
+Q 2172 3584 2448 3432 
+Q 2725 3281 2906 2969 
+z
+M 947 1747 
+Q 947 1113 1208 752 
+Q 1469 391 1925 391 
+Q 2381 391 2643 752 
+Q 2906 1113 2906 1747 
+Q 2906 2381 2643 2742 
+Q 2381 3103 1925 3103 
+Q 1469 3103 1208 2742 
+Q 947 2381 947 1747 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-48" d="M 3597 1894 
+L 3597 1613 
+L 953 1613 
+Q 991 1019 1311 708 
+Q 1631 397 2203 397 
+Q 2534 397 2845 478 
+Q 3156 559 3463 722 
+L 3463 178 
+Q 3153 47 2828 -22 
+Q 2503 -91 2169 -91 
+Q 1331 -91 842 396 
+Q 353 884 353 1716 
+Q 353 2575 817 3079 
+Q 1281 3584 2069 3584 
+Q 2775 3584 3186 3129 
+Q 3597 2675 3597 1894 
+z
+M 3022 2063 
+Q 3016 2534 2758 2815 
+Q 2500 3097 2075 3097 
+Q 1594 3097 1305 2825 
+Q 1016 2553 972 2059 
+L 3022 2063 
+z
+" transform="scale(0.015625)"/>
+      </defs>
+      <use xlink:href="#DejaVuSans-2a"/>
+      <use xlink:href="#DejaVuSans-26" transform="translate(77.484375 0)"/>
+      <use xlink:href="#DejaVuSans-27" transform="translate(147.3125 0)"/>
+      <use xlink:href="#DejaVuSans-56" transform="translate(224.3125 0)"/>
+      <use xlink:href="#DejaVuSans-3" transform="translate(276.40625 0)"/>
+      <use xlink:href="#DejaVuSans-b" transform="translate(308.1875 0)"/>
+      <use xlink:href="#DejaVuSans-51" transform="translate(347.203125 0)"/>
+      <use xlink:href="#DejaVuSans-52" transform="translate(410.578125 0)"/>
+      <use xlink:href="#DejaVuSans-47" transform="translate(471.765625 0)"/>
+      <use xlink:href="#DejaVuSans-48" transform="translate(535.25 0)"/>
+      <use xlink:href="#DejaVuSans-56" transform="translate(596.78125 0)"/>
+      <use xlink:href="#DejaVuSans-c" transform="translate(648.875 0)"/>
+     </g>
+    </g>
+   </g>
+   <g id="matplotlib.axis_2">
+    <g id="ytick_1">
+     <g id="line2d_11">
+      <path d="M 44.103906 267.912 
+L 401.223906 267.912 
+" clip-path="url(#p001f968744)" style="fill: none; stroke: #d5d8dc; stroke-width: 0.6; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_12">
+      <defs>
+       <path id="m0093af3f32" d="M 0 0 
+L -3.5 0 
+" style="stroke: #000000; stroke-width: 0.8"/>
+      </defs>
+      <g>
+       <use xlink:href="#m0093af3f32" x="44.103906" y="267.912" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_7">
+      <!-- 1.0 -->
+      <g transform="translate(21.200781 271.710828) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-11" d="M 684 794 
+L 1344 794 
+L 1344 0 
+L 684 0 
+L 684 794 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-14"/>
+       <use xlink:href="#DejaVuSans-11" transform="translate(63.625 0)"/>
+       <use xlink:href="#DejaVuSans-13" transform="translate(95.40625 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_2">
+     <g id="line2d_13">
+      <path d="M 44.103906 229.272 
+L 401.223906 229.272 
+" clip-path="url(#p001f968744)" style="fill: none; stroke: #d5d8dc; stroke-width: 0.6; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_14">
+      <g>
+       <use xlink:href="#m0093af3f32" x="44.103906" y="229.272" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_8">
+      <!-- 1.5 -->
+      <g transform="translate(21.200781 233.070828) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-18" d="M 691 4666 
+L 3169 4666 
+L 3169 4134 
+L 1269 4134 
+L 1269 2991 
+Q 1406 3038 1543 3061 
+Q 1681 3084 1819 3084 
+Q 2600 3084 3056 2656 
+Q 3513 2228 3513 1497 
+Q 3513 744 3044 326 
+Q 2575 -91 1722 -91 
+Q 1428 -91 1123 -41 
+Q 819 9 494 109 
+L 494 744 
+Q 775 591 1075 516 
+Q 1375 441 1709 441 
+Q 2250 441 2565 725 
+Q 2881 1009 2881 1497 
+Q 2881 1984 2565 2268 
+Q 2250 2553 1709 2553 
+Q 1456 2553 1204 2497 
+Q 953 2441 691 2322 
+L 691 4666 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-14"/>
+       <use xlink:href="#DejaVuSans-11" transform="translate(63.625 0)"/>
+       <use xlink:href="#DejaVuSans-18" transform="translate(95.40625 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_3">
+     <g id="line2d_15">
+      <path d="M 44.103906 190.632 
+L 401.223906 190.632 
+" clip-path="url(#p001f968744)" style="fill: none; stroke: #d5d8dc; stroke-width: 0.6; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_16">
+      <g>
+       <use xlink:href="#m0093af3f32" x="44.103906" y="190.632" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_9">
+      <!-- 2.0 -->
+      <g transform="translate(21.200781 194.430828) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-15"/>
+       <use xlink:href="#DejaVuSans-11" transform="translate(63.625 0)"/>
+       <use xlink:href="#DejaVuSans-13" transform="translate(95.40625 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_4">
+     <g id="line2d_17">
+      <path d="M 44.103906 151.992 
+L 401.223906 151.992 
+" clip-path="url(#p001f968744)" style="fill: none; stroke: #d5d8dc; stroke-width: 0.6; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_18">
+      <g>
+       <use xlink:href="#m0093af3f32" x="44.103906" y="151.992" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_10">
+      <!-- 2.5 -->
+      <g transform="translate(21.200781 155.790828) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-15"/>
+       <use xlink:href="#DejaVuSans-11" transform="translate(63.625 0)"/>
+       <use xlink:href="#DejaVuSans-18" transform="translate(95.40625 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_5">
+     <g id="line2d_19">
+      <path d="M 44.103906 113.352 
+L 401.223906 113.352 
+" clip-path="url(#p001f968744)" style="fill: none; stroke: #d5d8dc; stroke-width: 0.6; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_20">
+      <g>
+       <use xlink:href="#m0093af3f32" x="44.103906" y="113.352" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_11">
+      <!-- 3.0 -->
+      <g transform="translate(21.200781 117.150828) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-16"/>
+       <use xlink:href="#DejaVuSans-11" transform="translate(63.625 0)"/>
+       <use xlink:href="#DejaVuSans-13" transform="translate(95.40625 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_6">
+     <g id="line2d_21">
+      <path d="M 44.103906 74.712 
+L 401.223906 74.712 
+" clip-path="url(#p001f968744)" style="fill: none; stroke: #d5d8dc; stroke-width: 0.6; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_22">
+      <g>
+       <use xlink:href="#m0093af3f32" x="44.103906" y="74.712" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_12">
+      <!-- 3.5 -->
+      <g transform="translate(21.200781 78.510828) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-16"/>
+       <use xlink:href="#DejaVuSans-11" transform="translate(63.625 0)"/>
+       <use xlink:href="#DejaVuSans-18" transform="translate(95.40625 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_7">
+     <g id="line2d_23">
+      <path d="M 44.103906 36.072 
+L 401.223906 36.072 
+" clip-path="url(#p001f968744)" style="fill: none; stroke: #d5d8dc; stroke-width: 0.6; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_24">
+      <g>
+       <use xlink:href="#m0093af3f32" x="44.103906" y="36.072" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_13">
+      <!-- 4.0 -->
+      <g transform="translate(21.200781 39.870828) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-17"/>
+       <use xlink:href="#DejaVuSans-11" transform="translate(63.625 0)"/>
+       <use xlink:href="#DejaVuSans-13" transform="translate(95.40625 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="text_14">
+     <!-- speedup vs 32 GCDs -->
+     <g transform="translate(14.798438 203.955281) rotate(-90) scale(0.1 -0.1)">
+      <defs>
+       <path id="DejaVuSans-53" d="M 1159 525 
+L 1159 -1331 
+L 581 -1331 
+L 581 3500 
+L 1159 3500 
+L 1159 2969 
+Q 1341 3281 1617 3432 
+Q 1894 3584 2278 3584 
+Q 2916 3584 3314 3078 
+Q 3713 2572 3713 1747 
+Q 3713 922 3314 415 
+Q 2916 -91 2278 -91 
+Q 1894 -91 1617 61 
+Q 1341 213 1159 525 
+z
+M 3116 1747 
+Q 3116 2381 2855 2742 
+Q 2594 3103 2138 3103 
+Q 1681 3103 1420 2742 
+Q 1159 2381 1159 1747 
+Q 1159 1113 1420 752 
+Q 1681 391 2138 391 
+Q 2594 391 2855 752 
+Q 3116 1113 3116 1747 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-58" d="M 544 1381 
+L 544 3500 
+L 1119 3500 
+L 1119 1403 
+Q 1119 906 1312 657 
+Q 1506 409 1894 409 
+Q 2359 409 2629 706 
+Q 2900 1003 2900 1516 
+L 2900 3500 
+L 3475 3500 
+L 3475 0 
+L 2900 0 
+L 2900 538 
+Q 2691 219 2414 64 
+Q 2138 -91 1772 -91 
+Q 1169 -91 856 284 
+Q 544 659 544 1381 
+z
+M 1991 3584 
+L 1991 3584 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-59" d="M 191 3500 
+L 800 3500 
+L 1894 563 
+L 2988 3500 
+L 3597 3500 
+L 2284 0 
+L 1503 0 
+L 191 3500 
+z
+" transform="scale(0.015625)"/>
+      </defs>
+      <use xlink:href="#DejaVuSans-56"/>
+      <use xlink:href="#DejaVuSans-53" transform="translate(52.09375 0)"/>
+      <use xlink:href="#DejaVuSans-48" transform="translate(115.578125 0)"/>
+      <use xlink:href="#DejaVuSans-48" transform="translate(177.109375 0)"/>
+      <use xlink:href="#DejaVuSans-47" transform="translate(238.640625 0)"/>
+      <use xlink:href="#DejaVuSans-58" transform="translate(302.125 0)"/>
+      <use xlink:href="#DejaVuSans-53" transform="translate(365.5 0)"/>
+      <use xlink:href="#DejaVuSans-3" transform="translate(428.984375 0)"/>
+      <use xlink:href="#DejaVuSans-59" transform="translate(460.765625 0)"/>
+      <use xlink:href="#DejaVuSans-56" transform="translate(519.953125 0)"/>
+      <use xlink:href="#DejaVuSans-3" transform="translate(572.046875 0)"/>
+      <use xlink:href="#DejaVuSans-16" transform="translate(603.828125 0)"/>
+      <use xlink:href="#DejaVuSans-15" transform="translate(667.453125 0)"/>
+      <use xlink:href="#DejaVuSans-3" transform="translate(731.078125 0)"/>
+      <use xlink:href="#DejaVuSans-2a" transform="translate(762.859375 0)"/>
+      <use xlink:href="#DejaVuSans-26" transform="translate(840.34375 0)"/>
+      <use xlink:href="#DejaVuSans-27" transform="translate(910.171875 0)"/>
+      <use xlink:href="#DejaVuSans-56" transform="translate(987.171875 0)"/>
+     </g>
+    </g>
+   </g>
+   <g id="line2d_25">
+    <path d="M 60.336634 267.912 
+L 222.663906 190.632 
+L 274.921616 151.992 
+L 317.619274 113.352 
+L 384.991179 36.072 
+" clip-path="url(#p001f968744)" style="fill: none; stroke-dasharray: 3.7,1.6; stroke-dashoffset: 0; stroke: #7a7a7a"/>
+   </g>
+   <g id="line2d_26">
+    <path d="M 60.336634 267.912 
+L 222.663906 213.743817 
+L 274.921616 182.722828 
+L 384.991179 91.694128 
+" clip-path="url(#p001f968744)" style="fill: none; stroke: #1f6fb4; stroke-width: 1.8; stroke-linecap: square"/>
+    <defs>
+     <path id="mc807f545de" d="M 0 3 
+C 0.795609 3 1.55874 2.683901 2.12132 2.12132 
+C 2.683901 1.55874 3 0.795609 3 0 
+C 3 -0.795609 2.683901 -1.55874 2.12132 -2.12132 
+C 1.55874 -2.683901 0.795609 -3 0 -3 
+C -0.795609 -3 -1.55874 -2.683901 -2.12132 -2.12132 
+C -2.683901 -1.55874 -3 -0.795609 -3 0 
+C -3 0.795609 -2.683901 1.55874 -2.12132 2.12132 
+C -1.55874 2.683901 -0.795609 3 0 3 
+z
+" style="stroke: #1f6fb4"/>
+    </defs>
+    <g clip-path="url(#p001f968744)">
+     <use xlink:href="#mc807f545de" x="60.336634" y="267.912" style="fill: #1f6fb4; stroke: #1f6fb4"/>
+     <use xlink:href="#mc807f545de" x="222.663906" y="213.743817" style="fill: #1f6fb4; stroke: #1f6fb4"/>
+     <use xlink:href="#mc807f545de" x="274.921616" y="182.722828" style="fill: #1f6fb4; stroke: #1f6fb4"/>
+     <use xlink:href="#mc807f545de" x="384.991179" y="91.694128" style="fill: #1f6fb4; stroke: #1f6fb4"/>
+    </g>
+   </g>
+   <g id="line2d_27">
+    <defs>
+     <path id="m187ea5c38a" d="M 0 4.5 
+C 1.193414 4.5 2.338109 4.025852 3.181981 3.181981 
+C 4.025852 2.338109 4.5 1.193414 4.5 0 
+C 4.5 -1.193414 4.025852 -2.338109 3.181981 -3.181981 
+C 2.338109 -4.025852 1.193414 -4.5 0 -4.5 
+C -1.193414 -4.5 -2.338109 -4.025852 -3.181981 -3.181981 
+C -4.025852 -2.338109 -4.5 -1.193414 -4.5 0 
+C -4.5 1.193414 -4.025852 2.338109 -3.181981 3.181981 
+C -2.338109 4.025852 -1.193414 4.5 0 4.5 
+z
+" style="stroke: #c1662f; stroke-width: 1.8"/>
+    </defs>
+    <g clip-path="url(#p001f968744)">
+     <use xlink:href="#m187ea5c38a" x="317.619274" y="256.511355" style="fill: #ffffff; stroke: #c1662f; stroke-width: 1.8"/>
+    </g>
+   </g>
+   <g id="patch_3">
+    <path d="M 44.103906 279.504 
+L 44.103906 24.48 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_4">
+    <path d="M 401.223906 279.504 
+L 401.223906 24.48 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_5">
+    <path d="M 44.103906 279.504 
+L 401.223906 279.504 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_6">
+    <path d="M 44.103906 24.48 
+L 401.223906 24.48 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_7">
+    <path d="M 275.449278 182.985453 
+Q 296.036879 218.881163 316.179486 254.000999 
+" style="fill: none; stroke: #7a7a7a; stroke-width: 0.8; stroke-linecap: round"/>
+    <path d="M 315.98811 250.652361 
+L 316.179486 254.000999 
+L 313.38575 252.144917 
+" style="fill: none; stroke: #7a7a7a; stroke-width: 0.8; stroke-linecap: round"/>
+   </g>
+   <g id="text_15">
+    <!-- 1280/96 = 13.33: -->
+    <g style="fill: #4a4a4a" transform="translate(205.668666 158.694673) scale(0.075 -0.075)">
+     <defs>
+      <path id="DejaVuSans-12" d="M 1625 4666 
+L 2156 4666 
+L 531 -594 
+L 0 -594 
+L 1625 4666 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-20" d="M 678 2906 
+L 4684 2906 
+L 4684 2381 
+L 678 2381 
+L 678 2906 
+z
+M 678 1631 
+L 4684 1631 
+L 4684 1100 
+L 678 1100 
+L 678 1631 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-1d" d="M 750 794 
+L 1409 794 
+L 1409 0 
+L 750 0 
+L 750 794 
+z
+M 750 3309 
+L 1409 3309 
+L 1409 2516 
+L 750 2516 
+L 750 3309 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-14"/>
+     <use xlink:href="#DejaVuSans-15" transform="translate(63.625 0)"/>
+     <use xlink:href="#DejaVuSans-1b" transform="translate(127.25 0)"/>
+     <use xlink:href="#DejaVuSans-13" transform="translate(190.875 0)"/>
+     <use xlink:href="#DejaVuSans-12" transform="translate(254.5 0)"/>
+     <use xlink:href="#DejaVuSans-1c" transform="translate(288.1875 0)"/>
+     <use xlink:href="#DejaVuSans-19" transform="translate(351.8125 0)"/>
+     <use xlink:href="#DejaVuSans-3" transform="translate(415.4375 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(447.21875 0)"/>
+     <use xlink:href="#DejaVuSans-3" transform="translate(531.015625 0)"/>
+     <use xlink:href="#DejaVuSans-14" transform="translate(562.796875 0)"/>
+     <use xlink:href="#DejaVuSans-16" transform="translate(626.421875 0)"/>
+     <use xlink:href="#DejaVuSans-11" transform="translate(690.046875 0)"/>
+     <use xlink:href="#DejaVuSans-16" transform="translate(721.828125 0)"/>
+     <use xlink:href="#DejaVuSans-16" transform="translate(785.453125 0)"/>
+     <use xlink:href="#DejaVuSans-1d" transform="translate(849.078125 0)"/>
+    </g>
+    <!-- ranks get 13 or 14 planes, -->
+    <g style="fill: #4a4a4a" transform="translate(205.668666 167.696724) scale(0.075 -0.075)">
+     <defs>
+      <path id="DejaVuSans-55" d="M 2631 2963 
+Q 2534 3019 2420 3045 
+Q 2306 3072 2169 3072 
+Q 1681 3072 1420 2755 
+Q 1159 2438 1159 1844 
+L 1159 0 
+L 581 0 
+L 581 3500 
+L 1159 3500 
+L 1159 2956 
+Q 1341 3275 1631 3429 
+Q 1922 3584 2338 3584 
+Q 2397 3584 2469 3576 
+Q 2541 3569 2628 3553 
+L 2631 2963 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-44" d="M 2194 1759 
+Q 1497 1759 1228 1600 
+Q 959 1441 959 1056 
+Q 959 750 1161 570 
+Q 1363 391 1709 391 
+Q 2188 391 2477 730 
+Q 2766 1069 2766 1631 
+L 2766 1759 
+L 2194 1759 
+z
+M 3341 1997 
+L 3341 0 
+L 2766 0 
+L 2766 531 
+Q 2569 213 2275 61 
+Q 1981 -91 1556 -91 
+Q 1019 -91 701 211 
+Q 384 513 384 1019 
+Q 384 1609 779 1909 
+Q 1175 2209 1959 2209 
+L 2766 2209 
+L 2766 2266 
+Q 2766 2663 2505 2880 
+Q 2244 3097 1772 3097 
+Q 1472 3097 1187 3025 
+Q 903 2953 641 2809 
+L 641 3341 
+Q 956 3463 1253 3523 
+Q 1550 3584 1831 3584 
+Q 2591 3584 2966 3190 
+Q 3341 2797 3341 1997 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-4e" d="M 581 4863 
+L 1159 4863 
+L 1159 1991 
+L 2875 3500 
+L 3609 3500 
+L 1753 1863 
+L 3688 0 
+L 2938 0 
+L 1159 1709 
+L 1159 0 
+L 581 0 
+L 581 4863 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-4a" d="M 2906 1791 
+Q 2906 2416 2648 2759 
+Q 2391 3103 1925 3103 
+Q 1463 3103 1205 2759 
+Q 947 2416 947 1791 
+Q 947 1169 1205 825 
+Q 1463 481 1925 481 
+Q 2391 481 2648 825 
+Q 2906 1169 2906 1791 
+z
+M 3481 434 
+Q 3481 -459 3084 -895 
+Q 2688 -1331 1869 -1331 
+Q 1566 -1331 1297 -1286 
+Q 1028 -1241 775 -1147 
+L 775 -588 
+Q 1028 -725 1275 -790 
+Q 1522 -856 1778 -856 
+Q 2344 -856 2625 -561 
+Q 2906 -266 2906 331 
+L 2906 616 
+Q 2728 306 2450 153 
+Q 2172 0 1784 0 
+Q 1141 0 747 490 
+Q 353 981 353 1791 
+Q 353 2603 747 3093 
+Q 1141 3584 1784 3584 
+Q 2172 3584 2450 3431 
+Q 2728 3278 2906 2969 
+L 2906 3500 
+L 3481 3500 
+L 3481 434 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-57" d="M 1172 4494 
+L 1172 3500 
+L 2356 3500 
+L 2356 3053 
+L 1172 3053 
+L 1172 1153 
+Q 1172 725 1289 603 
+Q 1406 481 1766 481 
+L 2356 481 
+L 2356 0 
+L 1766 0 
+Q 1100 0 847 248 
+Q 594 497 594 1153 
+L 594 3053 
+L 172 3053 
+L 172 3500 
+L 594 3500 
+L 594 4494 
+L 1172 4494 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-4f" d="M 603 4863 
+L 1178 4863 
+L 1178 0 
+L 603 0 
+L 603 4863 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-f" d="M 750 794 
+L 1409 794 
+L 1409 256 
+L 897 -744 
+L 494 -744 
+L 750 256 
+L 750 794 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-55"/>
+     <use xlink:href="#DejaVuSans-44" transform="translate(41.109375 0)"/>
+     <use xlink:href="#DejaVuSans-51" transform="translate(102.390625 0)"/>
+     <use xlink:href="#DejaVuSans-4e" transform="translate(165.765625 0)"/>
+     <use xlink:href="#DejaVuSans-56" transform="translate(223.671875 0)"/>
+     <use xlink:href="#DejaVuSans-3" transform="translate(275.765625 0)"/>
+     <use xlink:href="#DejaVuSans-4a" transform="translate(307.546875 0)"/>
+     <use xlink:href="#DejaVuSans-48" transform="translate(371.03125 0)"/>
+     <use xlink:href="#DejaVuSans-57" transform="translate(432.5625 0)"/>
+     <use xlink:href="#DejaVuSans-3" transform="translate(471.765625 0)"/>
+     <use xlink:href="#DejaVuSans-14" transform="translate(503.546875 0)"/>
+     <use xlink:href="#DejaVuSans-16" transform="translate(567.171875 0)"/>
+     <use xlink:href="#DejaVuSans-3" transform="translate(630.796875 0)"/>
+     <use xlink:href="#DejaVuSans-52" transform="translate(662.578125 0)"/>
+     <use xlink:href="#DejaVuSans-55" transform="translate(723.765625 0)"/>
+     <use xlink:href="#DejaVuSans-3" transform="translate(764.875 0)"/>
+     <use xlink:href="#DejaVuSans-14" transform="translate(796.65625 0)"/>
+     <use xlink:href="#DejaVuSans-17" transform="translate(860.28125 0)"/>
+     <use xlink:href="#DejaVuSans-3" transform="translate(923.90625 0)"/>
+     <use xlink:href="#DejaVuSans-53" transform="translate(955.6875 0)"/>
+     <use xlink:href="#DejaVuSans-4f" transform="translate(1019.171875 0)"/>
+     <use xlink:href="#DejaVuSans-44" transform="translate(1046.953125 0)"/>
+     <use xlink:href="#DejaVuSans-51" transform="translate(1108.234375 0)"/>
+     <use xlink:href="#DejaVuSans-48" transform="translate(1171.609375 0)"/>
+     <use xlink:href="#DejaVuSans-56" transform="translate(1233.140625 0)"/>
+     <use xlink:href="#DejaVuSans-f" transform="translate(1285.234375 0)"/>
+    </g>
+    <!-- every step waits for the slowest -->
+    <g style="fill: #4a4a4a" transform="translate(205.668666 176.698775) scale(0.075 -0.075)">
+     <defs>
+      <path id="DejaVuSans-5c" d="M 2059 -325 
+Q 1816 -950 1584 -1140 
+Q 1353 -1331 966 -1331 
+L 506 -1331 
+L 506 -850 
+L 844 -850 
+Q 1081 -850 1212 -737 
+Q 1344 -625 1503 -206 
+L 1606 56 
+L 191 3500 
+L 800 3500 
+L 1894 763 
+L 2988 3500 
+L 3597 3500 
+L 2059 -325 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-5a" d="M 269 3500 
+L 844 3500 
+L 1563 769 
+L 2278 3500 
+L 2956 3500 
+L 3675 769 
+L 4391 3500 
+L 4966 3500 
+L 4050 0 
+L 3372 0 
+L 2619 2869 
+L 1863 0 
+L 1184 0 
+L 269 3500 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-4c" d="M 603 3500 
+L 1178 3500 
+L 1178 0 
+L 603 0 
+L 603 3500 
+z
+M 603 4863 
+L 1178 4863 
+L 1178 4134 
+L 603 4134 
+L 603 4863 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-49" d="M 2375 4863 
+L 2375 4384 
+L 1825 4384 
+Q 1516 4384 1395 4259 
+Q 1275 4134 1275 3809 
+L 1275 3500 
+L 2222 3500 
+L 2222 3053 
+L 1275 3053 
+L 1275 0 
+L 697 0 
+L 697 3053 
+L 147 3053 
+L 147 3500 
+L 697 3500 
+L 697 3744 
+Q 697 4328 969 4595 
+Q 1241 4863 1831 4863 
+L 2375 4863 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-4b" d="M 3513 2113 
+L 3513 0 
+L 2938 0 
+L 2938 2094 
+Q 2938 2591 2744 2837 
+Q 2550 3084 2163 3084 
+Q 1697 3084 1428 2787 
+Q 1159 2491 1159 1978 
+L 1159 0 
+L 581 0 
+L 581 4863 
+L 1159 4863 
+L 1159 2956 
+Q 1366 3272 1645 3428 
+Q 1925 3584 2291 3584 
+Q 2894 3584 3203 3211 
+Q 3513 2838 3513 2113 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-48"/>
+     <use xlink:href="#DejaVuSans-59" transform="translate(61.53125 0)"/>
+     <use xlink:href="#DejaVuSans-48" transform="translate(120.71875 0)"/>
+     <use xlink:href="#DejaVuSans-55" transform="translate(182.25 0)"/>
+     <use xlink:href="#DejaVuSans-5c" transform="translate(223.359375 0)"/>
+     <use xlink:href="#DejaVuSans-3" transform="translate(282.546875 0)"/>
+     <use xlink:href="#DejaVuSans-56" transform="translate(314.328125 0)"/>
+     <use xlink:href="#DejaVuSans-57" transform="translate(366.421875 0)"/>
+     <use xlink:href="#DejaVuSans-48" transform="translate(405.625 0)"/>
+     <use xlink:href="#DejaVuSans-53" transform="translate(467.15625 0)"/>
+     <use xlink:href="#DejaVuSans-3" transform="translate(530.640625 0)"/>
+     <use xlink:href="#DejaVuSans-5a" transform="translate(562.421875 0)"/>
+     <use xlink:href="#DejaVuSans-44" transform="translate(644.203125 0)"/>
+     <use xlink:href="#DejaVuSans-4c" transform="translate(705.484375 0)"/>
+     <use xlink:href="#DejaVuSans-57" transform="translate(733.265625 0)"/>
+     <use xlink:href="#DejaVuSans-56" transform="translate(772.46875 0)"/>
+     <use xlink:href="#DejaVuSans-3" transform="translate(824.5625 0)"/>
+     <use xlink:href="#DejaVuSans-49" transform="translate(856.34375 0)"/>
+     <use xlink:href="#DejaVuSans-52" transform="translate(891.546875 0)"/>
+     <use xlink:href="#DejaVuSans-55" transform="translate(952.734375 0)"/>
+     <use xlink:href="#DejaVuSans-3" transform="translate(993.84375 0)"/>
+     <use xlink:href="#DejaVuSans-57" transform="translate(1025.625 0)"/>
+     <use xlink:href="#DejaVuSans-4b" transform="translate(1064.828125 0)"/>
+     <use xlink:href="#DejaVuSans-48" transform="translate(1128.203125 0)"/>
+     <use xlink:href="#DejaVuSans-3" transform="translate(1189.734375 0)"/>
+     <use xlink:href="#DejaVuSans-56" transform="translate(1221.515625 0)"/>
+     <use xlink:href="#DejaVuSans-4f" transform="translate(1273.609375 0)"/>
+     <use xlink:href="#DejaVuSans-52" transform="translate(1301.390625 0)"/>
+     <use xlink:href="#DejaVuSans-5a" transform="translate(1362.578125 0)"/>
+     <use xlink:href="#DejaVuSans-48" transform="translate(1444.359375 0)"/>
+     <use xlink:href="#DejaVuSans-56" transform="translate(1505.890625 0)"/>
+     <use xlink:href="#DejaVuSans-57" transform="translate(1557.984375 0)"/>
+    </g>
+   </g>
+   <g id="text_16">
+    <!-- 100% -->
+    <g transform="translate(64.336634 277.912) scale(0.075 -0.075)">
+     <defs>
+      <path id="DejaVuSans-8" d="M 4653 2053 
+Q 4381 2053 4226 1822 
+Q 4072 1591 4072 1178 
+Q 4072 772 4226 539 
+Q 4381 306 4653 306 
+Q 4919 306 5073 539 
+Q 5228 772 5228 1178 
+Q 5228 1588 5073 1820 
+Q 4919 2053 4653 2053 
+z
+M 4653 2450 
+Q 5147 2450 5437 2106 
+Q 5728 1763 5728 1178 
+Q 5728 594 5436 251 
+Q 5144 -91 4653 -91 
+Q 4153 -91 3862 251 
+Q 3572 594 3572 1178 
+Q 3572 1766 3864 2108 
+Q 4156 2450 4653 2450 
+z
+M 1428 4353 
+Q 1159 4353 1004 4120 
+Q 850 3888 850 3481 
+Q 850 3069 1003 2837 
+Q 1156 2606 1428 2606 
+Q 1700 2606 1854 2837 
+Q 2009 3069 2009 3481 
+Q 2009 3884 1853 4118 
+Q 1697 4353 1428 4353 
+z
+M 4250 4750 
+L 4750 4750 
+L 1831 -91 
+L 1331 -91 
+L 4250 4750 
+z
+M 1428 4750 
+Q 1922 4750 2215 4408 
+Q 2509 4066 2509 3481 
+Q 2509 2891 2217 2550 
+Q 1925 2209 1428 2209 
+Q 931 2209 642 2551 
+Q 353 2894 353 3481 
+Q 353 4063 643 4406 
+Q 934 4750 1428 4750 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-14"/>
+     <use xlink:href="#DejaVuSans-13" transform="translate(63.625 0)"/>
+     <use xlink:href="#DejaVuSans-13" transform="translate(127.25 0)"/>
+     <use xlink:href="#DejaVuSans-8" transform="translate(190.875 0)"/>
+    </g>
+   </g>
+   <g id="text_17">
+    <!-- 85% -->
+    <g transform="translate(226.663906 223.743817) scale(0.075 -0.075)">
+     <use xlink:href="#DejaVuSans-1b"/>
+     <use xlink:href="#DejaVuSans-18" transform="translate(63.625 0)"/>
+     <use xlink:href="#DejaVuSans-8" transform="translate(127.25 0)"/>
+    </g>
+   </g>
+   <g id="text_18">
+    <!-- 84% -->
+    <g transform="translate(278.921616 192.722828) scale(0.075 -0.075)">
+     <use xlink:href="#DejaVuSans-1b"/>
+     <use xlink:href="#DejaVuSans-17" transform="translate(63.625 0)"/>
+     <use xlink:href="#DejaVuSans-8" transform="translate(127.25 0)"/>
+    </g>
+   </g>
+   <g id="text_19">
+    <!-- 82% -->
+    <g transform="translate(388.991179 101.694128) scale(0.075 -0.075)">
+     <use xlink:href="#DejaVuSans-1b"/>
+     <use xlink:href="#DejaVuSans-15" transform="translate(63.625 0)"/>
+     <use xlink:href="#DejaVuSans-8" transform="translate(127.25 0)"/>
+    </g>
+   </g>
+   <g id="text_20">
+    <!-- Tungsten PFC strong scaling, $1280^3$, LUMI-G -->
+    <g transform="translate(91.143906 18.48) scale(0.12 -0.12)">
+     <defs>
+      <path id="DejaVuSans-37" d="M -19 4666 
+L 3928 4666 
+L 3928 4134 
+L 2272 4134 
+L 2272 0 
+L 1638 0 
+L 1638 4134 
+L -19 4134 
+L -19 4666 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-33" d="M 1259 4147 
+L 1259 2394 
+L 2053 2394 
+Q 2494 2394 2734 2622 
+Q 2975 2850 2975 3272 
+Q 2975 3691 2734 3919 
+Q 2494 4147 2053 4147 
+L 1259 4147 
+z
+M 628 4666 
+L 2053 4666 
+Q 2838 4666 3239 4311 
+Q 3641 3956 3641 3272 
+Q 3641 2581 3239 2228 
+Q 2838 1875 2053 1875 
+L 1259 1875 
+L 1259 0 
+L 628 0 
+L 628 4666 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-29" d="M 628 4666 
+L 3309 4666 
+L 3309 4134 
+L 1259 4134 
+L 1259 2759 
+L 3109 2759 
+L 3109 2228 
+L 1259 2228 
+L 1259 0 
+L 628 0 
+L 628 4666 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-46" d="M 3122 3366 
+L 3122 2828 
+Q 2878 2963 2633 3030 
+Q 2388 3097 2138 3097 
+Q 1578 3097 1268 2742 
+Q 959 2388 959 1747 
+Q 959 1106 1268 751 
+Q 1578 397 2138 397 
+Q 2388 397 2633 464 
+Q 2878 531 3122 666 
+L 3122 134 
+Q 2881 22 2623 -34 
+Q 2366 -91 2075 -91 
+Q 1284 -91 818 406 
+Q 353 903 353 1747 
+Q 353 2603 823 3093 
+Q 1294 3584 2113 3584 
+Q 2378 3584 2631 3529 
+Q 2884 3475 3122 3366 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-2f" d="M 628 4666 
+L 1259 4666 
+L 1259 531 
+L 3531 531 
+L 3531 0 
+L 628 0 
+L 628 4666 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-38" d="M 556 4666 
+L 1191 4666 
+L 1191 1831 
+Q 1191 1081 1462 751 
+Q 1734 422 2344 422 
+Q 2950 422 3222 751 
+Q 3494 1081 3494 1831 
+L 3494 4666 
+L 4128 4666 
+L 4128 1753 
+Q 4128 841 3676 375 
+Q 3225 -91 2344 -91 
+Q 1459 -91 1007 375 
+Q 556 841 556 1753 
+L 556 4666 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-30" d="M 628 4666 
+L 1569 4666 
+L 2759 1491 
+L 3956 4666 
+L 4897 4666 
+L 4897 0 
+L 4281 0 
+L 4281 4097 
+L 3078 897 
+L 2444 897 
+L 1241 4097 
+L 1241 0 
+L 628 0 
+L 628 4666 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-2c" d="M 628 4666 
+L 1259 4666 
+L 1259 0 
+L 628 0 
+L 628 4666 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-10" d="M 313 2009 
+L 1997 2009 
+L 1997 1497 
+L 313 1497 
+L 313 2009 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-37" transform="translate(0 0.746875)"/>
+     <use xlink:href="#DejaVuSans-58" transform="translate(46.083984 0.746875)"/>
+     <use xlink:href="#DejaVuSans-51" transform="translate(109.462891 0.746875)"/>
+     <use xlink:href="#DejaVuSans-4a" transform="translate(172.841797 0.746875)"/>
+     <use xlink:href="#DejaVuSans-56" transform="translate(236.318359 0.746875)"/>
+     <use xlink:href="#DejaVuSans-57" transform="translate(288.417969 0.746875)"/>
+     <use xlink:href="#DejaVuSans-48" transform="translate(327.626953 0.746875)"/>
+     <use xlink:href="#DejaVuSans-51" transform="translate(389.150391 0.746875)"/>
+     <use xlink:href="#DejaVuSans-3" transform="translate(452.529297 0.746875)"/>
+     <use xlink:href="#DejaVuSans-33" transform="translate(484.316406 0.746875)"/>
+     <use xlink:href="#DejaVuSans-29" transform="translate(544.619141 0.746875)"/>
+     <use xlink:href="#DejaVuSans-26" transform="translate(602.138672 0.746875)"/>
+     <use xlink:href="#DejaVuSans-3" transform="translate(671.962891 0.746875)"/>
+     <use xlink:href="#DejaVuSans-56" transform="translate(703.75 0.746875)"/>
+     <use xlink:href="#DejaVuSans-57" transform="translate(755.849609 0.746875)"/>
+     <use xlink:href="#DejaVuSans-55" transform="translate(795.058594 0.746875)"/>
+     <use xlink:href="#DejaVuSans-52" transform="translate(834.171875 0.746875)"/>
+     <use xlink:href="#DejaVuSans-51" transform="translate(895.353516 0.746875)"/>
+     <use xlink:href="#DejaVuSans-4a" transform="translate(958.732422 0.746875)"/>
+     <use xlink:href="#DejaVuSans-3" transform="translate(1022.208984 0.746875)"/>
+     <use xlink:href="#DejaVuSans-56" transform="translate(1053.996094 0.746875)"/>
+     <use xlink:href="#DejaVuSans-46" transform="translate(1106.095703 0.746875)"/>
+     <use xlink:href="#DejaVuSans-44" transform="translate(1161.076172 0.746875)"/>
+     <use xlink:href="#DejaVuSans-4f" transform="translate(1222.355469 0.746875)"/>
+     <use xlink:href="#DejaVuSans-4c" transform="translate(1250.138672 0.746875)"/>
+     <use xlink:href="#DejaVuSans-51" transform="translate(1277.921875 0.746875)"/>
+     <use xlink:href="#DejaVuSans-4a" transform="translate(1341.300781 0.746875)"/>
+     <use xlink:href="#DejaVuSans-f" transform="translate(1404.777344 0.746875)"/>
+     <use xlink:href="#DejaVuSans-3" transform="translate(1436.564453 0.746875)"/>
+     <use xlink:href="#DejaVuSans-14" transform="translate(1468.351562 0.746875)"/>
+     <use xlink:href="#DejaVuSans-15" transform="translate(1531.974609 0.746875)"/>
+     <use xlink:href="#DejaVuSans-1b" transform="translate(1595.597656 0.746875)"/>
+     <use xlink:href="#DejaVuSans-13" transform="translate(1659.220703 0.746875)"/>
+     <use xlink:href="#DejaVuSans-16" transform="translate(1723.800781 42.046875) scale(0.7)"/>
+     <use xlink:href="#DejaVuSans-f" transform="translate(1771.071289 0.746875)"/>
+     <use xlink:href="#DejaVuSans-3" transform="translate(1802.858398 0.746875)"/>
+     <use xlink:href="#DejaVuSans-2f" transform="translate(1834.645508 0.746875)"/>
+     <use xlink:href="#DejaVuSans-38" transform="translate(1885.358398 0.746875)"/>
+     <use xlink:href="#DejaVuSans-30" transform="translate(1958.551758 0.746875)"/>
+     <use xlink:href="#DejaVuSans-2c" transform="translate(2044.831055 0.746875)"/>
+     <use xlink:href="#DejaVuSans-10" transform="translate(2074.323242 0.746875)"/>
+     <use xlink:href="#DejaVuSans-2a" transform="translate(2114.407227 0.746875)"/>
+    </g>
+   </g>
+   <g id="legend_1">
+    <g id="line2d_28">
+     <path d="M 51.303906 34.95875 
+L 59.303906 34.95875 
+L 67.303906 34.95875 
+" style="fill: none; stroke-dasharray: 3.7,1.6; stroke-dashoffset: 0; stroke: #7a7a7a"/>
+    </g>
+    <g id="text_21">
+     <!-- ideal -->
+     <g transform="translate(73.703906 37.75875) scale(0.08 -0.08)">
+      <use xlink:href="#DejaVuSans-4c"/>
+      <use xlink:href="#DejaVuSans-47" transform="translate(27.78125 0)"/>
+      <use xlink:href="#DejaVuSans-48" transform="translate(91.265625 0)"/>
+      <use xlink:href="#DejaVuSans-44" transform="translate(152.796875 0)"/>
+      <use xlink:href="#DejaVuSans-4f" transform="translate(214.078125 0)"/>
+     </g>
+    </g>
+    <g id="line2d_29">
+     <path d="M 51.303906 46.959375 
+L 59.303906 46.959375 
+L 67.303906 46.959375 
+" style="fill: none; stroke: #1f6fb4; stroke-width: 1.8; stroke-linecap: square"/>
+     <g>
+      <use xlink:href="#mc807f545de" x="59.303906" y="46.959375" style="fill: #1f6fb4; stroke: #1f6fb4"/>
+     </g>
+    </g>
+    <g id="text_22">
+     <!-- z-planes divide evenly -->
+     <g transform="translate(73.703906 49.759375) scale(0.08 -0.08)">
+      <defs>
+       <path id="DejaVuSans-5d" d="M 353 3500 
+L 3084 3500 
+L 3084 2975 
+L 922 459 
+L 3084 459 
+L 3084 0 
+L 275 0 
+L 275 525 
+L 2438 3041 
+L 353 3041 
+L 353 3500 
+z
+" transform="scale(0.015625)"/>
+      </defs>
+      <use xlink:href="#DejaVuSans-5d"/>
+      <use xlink:href="#DejaVuSans-10" transform="translate(52.484375 0)"/>
+      <use xlink:href="#DejaVuSans-53" transform="translate(88.5625 0)"/>
+      <use xlink:href="#DejaVuSans-4f" transform="translate(152.046875 0)"/>
+      <use xlink:href="#DejaVuSans-44" transform="translate(179.828125 0)"/>
+      <use xlink:href="#DejaVuSans-51" transform="translate(241.109375 0)"/>
+      <use xlink:href="#DejaVuSans-48" transform="translate(304.484375 0)"/>
+      <use xlink:href="#DejaVuSans-56" transform="translate(366.015625 0)"/>
+      <use xlink:href="#DejaVuSans-3" transform="translate(418.109375 0)"/>
+      <use xlink:href="#DejaVuSans-47" transform="translate(449.890625 0)"/>
+      <use xlink:href="#DejaVuSans-4c" transform="translate(513.375 0)"/>
+      <use xlink:href="#DejaVuSans-59" transform="translate(541.15625 0)"/>
+      <use xlink:href="#DejaVuSans-4c" transform="translate(600.34375 0)"/>
+      <use xlink:href="#DejaVuSans-47" transform="translate(628.125 0)"/>
+      <use xlink:href="#DejaVuSans-48" transform="translate(691.609375 0)"/>
+      <use xlink:href="#DejaVuSans-3" transform="translate(753.140625 0)"/>
+      <use xlink:href="#DejaVuSans-48" transform="translate(784.921875 0)"/>
+      <use xlink:href="#DejaVuSans-59" transform="translate(846.453125 0)"/>
+      <use xlink:href="#DejaVuSans-48" transform="translate(905.640625 0)"/>
+      <use xlink:href="#DejaVuSans-51" transform="translate(967.171875 0)"/>
+      <use xlink:href="#DejaVuSans-4f" transform="translate(1030.546875 0)"/>
+      <use xlink:href="#DejaVuSans-5c" transform="translate(1058.328125 0)"/>
+     </g>
+    </g>
+    <g id="line2d_30">
+     <g>
+      <use xlink:href="#m187ea5c38a" x="59.303906" y="58.96" style="fill: #ffffff; stroke: #c1662f; stroke-width: 1.8"/>
+     </g>
+    </g>
+    <g id="text_23">
+     <!-- does not divide -->
+     <g transform="translate(73.703906 61.76) scale(0.08 -0.08)">
+      <use xlink:href="#DejaVuSans-47"/>
+      <use xlink:href="#DejaVuSans-52" transform="translate(63.484375 0)"/>
+      <use xlink:href="#DejaVuSans-48" transform="translate(124.671875 0)"/>
+      <use xlink:href="#DejaVuSans-56" transform="translate(186.203125 0)"/>
+      <use xlink:href="#DejaVuSans-3" transform="translate(238.296875 0)"/>
+      <use xlink:href="#DejaVuSans-51" transform="translate(270.078125 0)"/>
+      <use xlink:href="#DejaVuSans-52" transform="translate(333.453125 0)"/>
+      <use xlink:href="#DejaVuSans-57" transform="translate(394.640625 0)"/>
+      <use xlink:href="#DejaVuSans-3" transform="translate(433.84375 0)"/>
+      <use xlink:href="#DejaVuSans-47" transform="translate(465.625 0)"/>
+      <use xlink:href="#DejaVuSans-4c" transform="translate(529.109375 0)"/>
+      <use xlink:href="#DejaVuSans-59" transform="translate(556.890625 0)"/>
+      <use xlink:href="#DejaVuSans-4c" transform="translate(616.078125 0)"/>
+      <use xlink:href="#DejaVuSans-47" transform="translate(643.859375 0)"/>
+      <use xlink:href="#DejaVuSans-48" transform="translate(707.34375 0)"/>
+     </g>
+    </g>
+   </g>
+  </g>
+ </g>
+ <defs>
+  <clipPath id="p001f968744">
+   <rect x="44.103906" y="24.48" width="357.12" height="255.024"/>
+  </clipPath>
+ </defs>
+</svg>

--- a/docs/report/figures/tungsten_weak_16n.svg
+++ b/docs/report/figures/tungsten_weak_16n.svg
@@ -1,0 +1,1861 @@
+<?xml version="1.0" encoding="utf-8" standalone="no"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN"
+  "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="590.168281pt" height="307.480781pt" viewBox="0 0 590.168281 307.480781" xmlns="http://www.w3.org/2000/svg" version="1.1">
+ <metadata>
+  <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+   <cc:Work>
+    <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
+    <dc:date>2026-09-10T16:41:06.488022</dc:date>
+    <dc:format>image/svg+xml</dc:format>
+    <dc:creator>
+     <cc:Agent>
+      <dc:title>Matplotlib v3.11.1, https://matplotlib.org/</dc:title>
+     </cc:Agent>
+    </dc:creator>
+   </cc:Work>
+  </rdf:RDF>
+ </metadata>
+ <defs>
+  <style type="text/css">*{stroke-linejoin: round; stroke-linecap: butt}</style>
+ </defs>
+ <g id="figure_1">
+  <g id="patch_1">
+   <path d="M 0 307.480781 
+L 590.168281 307.480781 
+L 590.168281 0 
+L 0 0 
+z
+" style="fill: #ffffff"/>
+  </g>
+  <g id="axes_1">
+   <g id="patch_2">
+    <path d="M 47.288281 269.28 
+L 290.77919 269.28 
+L 290.77919 47.52 
+L 47.288281 47.52 
+z
+" style="fill: #ffffff"/>
+   </g>
+   <g id="matplotlib.axis_1">
+    <g id="xtick_1">
+     <g id="line2d_1">
+      <path d="M 58.35605 269.28 
+L 58.35605 47.52 
+" clip-path="url(#pdfc3c61db6)" style="fill: none; stroke: #d5d8dc; stroke-width: 0.6; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_2">
+      <defs>
+       <path id="ma95b824712" d="M 0 0 
+L 0 3.5 
+" style="stroke: #000000; stroke-width: 0.8"/>
+      </defs>
+      <g>
+       <use xlink:href="#ma95b824712" x="58.35605" y="269.28" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_1">
+      <!-- 1 -->
+      <g transform="translate(55.1748 283.877656) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-14" d="M 794 531 
+L 1825 531 
+L 1825 4091 
+L 703 3866 
+L 703 4441 
+L 1819 4666 
+L 2450 4666 
+L 2450 531 
+L 3481 531 
+L 3481 0 
+L 794 0 
+L 794 531 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-14"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_2">
+     <g id="line2d_3">
+      <path d="M 113.694893 269.28 
+L 113.694893 47.52 
+" clip-path="url(#pdfc3c61db6)" style="fill: none; stroke: #d5d8dc; stroke-width: 0.6; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_4">
+      <g>
+       <use xlink:href="#ma95b824712" x="113.694893" y="269.28" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_2">
+      <!-- 2 -->
+      <g transform="translate(110.513643 283.877656) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-15" d="M 1228 531 
+L 3431 531 
+L 3431 0 
+L 469 0 
+L 469 531 
+Q 828 903 1448 1529 
+Q 2069 2156 2228 2338 
+Q 2531 2678 2651 2914 
+Q 2772 3150 2772 3378 
+Q 2772 3750 2511 3984 
+Q 2250 4219 1831 4219 
+Q 1534 4219 1204 4116 
+Q 875 4013 500 3803 
+L 500 4441 
+Q 881 4594 1212 4672 
+Q 1544 4750 1819 4750 
+Q 2544 4750 2975 4387 
+Q 3406 4025 3406 3419 
+Q 3406 3131 3298 2873 
+Q 3191 2616 2906 2266 
+Q 2828 2175 2409 1742 
+Q 1991 1309 1228 531 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-15"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_3">
+     <g id="line2d_5">
+      <path d="M 169.033736 269.28 
+L 169.033736 47.52 
+" clip-path="url(#pdfc3c61db6)" style="fill: none; stroke: #d5d8dc; stroke-width: 0.6; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_6">
+      <g>
+       <use xlink:href="#ma95b824712" x="169.033736" y="269.28" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_3">
+      <!-- 4 -->
+      <g transform="translate(165.852486 283.877656) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-17" d="M 2419 4116 
+L 825 1625 
+L 2419 1625 
+L 2419 4116 
+z
+M 2253 4666 
+L 3047 4666 
+L 3047 1625 
+L 3713 1625 
+L 3713 1100 
+L 3047 1100 
+L 3047 0 
+L 2419 0 
+L 2419 1100 
+L 313 1100 
+L 313 1709 
+L 2253 4666 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-17"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_4">
+     <g id="line2d_7">
+      <path d="M 224.372579 269.28 
+L 224.372579 47.52 
+" clip-path="url(#pdfc3c61db6)" style="fill: none; stroke: #d5d8dc; stroke-width: 0.6; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_8">
+      <g>
+       <use xlink:href="#ma95b824712" x="224.372579" y="269.28" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_4">
+      <!-- 8 -->
+      <g transform="translate(221.191329 283.877656) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-1b" d="M 2034 2216 
+Q 1584 2216 1326 1975 
+Q 1069 1734 1069 1313 
+Q 1069 891 1326 650 
+Q 1584 409 2034 409 
+Q 2484 409 2743 651 
+Q 3003 894 3003 1313 
+Q 3003 1734 2745 1975 
+Q 2488 2216 2034 2216 
+z
+M 1403 2484 
+Q 997 2584 770 2862 
+Q 544 3141 544 3541 
+Q 544 4100 942 4425 
+Q 1341 4750 2034 4750 
+Q 2731 4750 3128 4425 
+Q 3525 4100 3525 3541 
+Q 3525 3141 3298 2862 
+Q 3072 2584 2669 2484 
+Q 3125 2378 3379 2068 
+Q 3634 1759 3634 1313 
+Q 3634 634 3220 271 
+Q 2806 -91 2034 -91 
+Q 1263 -91 848 271 
+Q 434 634 434 1313 
+Q 434 1759 690 2068 
+Q 947 2378 1403 2484 
+z
+M 1172 3481 
+Q 1172 3119 1398 2916 
+Q 1625 2713 2034 2713 
+Q 2441 2713 2670 2916 
+Q 2900 3119 2900 3481 
+Q 2900 3844 2670 4047 
+Q 2441 4250 2034 4250 
+Q 1625 4250 1398 4047 
+Q 1172 3844 1172 3481 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-1b"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_5">
+     <g id="line2d_9">
+      <path d="M 279.711422 269.28 
+L 279.711422 47.52 
+" clip-path="url(#pdfc3c61db6)" style="fill: none; stroke: #d5d8dc; stroke-width: 0.6; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_10">
+      <g>
+       <use xlink:href="#ma95b824712" x="279.711422" y="269.28" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_5">
+      <!-- 16 -->
+      <g transform="translate(273.348922 283.877656) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-19" d="M 2113 2584 
+Q 1688 2584 1439 2293 
+Q 1191 2003 1191 1497 
+Q 1191 994 1439 701 
+Q 1688 409 2113 409 
+Q 2538 409 2786 701 
+Q 3034 994 3034 1497 
+Q 3034 2003 2786 2293 
+Q 2538 2584 2113 2584 
+z
+M 3366 4563 
+L 3366 3988 
+Q 3128 4100 2886 4159 
+Q 2644 4219 2406 4219 
+Q 1781 4219 1451 3797 
+Q 1122 3375 1075 2522 
+Q 1259 2794 1537 2939 
+Q 1816 3084 2150 3084 
+Q 2853 3084 3261 2657 
+Q 3669 2231 3669 1497 
+Q 3669 778 3244 343 
+Q 2819 -91 2113 -91 
+Q 1303 -91 875 529 
+Q 447 1150 447 2328 
+Q 447 3434 972 4092 
+Q 1497 4750 2381 4750 
+Q 2619 4750 2861 4703 
+Q 3103 4656 3366 4563 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-14"/>
+       <use xlink:href="#DejaVuSans-19" transform="translate(63.625 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="text_6">
+     <!-- nodes (8 GCDs each) -->
+     <g transform="translate(116.221236 297.878437) scale(0.1 -0.1)">
+      <defs>
+       <path id="DejaVuSans-51" d="M 3513 2113 
+L 3513 0 
+L 2938 0 
+L 2938 2094 
+Q 2938 2591 2744 2837 
+Q 2550 3084 2163 3084 
+Q 1697 3084 1428 2787 
+Q 1159 2491 1159 1978 
+L 1159 0 
+L 581 0 
+L 581 3500 
+L 1159 3500 
+L 1159 2956 
+Q 1366 3272 1645 3428 
+Q 1925 3584 2291 3584 
+Q 2894 3584 3203 3211 
+Q 3513 2838 3513 2113 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-52" d="M 1959 3097 
+Q 1497 3097 1228 2736 
+Q 959 2375 959 1747 
+Q 959 1119 1226 758 
+Q 1494 397 1959 397 
+Q 2419 397 2687 759 
+Q 2956 1122 2956 1747 
+Q 2956 2369 2687 2733 
+Q 2419 3097 1959 3097 
+z
+M 1959 3584 
+Q 2709 3584 3137 3096 
+Q 3566 2609 3566 1747 
+Q 3566 888 3137 398 
+Q 2709 -91 1959 -91 
+Q 1206 -91 779 398 
+Q 353 888 353 1747 
+Q 353 2609 779 3096 
+Q 1206 3584 1959 3584 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-47" d="M 2906 2969 
+L 2906 4863 
+L 3481 4863 
+L 3481 0 
+L 2906 0 
+L 2906 525 
+Q 2725 213 2448 61 
+Q 2172 -91 1784 -91 
+Q 1150 -91 751 415 
+Q 353 922 353 1747 
+Q 353 2572 751 3078 
+Q 1150 3584 1784 3584 
+Q 2172 3584 2448 3432 
+Q 2725 3281 2906 2969 
+z
+M 947 1747 
+Q 947 1113 1208 752 
+Q 1469 391 1925 391 
+Q 2381 391 2643 752 
+Q 2906 1113 2906 1747 
+Q 2906 2381 2643 2742 
+Q 2381 3103 1925 3103 
+Q 1469 3103 1208 2742 
+Q 947 2381 947 1747 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-48" d="M 3597 1894 
+L 3597 1613 
+L 953 1613 
+Q 991 1019 1311 708 
+Q 1631 397 2203 397 
+Q 2534 397 2845 478 
+Q 3156 559 3463 722 
+L 3463 178 
+Q 3153 47 2828 -22 
+Q 2503 -91 2169 -91 
+Q 1331 -91 842 396 
+Q 353 884 353 1716 
+Q 353 2575 817 3079 
+Q 1281 3584 2069 3584 
+Q 2775 3584 3186 3129 
+Q 3597 2675 3597 1894 
+z
+M 3022 2063 
+Q 3016 2534 2758 2815 
+Q 2500 3097 2075 3097 
+Q 1594 3097 1305 2825 
+Q 1016 2553 972 2059 
+L 3022 2063 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-56" d="M 2834 3397 
+L 2834 2853 
+Q 2591 2978 2328 3040 
+Q 2066 3103 1784 3103 
+Q 1356 3103 1142 2972 
+Q 928 2841 928 2578 
+Q 928 2378 1081 2264 
+Q 1234 2150 1697 2047 
+L 1894 2003 
+Q 2506 1872 2764 1633 
+Q 3022 1394 3022 966 
+Q 3022 478 2636 193 
+Q 2250 -91 1575 -91 
+Q 1294 -91 989 -36 
+Q 684 19 347 128 
+L 347 722 
+Q 666 556 975 473 
+Q 1284 391 1588 391 
+Q 1994 391 2212 530 
+Q 2431 669 2431 922 
+Q 2431 1156 2273 1281 
+Q 2116 1406 1581 1522 
+L 1381 1569 
+Q 847 1681 609 1914 
+Q 372 2147 372 2553 
+Q 372 3047 722 3315 
+Q 1072 3584 1716 3584 
+Q 2034 3584 2315 3537 
+Q 2597 3491 2834 3397 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-3" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-b" d="M 1984 4856 
+Q 1566 4138 1362 3434 
+Q 1159 2731 1159 2009 
+Q 1159 1288 1364 580 
+Q 1569 -128 1984 -844 
+L 1484 -844 
+Q 1016 -109 783 600 
+Q 550 1309 550 2009 
+Q 550 2706 781 3412 
+Q 1013 4119 1484 4856 
+L 1984 4856 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-2a" d="M 3809 666 
+L 3809 1919 
+L 2778 1919 
+L 2778 2438 
+L 4434 2438 
+L 4434 434 
+Q 4069 175 3628 42 
+Q 3188 -91 2688 -91 
+Q 1594 -91 976 548 
+Q 359 1188 359 2328 
+Q 359 3472 976 4111 
+Q 1594 4750 2688 4750 
+Q 3144 4750 3555 4637 
+Q 3966 4525 4313 4306 
+L 4313 3634 
+Q 3963 3931 3569 4081 
+Q 3175 4231 2741 4231 
+Q 1884 4231 1454 3753 
+Q 1025 3275 1025 2328 
+Q 1025 1384 1454 906 
+Q 1884 428 2741 428 
+Q 3075 428 3337 486 
+Q 3600 544 3809 666 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-26" d="M 4122 4306 
+L 4122 3641 
+Q 3803 3938 3442 4084 
+Q 3081 4231 2675 4231 
+Q 1875 4231 1450 3742 
+Q 1025 3253 1025 2328 
+Q 1025 1406 1450 917 
+Q 1875 428 2675 428 
+Q 3081 428 3442 575 
+Q 3803 722 4122 1019 
+L 4122 359 
+Q 3791 134 3420 21 
+Q 3050 -91 2638 -91 
+Q 1578 -91 968 557 
+Q 359 1206 359 2328 
+Q 359 3453 968 4101 
+Q 1578 4750 2638 4750 
+Q 3056 4750 3426 4639 
+Q 3797 4528 4122 4306 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-27" d="M 1259 4147 
+L 1259 519 
+L 2022 519 
+Q 2988 519 3436 956 
+Q 3884 1394 3884 2338 
+Q 3884 3275 3436 3711 
+Q 2988 4147 2022 4147 
+L 1259 4147 
+z
+M 628 4666 
+L 1925 4666 
+Q 3281 4666 3915 4102 
+Q 4550 3538 4550 2338 
+Q 4550 1131 3912 565 
+Q 3275 0 1925 0 
+L 628 0 
+L 628 4666 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-44" d="M 2194 1759 
+Q 1497 1759 1228 1600 
+Q 959 1441 959 1056 
+Q 959 750 1161 570 
+Q 1363 391 1709 391 
+Q 2188 391 2477 730 
+Q 2766 1069 2766 1631 
+L 2766 1759 
+L 2194 1759 
+z
+M 3341 1997 
+L 3341 0 
+L 2766 0 
+L 2766 531 
+Q 2569 213 2275 61 
+Q 1981 -91 1556 -91 
+Q 1019 -91 701 211 
+Q 384 513 384 1019 
+Q 384 1609 779 1909 
+Q 1175 2209 1959 2209 
+L 2766 2209 
+L 2766 2266 
+Q 2766 2663 2505 2880 
+Q 2244 3097 1772 3097 
+Q 1472 3097 1187 3025 
+Q 903 2953 641 2809 
+L 641 3341 
+Q 956 3463 1253 3523 
+Q 1550 3584 1831 3584 
+Q 2591 3584 2966 3190 
+Q 3341 2797 3341 1997 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-46" d="M 3122 3366 
+L 3122 2828 
+Q 2878 2963 2633 3030 
+Q 2388 3097 2138 3097 
+Q 1578 3097 1268 2742 
+Q 959 2388 959 1747 
+Q 959 1106 1268 751 
+Q 1578 397 2138 397 
+Q 2388 397 2633 464 
+Q 2878 531 3122 666 
+L 3122 134 
+Q 2881 22 2623 -34 
+Q 2366 -91 2075 -91 
+Q 1284 -91 818 406 
+Q 353 903 353 1747 
+Q 353 2603 823 3093 
+Q 1294 3584 2113 3584 
+Q 2378 3584 2631 3529 
+Q 2884 3475 3122 3366 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-4b" d="M 3513 2113 
+L 3513 0 
+L 2938 0 
+L 2938 2094 
+Q 2938 2591 2744 2837 
+Q 2550 3084 2163 3084 
+Q 1697 3084 1428 2787 
+Q 1159 2491 1159 1978 
+L 1159 0 
+L 581 0 
+L 581 4863 
+L 1159 4863 
+L 1159 2956 
+Q 1366 3272 1645 3428 
+Q 1925 3584 2291 3584 
+Q 2894 3584 3203 3211 
+Q 3513 2838 3513 2113 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-c" d="M 513 4856 
+L 1013 4856 
+Q 1481 4119 1714 3412 
+Q 1947 2706 1947 2009 
+Q 1947 1309 1714 600 
+Q 1481 -109 1013 -844 
+L 513 -844 
+Q 928 -128 1133 580 
+Q 1338 1288 1338 2009 
+Q 1338 2731 1133 3434 
+Q 928 4138 513 4856 
+z
+" transform="scale(0.015625)"/>
+      </defs>
+      <use xlink:href="#DejaVuSans-51"/>
+      <use xlink:href="#DejaVuSans-52" transform="translate(63.375 0)"/>
+      <use xlink:href="#DejaVuSans-47" transform="translate(124.5625 0)"/>
+      <use xlink:href="#DejaVuSans-48" transform="translate(188.046875 0)"/>
+      <use xlink:href="#DejaVuSans-56" transform="translate(249.578125 0)"/>
+      <use xlink:href="#DejaVuSans-3" transform="translate(301.671875 0)"/>
+      <use xlink:href="#DejaVuSans-b" transform="translate(333.453125 0)"/>
+      <use xlink:href="#DejaVuSans-1b" transform="translate(372.46875 0)"/>
+      <use xlink:href="#DejaVuSans-3" transform="translate(436.09375 0)"/>
+      <use xlink:href="#DejaVuSans-2a" transform="translate(467.875 0)"/>
+      <use xlink:href="#DejaVuSans-26" transform="translate(545.359375 0)"/>
+      <use xlink:href="#DejaVuSans-27" transform="translate(615.1875 0)"/>
+      <use xlink:href="#DejaVuSans-56" transform="translate(692.1875 0)"/>
+      <use xlink:href="#DejaVuSans-3" transform="translate(744.28125 0)"/>
+      <use xlink:href="#DejaVuSans-48" transform="translate(776.0625 0)"/>
+      <use xlink:href="#DejaVuSans-44" transform="translate(837.59375 0)"/>
+      <use xlink:href="#DejaVuSans-46" transform="translate(898.875 0)"/>
+      <use xlink:href="#DejaVuSans-4b" transform="translate(953.859375 0)"/>
+      <use xlink:href="#DejaVuSans-c" transform="translate(1017.234375 0)"/>
+     </g>
+    </g>
+   </g>
+   <g id="matplotlib.axis_2">
+    <g id="ytick_1">
+     <g id="line2d_11">
+      <path d="M 47.288281 263.613395 
+L 290.77919 263.613395 
+" clip-path="url(#pdfc3c61db6)" style="fill: none; stroke: #d5d8dc; stroke-width: 0.6; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_12">
+      <defs>
+       <path id="m3d5d4485ef" d="M 0 0 
+L -3.5 0 
+" style="stroke: #000000; stroke-width: 0.8"/>
+      </defs>
+      <g>
+       <use xlink:href="#m3d5d4485ef" x="47.288281" y="263.613395" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_7">
+      <!-- 200 -->
+      <g transform="translate(21.200781 267.412223) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-13" d="M 2034 4250 
+Q 1547 4250 1301 3770 
+Q 1056 3291 1056 2328 
+Q 1056 1369 1301 889 
+Q 1547 409 2034 409 
+Q 2525 409 2770 889 
+Q 3016 1369 3016 2328 
+Q 3016 3291 2770 3770 
+Q 2525 4250 2034 4250 
+z
+M 2034 4750 
+Q 2819 4750 3233 4129 
+Q 3647 3509 3647 2328 
+Q 3647 1150 3233 529 
+Q 2819 -91 2034 -91 
+Q 1250 -91 836 529 
+Q 422 1150 422 2328 
+Q 422 3509 836 4129 
+Q 1250 4750 2034 4750 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-15"/>
+       <use xlink:href="#DejaVuSans-13" transform="translate(63.625 0)"/>
+       <use xlink:href="#DejaVuSans-13" transform="translate(127.25 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_2">
+     <g id="line2d_13">
+      <path d="M 47.288281 215.11455 
+L 290.77919 215.11455 
+" clip-path="url(#pdfc3c61db6)" style="fill: none; stroke: #d5d8dc; stroke-width: 0.6; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_14">
+      <g>
+       <use xlink:href="#m3d5d4485ef" x="47.288281" y="215.11455" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_8">
+      <!-- 250 -->
+      <g transform="translate(21.200781 218.913378) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-18" d="M 691 4666 
+L 3169 4666 
+L 3169 4134 
+L 1269 4134 
+L 1269 2991 
+Q 1406 3038 1543 3061 
+Q 1681 3084 1819 3084 
+Q 2600 3084 3056 2656 
+Q 3513 2228 3513 1497 
+Q 3513 744 3044 326 
+Q 2575 -91 1722 -91 
+Q 1428 -91 1123 -41 
+Q 819 9 494 109 
+L 494 744 
+Q 775 591 1075 516 
+Q 1375 441 1709 441 
+Q 2250 441 2565 725 
+Q 2881 1009 2881 1497 
+Q 2881 1984 2565 2268 
+Q 2250 2553 1709 2553 
+Q 1456 2553 1204 2497 
+Q 953 2441 691 2322 
+L 691 4666 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-15"/>
+       <use xlink:href="#DejaVuSans-18" transform="translate(63.625 0)"/>
+       <use xlink:href="#DejaVuSans-13" transform="translate(127.25 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_3">
+     <g id="line2d_15">
+      <path d="M 47.288281 166.615704 
+L 290.77919 166.615704 
+" clip-path="url(#pdfc3c61db6)" style="fill: none; stroke: #d5d8dc; stroke-width: 0.6; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_16">
+      <g>
+       <use xlink:href="#m3d5d4485ef" x="47.288281" y="166.615704" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_9">
+      <!-- 300 -->
+      <g transform="translate(21.200781 170.414533) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-16" d="M 2597 2516 
+Q 3050 2419 3304 2112 
+Q 3559 1806 3559 1356 
+Q 3559 666 3084 287 
+Q 2609 -91 1734 -91 
+Q 1441 -91 1130 -33 
+Q 819 25 488 141 
+L 488 750 
+Q 750 597 1062 519 
+Q 1375 441 1716 441 
+Q 2309 441 2620 675 
+Q 2931 909 2931 1356 
+Q 2931 1769 2642 2001 
+Q 2353 2234 1838 2234 
+L 1294 2234 
+L 1294 2753 
+L 1863 2753 
+Q 2328 2753 2575 2939 
+Q 2822 3125 2822 3475 
+Q 2822 3834 2567 4026 
+Q 2313 4219 1838 4219 
+Q 1578 4219 1281 4162 
+Q 984 4106 628 3988 
+L 628 4550 
+Q 988 4650 1302 4700 
+Q 1616 4750 1894 4750 
+Q 2613 4750 3031 4423 
+Q 3450 4097 3450 3541 
+Q 3450 3153 3228 2886 
+Q 3006 2619 2597 2516 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-16"/>
+       <use xlink:href="#DejaVuSans-13" transform="translate(63.625 0)"/>
+       <use xlink:href="#DejaVuSans-13" transform="translate(127.25 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_4">
+     <g id="line2d_17">
+      <path d="M 47.288281 118.116859 
+L 290.77919 118.116859 
+" clip-path="url(#pdfc3c61db6)" style="fill: none; stroke: #d5d8dc; stroke-width: 0.6; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_18">
+      <g>
+       <use xlink:href="#m3d5d4485ef" x="47.288281" y="118.116859" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_10">
+      <!-- 350 -->
+      <g transform="translate(21.200781 121.915687) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-16"/>
+       <use xlink:href="#DejaVuSans-18" transform="translate(63.625 0)"/>
+       <use xlink:href="#DejaVuSans-13" transform="translate(127.25 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_5">
+     <g id="line2d_19">
+      <path d="M 47.288281 69.618014 
+L 290.77919 69.618014 
+" clip-path="url(#pdfc3c61db6)" style="fill: none; stroke: #d5d8dc; stroke-width: 0.6; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_20">
+      <g>
+       <use xlink:href="#m3d5d4485ef" x="47.288281" y="69.618014" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_11">
+      <!-- 400 -->
+      <g transform="translate(21.200781 73.416842) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-17"/>
+       <use xlink:href="#DejaVuSans-13" transform="translate(63.625 0)"/>
+       <use xlink:href="#DejaVuSans-13" transform="translate(127.25 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="text_12">
+     <!-- wall time per step [ms] -->
+     <g transform="translate(14.798438 216.482031) rotate(-90) scale(0.1 -0.1)">
+      <defs>
+       <path id="DejaVuSans-5a" d="M 269 3500 
+L 844 3500 
+L 1563 769 
+L 2278 3500 
+L 2956 3500 
+L 3675 769 
+L 4391 3500 
+L 4966 3500 
+L 4050 0 
+L 3372 0 
+L 2619 2869 
+L 1863 0 
+L 1184 0 
+L 269 3500 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-4f" d="M 603 4863 
+L 1178 4863 
+L 1178 0 
+L 603 0 
+L 603 4863 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-57" d="M 1172 4494 
+L 1172 3500 
+L 2356 3500 
+L 2356 3053 
+L 1172 3053 
+L 1172 1153 
+Q 1172 725 1289 603 
+Q 1406 481 1766 481 
+L 2356 481 
+L 2356 0 
+L 1766 0 
+Q 1100 0 847 248 
+Q 594 497 594 1153 
+L 594 3053 
+L 172 3053 
+L 172 3500 
+L 594 3500 
+L 594 4494 
+L 1172 4494 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-4c" d="M 603 3500 
+L 1178 3500 
+L 1178 0 
+L 603 0 
+L 603 3500 
+z
+M 603 4863 
+L 1178 4863 
+L 1178 4134 
+L 603 4134 
+L 603 4863 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-50" d="M 3328 2828 
+Q 3544 3216 3844 3400 
+Q 4144 3584 4550 3584 
+Q 5097 3584 5394 3201 
+Q 5691 2819 5691 2113 
+L 5691 0 
+L 5113 0 
+L 5113 2094 
+Q 5113 2597 4934 2840 
+Q 4756 3084 4391 3084 
+Q 3944 3084 3684 2787 
+Q 3425 2491 3425 1978 
+L 3425 0 
+L 2847 0 
+L 2847 2094 
+Q 2847 2600 2669 2842 
+Q 2491 3084 2119 3084 
+Q 1678 3084 1418 2786 
+Q 1159 2488 1159 1978 
+L 1159 0 
+L 581 0 
+L 581 3500 
+L 1159 3500 
+L 1159 2956 
+Q 1356 3278 1631 3431 
+Q 1906 3584 2284 3584 
+Q 2666 3584 2933 3390 
+Q 3200 3197 3328 2828 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-53" d="M 1159 525 
+L 1159 -1331 
+L 581 -1331 
+L 581 3500 
+L 1159 3500 
+L 1159 2969 
+Q 1341 3281 1617 3432 
+Q 1894 3584 2278 3584 
+Q 2916 3584 3314 3078 
+Q 3713 2572 3713 1747 
+Q 3713 922 3314 415 
+Q 2916 -91 2278 -91 
+Q 1894 -91 1617 61 
+Q 1341 213 1159 525 
+z
+M 3116 1747 
+Q 3116 2381 2855 2742 
+Q 2594 3103 2138 3103 
+Q 1681 3103 1420 2742 
+Q 1159 2381 1159 1747 
+Q 1159 1113 1420 752 
+Q 1681 391 2138 391 
+Q 2594 391 2855 752 
+Q 3116 1113 3116 1747 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-55" d="M 2631 2963 
+Q 2534 3019 2420 3045 
+Q 2306 3072 2169 3072 
+Q 1681 3072 1420 2755 
+Q 1159 2438 1159 1844 
+L 1159 0 
+L 581 0 
+L 581 3500 
+L 1159 3500 
+L 1159 2956 
+Q 1341 3275 1631 3429 
+Q 1922 3584 2338 3584 
+Q 2397 3584 2469 3576 
+Q 2541 3569 2628 3553 
+L 2631 2963 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-3e" d="M 550 4863 
+L 1875 4863 
+L 1875 4416 
+L 1125 4416 
+L 1125 -397 
+L 1875 -397 
+L 1875 -844 
+L 550 -844 
+L 550 4863 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-40" d="M 1947 4863 
+L 1947 -844 
+L 622 -844 
+L 622 -397 
+L 1369 -397 
+L 1369 4416 
+L 622 4416 
+L 622 4863 
+L 1947 4863 
+z
+" transform="scale(0.015625)"/>
+      </defs>
+      <use xlink:href="#DejaVuSans-5a"/>
+      <use xlink:href="#DejaVuSans-44" transform="translate(81.78125 0)"/>
+      <use xlink:href="#DejaVuSans-4f" transform="translate(143.0625 0)"/>
+      <use xlink:href="#DejaVuSans-4f" transform="translate(170.84375 0)"/>
+      <use xlink:href="#DejaVuSans-3" transform="translate(198.625 0)"/>
+      <use xlink:href="#DejaVuSans-57" transform="translate(230.40625 0)"/>
+      <use xlink:href="#DejaVuSans-4c" transform="translate(269.609375 0)"/>
+      <use xlink:href="#DejaVuSans-50" transform="translate(297.390625 0)"/>
+      <use xlink:href="#DejaVuSans-48" transform="translate(394.796875 0)"/>
+      <use xlink:href="#DejaVuSans-3" transform="translate(456.328125 0)"/>
+      <use xlink:href="#DejaVuSans-53" transform="translate(488.109375 0)"/>
+      <use xlink:href="#DejaVuSans-48" transform="translate(551.59375 0)"/>
+      <use xlink:href="#DejaVuSans-55" transform="translate(613.125 0)"/>
+      <use xlink:href="#DejaVuSans-3" transform="translate(654.234375 0)"/>
+      <use xlink:href="#DejaVuSans-56" transform="translate(686.015625 0)"/>
+      <use xlink:href="#DejaVuSans-57" transform="translate(738.109375 0)"/>
+      <use xlink:href="#DejaVuSans-48" transform="translate(777.3125 0)"/>
+      <use xlink:href="#DejaVuSans-53" transform="translate(838.84375 0)"/>
+      <use xlink:href="#DejaVuSans-3" transform="translate(902.328125 0)"/>
+      <use xlink:href="#DejaVuSans-3e" transform="translate(934.109375 0)"/>
+      <use xlink:href="#DejaVuSans-50" transform="translate(973.125 0)"/>
+      <use xlink:href="#DejaVuSans-56" transform="translate(1070.53125 0)"/>
+      <use xlink:href="#DejaVuSans-40" transform="translate(1122.625 0)"/>
+     </g>
+    </g>
+   </g>
+   <g id="line2d_21">
+    <path d="M 58.35605 259.2 
+L 113.694893 249.95612 
+L 169.033736 151.173672 
+L 224.372579 71.499769 
+L 279.711422 57.6 
+" clip-path="url(#pdfc3c61db6)" style="fill: none; stroke: #1f6fb4; stroke-width: 1.8; stroke-linecap: square"/>
+    <defs>
+     <path id="me04f7732ad" d="M 0 3 
+C 0.795609 3 1.55874 2.683901 2.12132 2.12132 
+C 2.683901 1.55874 3 0.795609 3 0 
+C 3 -0.795609 2.683901 -1.55874 2.12132 -2.12132 
+C 1.55874 -2.683901 0.795609 -3 0 -3 
+C -0.795609 -3 -1.55874 -2.683901 -2.12132 -2.12132 
+C -2.683901 -1.55874 -3 -0.795609 -3 0 
+C -3 0.795609 -2.683901 1.55874 -2.12132 2.12132 
+C -1.55874 2.683901 -0.795609 3 0 3 
+z
+" style="stroke: #1f6fb4"/>
+    </defs>
+    <g clip-path="url(#pdfc3c61db6)">
+     <use xlink:href="#me04f7732ad" x="58.35605" y="259.2" style="fill: #1f6fb4; stroke: #1f6fb4"/>
+     <use xlink:href="#me04f7732ad" x="113.694893" y="249.95612" style="fill: #1f6fb4; stroke: #1f6fb4"/>
+     <use xlink:href="#me04f7732ad" x="169.033736" y="151.173672" style="fill: #1f6fb4; stroke: #1f6fb4"/>
+     <use xlink:href="#me04f7732ad" x="224.372579" y="71.499769" style="fill: #1f6fb4; stroke: #1f6fb4"/>
+     <use xlink:href="#me04f7732ad" x="279.711422" y="57.6" style="fill: #1f6fb4; stroke: #1f6fb4"/>
+    </g>
+   </g>
+   <g id="line2d_22">
+    <path d="M 47.288281 259.2 
+L 290.77919 259.2 
+" clip-path="url(#pdfc3c61db6)" style="fill: none; stroke-dasharray: 3.7,1.6; stroke-dashoffset: 0; stroke: #7a7a7a"/>
+   </g>
+   <g id="patch_3">
+    <path d="M 47.288281 269.28 
+L 47.288281 47.52 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_4">
+    <path d="M 290.77919 269.28 
+L 290.77919 47.52 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_5">
+    <path d="M 47.288281 269.28 
+L 290.77919 269.28 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_6">
+    <path d="M 47.288281 47.52 
+L 290.77919 47.52 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="text_13">
+    <!-- ideal (flat) -->
+    <g style="fill: #4a4a4a" transform="translate(64.35605 253.2) scale(0.08 -0.08)">
+     <defs>
+      <path id="DejaVuSans-13b0" d="M 1831 4863 
+L 3431 4863 
+L 3431 0 
+L 2853 0 
+L 2853 4384 
+L 1825 4384 
+Q 1516 4384 1395 4259 
+Q 1275 4134 1275 3809 
+L 1275 3500 
+L 2222 3500 
+L 2222 3053 
+L 1275 3053 
+L 1275 0 
+L 697 0 
+L 697 3053 
+L 147 3053 
+L 147 3500 
+L 697 3500 
+L 697 3744 
+Q 697 4328 969 4595 
+Q 1241 4863 1831 4863 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-4c"/>
+     <use xlink:href="#DejaVuSans-47" transform="translate(27.78125 0)"/>
+     <use xlink:href="#DejaVuSans-48" transform="translate(91.265625 0)"/>
+     <use xlink:href="#DejaVuSans-44" transform="translate(152.796875 0)"/>
+     <use xlink:href="#DejaVuSans-4f" transform="translate(214.078125 0)"/>
+     <use xlink:href="#DejaVuSans-3" transform="translate(241.859375 0)"/>
+     <use xlink:href="#DejaVuSans-b" transform="translate(273.640625 0)"/>
+     <use xlink:href="#DejaVuSans-13b0" transform="translate(312.65625 0)"/>
+     <use xlink:href="#DejaVuSans-44" transform="translate(375.640625 0)"/>
+     <use xlink:href="#DejaVuSans-57" transform="translate(436.921875 0)"/>
+     <use xlink:href="#DejaVuSans-c" transform="translate(476.125 0)"/>
+    </g>
+   </g>
+   <g id="text_14">
+    <!-- Constant 67.1M cells per GCD -->
+    <g transform="translate(79.020611 41.52) scale(0.12 -0.12)">
+     <defs>
+      <path id="DejaVuSans-1a" d="M 525 4666 
+L 3525 4666 
+L 3525 4397 
+L 1831 0 
+L 1172 0 
+L 2766 4134 
+L 525 4134 
+L 525 4666 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-11" d="M 684 794 
+L 1344 794 
+L 1344 0 
+L 684 0 
+L 684 794 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-30" d="M 628 4666 
+L 1569 4666 
+L 2759 1491 
+L 3956 4666 
+L 4897 4666 
+L 4897 0 
+L 4281 0 
+L 4281 4097 
+L 3078 897 
+L 2444 897 
+L 1241 4097 
+L 1241 0 
+L 628 0 
+L 628 4666 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-26"/>
+     <use xlink:href="#DejaVuSans-52" transform="translate(69.828125 0)"/>
+     <use xlink:href="#DejaVuSans-51" transform="translate(131.015625 0)"/>
+     <use xlink:href="#DejaVuSans-56" transform="translate(194.390625 0)"/>
+     <use xlink:href="#DejaVuSans-57" transform="translate(246.484375 0)"/>
+     <use xlink:href="#DejaVuSans-44" transform="translate(285.6875 0)"/>
+     <use xlink:href="#DejaVuSans-51" transform="translate(346.96875 0)"/>
+     <use xlink:href="#DejaVuSans-57" transform="translate(410.34375 0)"/>
+     <use xlink:href="#DejaVuSans-3" transform="translate(449.546875 0)"/>
+     <use xlink:href="#DejaVuSans-19" transform="translate(481.328125 0)"/>
+     <use xlink:href="#DejaVuSans-1a" transform="translate(544.953125 0)"/>
+     <use xlink:href="#DejaVuSans-11" transform="translate(608.578125 0)"/>
+     <use xlink:href="#DejaVuSans-14" transform="translate(640.359375 0)"/>
+     <use xlink:href="#DejaVuSans-30" transform="translate(703.984375 0)"/>
+     <use xlink:href="#DejaVuSans-3" transform="translate(790.265625 0)"/>
+     <use xlink:href="#DejaVuSans-46" transform="translate(822.046875 0)"/>
+     <use xlink:href="#DejaVuSans-48" transform="translate(877.03125 0)"/>
+     <use xlink:href="#DejaVuSans-4f" transform="translate(938.5625 0)"/>
+     <use xlink:href="#DejaVuSans-4f" transform="translate(966.34375 0)"/>
+     <use xlink:href="#DejaVuSans-56" transform="translate(994.125 0)"/>
+     <use xlink:href="#DejaVuSans-3" transform="translate(1046.21875 0)"/>
+     <use xlink:href="#DejaVuSans-53" transform="translate(1078 0)"/>
+     <use xlink:href="#DejaVuSans-48" transform="translate(1141.484375 0)"/>
+     <use xlink:href="#DejaVuSans-55" transform="translate(1203.015625 0)"/>
+     <use xlink:href="#DejaVuSans-3" transform="translate(1244.125 0)"/>
+     <use xlink:href="#DejaVuSans-2a" transform="translate(1275.90625 0)"/>
+     <use xlink:href="#DejaVuSans-26" transform="translate(1353.390625 0)"/>
+     <use xlink:href="#DejaVuSans-27" transform="translate(1423.21875 0)"/>
+    </g>
+   </g>
+  </g>
+  <g id="axes_2">
+   <g id="patch_7">
+    <path d="M 339.477372 269.28 
+L 582.968281 269.28 
+L 582.968281 47.52 
+L 339.477372 47.52 
+z
+" style="fill: #ffffff"/>
+   </g>
+   <g id="matplotlib.axis_3">
+    <g id="xtick_6">
+     <g id="line2d_23">
+      <path d="M 350.545141 269.28 
+L 350.545141 47.52 
+" clip-path="url(#p12336abb0a)" style="fill: none; stroke: #d5d8dc; stroke-width: 0.6; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_24">
+      <g>
+       <use xlink:href="#ma95b824712" x="350.545141" y="269.28" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_15">
+      <!-- 1 -->
+      <g transform="translate(347.363891 283.877656) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-14"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_7">
+     <g id="line2d_25">
+      <path d="M 405.883984 269.28 
+L 405.883984 47.52 
+" clip-path="url(#p12336abb0a)" style="fill: none; stroke: #d5d8dc; stroke-width: 0.6; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_26">
+      <g>
+       <use xlink:href="#ma95b824712" x="405.883984" y="269.28" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_16">
+      <!-- 2 -->
+      <g transform="translate(402.702734 283.877656) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-15"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_8">
+     <g id="line2d_27">
+      <path d="M 461.222827 269.28 
+L 461.222827 47.52 
+" clip-path="url(#p12336abb0a)" style="fill: none; stroke: #d5d8dc; stroke-width: 0.6; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_28">
+      <g>
+       <use xlink:href="#ma95b824712" x="461.222827" y="269.28" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_17">
+      <!-- 4 -->
+      <g transform="translate(458.041577 283.877656) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-17"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_9">
+     <g id="line2d_29">
+      <path d="M 516.56167 269.28 
+L 516.56167 47.52 
+" clip-path="url(#p12336abb0a)" style="fill: none; stroke: #d5d8dc; stroke-width: 0.6; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_30">
+      <g>
+       <use xlink:href="#ma95b824712" x="516.56167" y="269.28" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_18">
+      <!-- 8 -->
+      <g transform="translate(513.38042 283.877656) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-1b"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_10">
+     <g id="line2d_31">
+      <path d="M 571.900513 269.28 
+L 571.900513 47.52 
+" clip-path="url(#p12336abb0a)" style="fill: none; stroke: #d5d8dc; stroke-width: 0.6; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_32">
+      <g>
+       <use xlink:href="#ma95b824712" x="571.900513" y="269.28" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_19">
+      <!-- 16 -->
+      <g transform="translate(565.538013 283.877656) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-14"/>
+       <use xlink:href="#DejaVuSans-19" transform="translate(63.625 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="text_20">
+     <!-- nodes -->
+     <g transform="translate(446.139233 297.878437) scale(0.1 -0.1)">
+      <use xlink:href="#DejaVuSans-51"/>
+      <use xlink:href="#DejaVuSans-52" transform="translate(63.375 0)"/>
+      <use xlink:href="#DejaVuSans-47" transform="translate(124.5625 0)"/>
+      <use xlink:href="#DejaVuSans-48" transform="translate(188.046875 0)"/>
+      <use xlink:href="#DejaVuSans-56" transform="translate(249.578125 0)"/>
+     </g>
+    </g>
+   </g>
+   <g id="matplotlib.axis_4">
+    <g id="ytick_6">
+     <g id="line2d_33">
+      <path d="M 339.477372 269.28 
+L 582.968281 269.28 
+" clip-path="url(#p12336abb0a)" style="fill: none; stroke: #d5d8dc; stroke-width: 0.6; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_34">
+      <g>
+       <use xlink:href="#m3d5d4485ef" x="339.477372" y="269.28" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_21">
+      <!-- 0 -->
+      <g transform="translate(326.114872 273.078828) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-13"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_7">
+     <g id="line2d_35">
+      <path d="M 339.477372 228.96 
+L 582.968281 228.96 
+" clip-path="url(#p12336abb0a)" style="fill: none; stroke: #d5d8dc; stroke-width: 0.6; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_36">
+      <g>
+       <use xlink:href="#m3d5d4485ef" x="339.477372" y="228.96" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_22">
+      <!-- 20 -->
+      <g transform="translate(319.752372 232.758828) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-15"/>
+       <use xlink:href="#DejaVuSans-13" transform="translate(63.625 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_8">
+     <g id="line2d_37">
+      <path d="M 339.477372 188.64 
+L 582.968281 188.64 
+" clip-path="url(#p12336abb0a)" style="fill: none; stroke: #d5d8dc; stroke-width: 0.6; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_38">
+      <g>
+       <use xlink:href="#m3d5d4485ef" x="339.477372" y="188.64" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_23">
+      <!-- 40 -->
+      <g transform="translate(319.752372 192.438828) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-17"/>
+       <use xlink:href="#DejaVuSans-13" transform="translate(63.625 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_9">
+     <g id="line2d_39">
+      <path d="M 339.477372 148.32 
+L 582.968281 148.32 
+" clip-path="url(#p12336abb0a)" style="fill: none; stroke: #d5d8dc; stroke-width: 0.6; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_40">
+      <g>
+       <use xlink:href="#m3d5d4485ef" x="339.477372" y="148.32" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_24">
+      <!-- 60 -->
+      <g transform="translate(319.752372 152.118828) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-19"/>
+       <use xlink:href="#DejaVuSans-13" transform="translate(63.625 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_10">
+     <g id="line2d_41">
+      <path d="M 339.477372 108 
+L 582.968281 108 
+" clip-path="url(#p12336abb0a)" style="fill: none; stroke: #d5d8dc; stroke-width: 0.6; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_42">
+      <g>
+       <use xlink:href="#m3d5d4485ef" x="339.477372" y="108" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_25">
+      <!-- 80 -->
+      <g transform="translate(319.752372 111.798828) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-1b"/>
+       <use xlink:href="#DejaVuSans-13" transform="translate(63.625 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_11">
+     <g id="line2d_43">
+      <path d="M 339.477372 67.68 
+L 582.968281 67.68 
+" clip-path="url(#p12336abb0a)" style="fill: none; stroke: #d5d8dc; stroke-width: 0.6; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_44">
+      <g>
+       <use xlink:href="#m3d5d4485ef" x="339.477372" y="67.68" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_26">
+      <!-- 100 -->
+      <g transform="translate(313.389872 71.478828) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-14"/>
+       <use xlink:href="#DejaVuSans-13" transform="translate(63.625 0)"/>
+       <use xlink:href="#DejaVuSans-13" transform="translate(127.25 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="text_27">
+     <!-- weak-scaling efficiency [%] -->
+     <g transform="translate(306.987528 226.701562) rotate(-90) scale(0.1 -0.1)">
+      <defs>
+       <path id="DejaVuSans-4e" d="M 581 4863 
+L 1159 4863 
+L 1159 1991 
+L 2875 3500 
+L 3609 3500 
+L 1753 1863 
+L 3688 0 
+L 2938 0 
+L 1159 1709 
+L 1159 0 
+L 581 0 
+L 581 4863 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-10" d="M 313 2009 
+L 1997 2009 
+L 1997 1497 
+L 313 1497 
+L 313 2009 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-4a" d="M 2906 1791 
+Q 2906 2416 2648 2759 
+Q 2391 3103 1925 3103 
+Q 1463 3103 1205 2759 
+Q 947 2416 947 1791 
+Q 947 1169 1205 825 
+Q 1463 481 1925 481 
+Q 2391 481 2648 825 
+Q 2906 1169 2906 1791 
+z
+M 3481 434 
+Q 3481 -459 3084 -895 
+Q 2688 -1331 1869 -1331 
+Q 1566 -1331 1297 -1286 
+Q 1028 -1241 775 -1147 
+L 775 -588 
+Q 1028 -725 1275 -790 
+Q 1522 -856 1778 -856 
+Q 2344 -856 2625 -561 
+Q 2906 -266 2906 331 
+L 2906 616 
+Q 2728 306 2450 153 
+Q 2172 0 1784 0 
+Q 1141 0 747 490 
+Q 353 981 353 1791 
+Q 353 2603 747 3093 
+Q 1141 3584 1784 3584 
+Q 2172 3584 2450 3431 
+Q 2728 3278 2906 2969 
+L 2906 3500 
+L 3481 3500 
+L 3481 434 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-13b1" d="M 2375 4863 
+L 2375 4384 
+L 1825 4384 
+Q 1516 4384 1394 4259 
+Q 1275 4134 1275 3809 
+L 1275 3500 
+L 2853 3500 
+L 2853 3744 
+Q 2853 4328 3125 4594 
+Q 3213 4681 3334 4741 
+Q 3578 4863 3988 4863 
+L 4531 4863 
+L 4531 4384 
+L 3981 4384 
+Q 3672 4384 3551 4259 
+Q 3431 4134 3431 3809 
+L 3431 3500 
+L 5588 3500 
+L 5588 0 
+L 5009 0 
+L 5009 3053 
+L 3431 3053 
+L 3431 0 
+L 2853 0 
+L 2853 3053 
+L 1275 3053 
+L 1275 0 
+L 697 0 
+L 697 3053 
+L 147 3053 
+L 147 3500 
+L 697 3500 
+L 697 3744 
+Q 697 4328 969 4595 
+Q 1241 4863 1831 4863 
+L 2375 4863 
+z
+M 5009 4856 
+L 5588 4856 
+L 5588 4128 
+L 5009 4128 
+L 5009 4856 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-5c" d="M 2059 -325 
+Q 1816 -950 1584 -1140 
+Q 1353 -1331 966 -1331 
+L 506 -1331 
+L 506 -850 
+L 844 -850 
+Q 1081 -850 1212 -737 
+Q 1344 -625 1503 -206 
+L 1606 56 
+L 191 3500 
+L 800 3500 
+L 1894 763 
+L 2988 3500 
+L 3597 3500 
+L 2059 -325 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-8" d="M 4653 2053 
+Q 4381 2053 4226 1822 
+Q 4072 1591 4072 1178 
+Q 4072 772 4226 539 
+Q 4381 306 4653 306 
+Q 4919 306 5073 539 
+Q 5228 772 5228 1178 
+Q 5228 1588 5073 1820 
+Q 4919 2053 4653 2053 
+z
+M 4653 2450 
+Q 5147 2450 5437 2106 
+Q 5728 1763 5728 1178 
+Q 5728 594 5436 251 
+Q 5144 -91 4653 -91 
+Q 4153 -91 3862 251 
+Q 3572 594 3572 1178 
+Q 3572 1766 3864 2108 
+Q 4156 2450 4653 2450 
+z
+M 1428 4353 
+Q 1159 4353 1004 4120 
+Q 850 3888 850 3481 
+Q 850 3069 1003 2837 
+Q 1156 2606 1428 2606 
+Q 1700 2606 1854 2837 
+Q 2009 3069 2009 3481 
+Q 2009 3884 1853 4118 
+Q 1697 4353 1428 4353 
+z
+M 4250 4750 
+L 4750 4750 
+L 1831 -91 
+L 1331 -91 
+L 4250 4750 
+z
+M 1428 4750 
+Q 1922 4750 2215 4408 
+Q 2509 4066 2509 3481 
+Q 2509 2891 2217 2550 
+Q 1925 2209 1428 2209 
+Q 931 2209 642 2551 
+Q 353 2894 353 3481 
+Q 353 4063 643 4406 
+Q 934 4750 1428 4750 
+z
+" transform="scale(0.015625)"/>
+      </defs>
+      <use xlink:href="#DejaVuSans-5a"/>
+      <use xlink:href="#DejaVuSans-48" transform="translate(81.78125 0)"/>
+      <use xlink:href="#DejaVuSans-44" transform="translate(143.3125 0)"/>
+      <use xlink:href="#DejaVuSans-4e" transform="translate(204.59375 0)"/>
+      <use xlink:href="#DejaVuSans-10" transform="translate(262.5 0)"/>
+      <use xlink:href="#DejaVuSans-56" transform="translate(298.578125 0)"/>
+      <use xlink:href="#DejaVuSans-46" transform="translate(350.671875 0)"/>
+      <use xlink:href="#DejaVuSans-44" transform="translate(405.65625 0)"/>
+      <use xlink:href="#DejaVuSans-4f" transform="translate(466.9375 0)"/>
+      <use xlink:href="#DejaVuSans-4c" transform="translate(494.71875 0)"/>
+      <use xlink:href="#DejaVuSans-51" transform="translate(522.5 0)"/>
+      <use xlink:href="#DejaVuSans-4a" transform="translate(585.875 0)"/>
+      <use xlink:href="#DejaVuSans-3" transform="translate(649.359375 0)"/>
+      <use xlink:href="#DejaVuSans-48" transform="translate(681.140625 0)"/>
+      <use xlink:href="#DejaVuSans-13b1" transform="translate(742.671875 0)"/>
+      <use xlink:href="#DejaVuSans-46" transform="translate(839.359375 0)"/>
+      <use xlink:href="#DejaVuSans-4c" transform="translate(894.34375 0)"/>
+      <use xlink:href="#DejaVuSans-48" transform="translate(922.125 0)"/>
+      <use xlink:href="#DejaVuSans-51" transform="translate(983.65625 0)"/>
+      <use xlink:href="#DejaVuSans-46" transform="translate(1047.03125 0)"/>
+      <use xlink:href="#DejaVuSans-5c" transform="translate(1102.015625 0)"/>
+      <use xlink:href="#DejaVuSans-3" transform="translate(1161.203125 0)"/>
+      <use xlink:href="#DejaVuSans-3e" transform="translate(1192.984375 0)"/>
+      <use xlink:href="#DejaVuSans-8" transform="translate(1232 0)"/>
+      <use xlink:href="#DejaVuSans-40" transform="translate(1327.015625 0)"/>
+     </g>
+    </g>
+   </g>
+   <g id="line2d_45">
+    <path d="M 350.545141 67.68 
+L 405.883984 76.654439 
+L 461.222827 138.749233 
+L 516.56167 165.684361 
+L 571.900513 169.284171 
+" clip-path="url(#p12336abb0a)" style="fill: none; stroke: #1f6fb4; stroke-width: 1.8; stroke-linecap: square"/>
+    <g clip-path="url(#p12336abb0a)">
+     <use xlink:href="#me04f7732ad" x="350.545141" y="67.68" style="fill: #1f6fb4; stroke: #1f6fb4"/>
+     <use xlink:href="#me04f7732ad" x="405.883984" y="76.654439" style="fill: #1f6fb4; stroke: #1f6fb4"/>
+     <use xlink:href="#me04f7732ad" x="461.222827" y="138.749233" style="fill: #1f6fb4; stroke: #1f6fb4"/>
+     <use xlink:href="#me04f7732ad" x="516.56167" y="165.684361" style="fill: #1f6fb4; stroke: #1f6fb4"/>
+     <use xlink:href="#me04f7732ad" x="571.900513" y="169.284171" style="fill: #1f6fb4; stroke: #1f6fb4"/>
+    </g>
+   </g>
+   <g id="patch_8">
+    <path d="M 339.477372 269.28 
+L 339.477372 47.52 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_9">
+    <path d="M 582.968281 269.28 
+L 582.968281 47.52 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_10">
+    <path d="M 339.477372 269.28 
+L 582.968281 269.28 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_11">
+    <path d="M 339.477372 47.52 
+L 582.968281 47.52 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="text_28">
+    <!-- 100% -->
+    <g transform="translate(339.824242 81.68) scale(0.075 -0.075)">
+     <use xlink:href="#DejaVuSans-14"/>
+     <use xlink:href="#DejaVuSans-13" transform="translate(63.625 0)"/>
+     <use xlink:href="#DejaVuSans-13" transform="translate(127.25 0)"/>
+     <use xlink:href="#DejaVuSans-8" transform="translate(190.875 0)"/>
+    </g>
+   </g>
+   <g id="text_29">
+    <!-- 96% -->
+    <g transform="translate(397.549023 90.654439) scale(0.075 -0.075)">
+     <defs>
+      <path id="DejaVuSans-1c" d="M 703 97 
+L 703 672 
+Q 941 559 1184 500 
+Q 1428 441 1663 441 
+Q 2288 441 2617 861 
+Q 2947 1281 2994 2138 
+Q 2813 1869 2534 1725 
+Q 2256 1581 1919 1581 
+Q 1219 1581 811 2004 
+Q 403 2428 403 3163 
+Q 403 3881 828 4315 
+Q 1253 4750 1959 4750 
+Q 2769 4750 3195 4129 
+Q 3622 3509 3622 2328 
+Q 3622 1225 3098 567 
+Q 2575 -91 1691 -91 
+Q 1453 -91 1209 -44 
+Q 966 3 703 97 
+z
+M 1959 2075 
+Q 2384 2075 2632 2365 
+Q 2881 2656 2881 3163 
+Q 2881 3666 2632 3958 
+Q 2384 4250 1959 4250 
+Q 1534 4250 1286 3958 
+Q 1038 3666 1038 3163 
+Q 1038 2656 1286 2365 
+Q 1534 2075 1959 2075 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-1c"/>
+     <use xlink:href="#DejaVuSans-19" transform="translate(63.625 0)"/>
+     <use xlink:href="#DejaVuSans-8" transform="translate(127.25 0)"/>
+    </g>
+   </g>
+   <g id="text_30">
+    <!-- 65% -->
+    <g transform="translate(452.887866 152.749233) scale(0.075 -0.075)">
+     <use xlink:href="#DejaVuSans-19"/>
+     <use xlink:href="#DejaVuSans-18" transform="translate(63.625 0)"/>
+     <use xlink:href="#DejaVuSans-8" transform="translate(127.25 0)"/>
+    </g>
+   </g>
+   <g id="text_31">
+    <!-- 51% -->
+    <g transform="translate(508.226709 179.684361) scale(0.075 -0.075)">
+     <use xlink:href="#DejaVuSans-18"/>
+     <use xlink:href="#DejaVuSans-14" transform="translate(63.625 0)"/>
+     <use xlink:href="#DejaVuSans-8" transform="translate(127.25 0)"/>
+    </g>
+   </g>
+   <g id="text_32">
+    <!-- 50% -->
+    <g transform="translate(563.565552 183.284171) scale(0.075 -0.075)">
+     <use xlink:href="#DejaVuSans-18"/>
+     <use xlink:href="#DejaVuSans-13" transform="translate(63.625 0)"/>
+     <use xlink:href="#DejaVuSans-8" transform="translate(127.25 0)"/>
+    </g>
+   </g>
+   <g id="text_33">
+    <!-- $8.59\times10^{9}$ cells at 16 nodes -->
+    <g transform="translate(377.102827 41.52) scale(0.12 -0.12)">
+     <defs>
+      <path id="DejaVuSans-99" d="M 4488 3438 
+L 3059 2003 
+L 4488 575 
+L 4116 197 
+L 2681 1631 
+L 1247 197 
+L 878 575 
+L 2303 2003 
+L 878 3438 
+L 1247 3816 
+L 2681 2381 
+L 4116 3816 
+L 4488 3438 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-1b" transform="translate(0 0.746875)"/>
+     <use xlink:href="#DejaVuSans-11" transform="translate(63.623047 0.746875)"/>
+     <use xlink:href="#DejaVuSans-18" transform="translate(95.410156 0.746875)"/>
+     <use xlink:href="#DejaVuSans-1c" transform="translate(159.033203 0.746875)"/>
+     <use xlink:href="#DejaVuSans-99" transform="translate(242.138672 0.746875)"/>
+     <use xlink:href="#DejaVuSans-14" transform="translate(345.410156 0.746875)"/>
+     <use xlink:href="#DejaVuSans-13" transform="translate(409.033203 0.746875)"/>
+     <use xlink:href="#DejaVuSans-1c" transform="translate(473.613281 42.046875) scale(0.7)"/>
+     <use xlink:href="#DejaVuSans-3" transform="translate(520.883789 0.746875)"/>
+     <use xlink:href="#DejaVuSans-46" transform="translate(552.670898 0.746875)"/>
+     <use xlink:href="#DejaVuSans-48" transform="translate(607.651367 0.746875)"/>
+     <use xlink:href="#DejaVuSans-4f" transform="translate(669.174805 0.746875)"/>
+     <use xlink:href="#DejaVuSans-4f" transform="translate(696.958008 0.746875)"/>
+     <use xlink:href="#DejaVuSans-56" transform="translate(724.741211 0.746875)"/>
+     <use xlink:href="#DejaVuSans-3" transform="translate(776.84082 0.746875)"/>
+     <use xlink:href="#DejaVuSans-44" transform="translate(808.62793 0.746875)"/>
+     <use xlink:href="#DejaVuSans-57" transform="translate(869.907227 0.746875)"/>
+     <use xlink:href="#DejaVuSans-3" transform="translate(909.116211 0.746875)"/>
+     <use xlink:href="#DejaVuSans-14" transform="translate(940.90332 0.746875)"/>
+     <use xlink:href="#DejaVuSans-19" transform="translate(1004.526367 0.746875)"/>
+     <use xlink:href="#DejaVuSans-3" transform="translate(1068.149414 0.746875)"/>
+     <use xlink:href="#DejaVuSans-51" transform="translate(1099.936523 0.746875)"/>
+     <use xlink:href="#DejaVuSans-52" transform="translate(1163.31543 0.746875)"/>
+     <use xlink:href="#DejaVuSans-47" transform="translate(1224.49707 0.746875)"/>
+     <use xlink:href="#DejaVuSans-48" transform="translate(1287.973633 0.746875)"/>
+     <use xlink:href="#DejaVuSans-56" transform="translate(1349.49707 0.746875)"/>
+    </g>
+   </g>
+  </g>
+  <g id="text_34">
+   <!-- Tungsten PFC weak scaling, LUMI-G -->
+   <g transform="translate(200.343594 16.318125) scale(0.12 -0.12)">
+    <defs>
+     <path id="DejaVuSans-37" d="M -19 4666 
+L 3928 4666 
+L 3928 4134 
+L 2272 4134 
+L 2272 0 
+L 1638 0 
+L 1638 4134 
+L -19 4134 
+L -19 4666 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-58" d="M 544 1381 
+L 544 3500 
+L 1119 3500 
+L 1119 1403 
+Q 1119 906 1312 657 
+Q 1506 409 1894 409 
+Q 2359 409 2629 706 
+Q 2900 1003 2900 1516 
+L 2900 3500 
+L 3475 3500 
+L 3475 0 
+L 2900 0 
+L 2900 538 
+Q 2691 219 2414 64 
+Q 2138 -91 1772 -91 
+Q 1169 -91 856 284 
+Q 544 659 544 1381 
+z
+M 1991 3584 
+L 1991 3584 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-33" d="M 1259 4147 
+L 1259 2394 
+L 2053 2394 
+Q 2494 2394 2734 2622 
+Q 2975 2850 2975 3272 
+Q 2975 3691 2734 3919 
+Q 2494 4147 2053 4147 
+L 1259 4147 
+z
+M 628 4666 
+L 2053 4666 
+Q 2838 4666 3239 4311 
+Q 3641 3956 3641 3272 
+Q 3641 2581 3239 2228 
+Q 2838 1875 2053 1875 
+L 1259 1875 
+L 1259 0 
+L 628 0 
+L 628 4666 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-29" d="M 628 4666 
+L 3309 4666 
+L 3309 4134 
+L 1259 4134 
+L 1259 2759 
+L 3109 2759 
+L 3109 2228 
+L 1259 2228 
+L 1259 0 
+L 628 0 
+L 628 4666 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-f" d="M 750 794 
+L 1409 794 
+L 1409 256 
+L 897 -744 
+L 494 -744 
+L 750 256 
+L 750 794 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-2f" d="M 628 4666 
+L 1259 4666 
+L 1259 531 
+L 3531 531 
+L 3531 0 
+L 628 0 
+L 628 4666 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-38" d="M 556 4666 
+L 1191 4666 
+L 1191 1831 
+Q 1191 1081 1462 751 
+Q 1734 422 2344 422 
+Q 2950 422 3222 751 
+Q 3494 1081 3494 1831 
+L 3494 4666 
+L 4128 4666 
+L 4128 1753 
+Q 4128 841 3676 375 
+Q 3225 -91 2344 -91 
+Q 1459 -91 1007 375 
+Q 556 841 556 1753 
+L 556 4666 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-2c" d="M 628 4666 
+L 1259 4666 
+L 1259 0 
+L 628 0 
+L 628 4666 
+z
+" transform="scale(0.015625)"/>
+    </defs>
+    <use xlink:href="#DejaVuSans-37"/>
+    <use xlink:href="#DejaVuSans-58" transform="translate(45.890625 0)"/>
+    <use xlink:href="#DejaVuSans-51" transform="translate(109.265625 0)"/>
+    <use xlink:href="#DejaVuSans-4a" transform="translate(172.640625 0)"/>
+    <use xlink:href="#DejaVuSans-56" transform="translate(236.125 0)"/>
+    <use xlink:href="#DejaVuSans-57" transform="translate(288.21875 0)"/>
+    <use xlink:href="#DejaVuSans-48" transform="translate(327.421875 0)"/>
+    <use xlink:href="#DejaVuSans-51" transform="translate(388.953125 0)"/>
+    <use xlink:href="#DejaVuSans-3" transform="translate(452.328125 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(484.109375 0)"/>
+    <use xlink:href="#DejaVuSans-29" transform="translate(544.40625 0)"/>
+    <use xlink:href="#DejaVuSans-26" transform="translate(601.921875 0)"/>
+    <use xlink:href="#DejaVuSans-3" transform="translate(671.75 0)"/>
+    <use xlink:href="#DejaVuSans-5a" transform="translate(703.53125 0)"/>
+    <use xlink:href="#DejaVuSans-48" transform="translate(785.3125 0)"/>
+    <use xlink:href="#DejaVuSans-44" transform="translate(846.84375 0)"/>
+    <use xlink:href="#DejaVuSans-4e" transform="translate(908.125 0)"/>
+    <use xlink:href="#DejaVuSans-3" transform="translate(966.03125 0)"/>
+    <use xlink:href="#DejaVuSans-56" transform="translate(997.8125 0)"/>
+    <use xlink:href="#DejaVuSans-46" transform="translate(1049.90625 0)"/>
+    <use xlink:href="#DejaVuSans-44" transform="translate(1104.890625 0)"/>
+    <use xlink:href="#DejaVuSans-4f" transform="translate(1166.171875 0)"/>
+    <use xlink:href="#DejaVuSans-4c" transform="translate(1193.953125 0)"/>
+    <use xlink:href="#DejaVuSans-51" transform="translate(1221.734375 0)"/>
+    <use xlink:href="#DejaVuSans-4a" transform="translate(1285.109375 0)"/>
+    <use xlink:href="#DejaVuSans-f" transform="translate(1348.59375 0)"/>
+    <use xlink:href="#DejaVuSans-3" transform="translate(1380.375 0)"/>
+    <use xlink:href="#DejaVuSans-2f" transform="translate(1412.15625 0)"/>
+    <use xlink:href="#DejaVuSans-38" transform="translate(1462.890625 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(1536.078125 0)"/>
+    <use xlink:href="#DejaVuSans-2c" transform="translate(1622.359375 0)"/>
+    <use xlink:href="#DejaVuSans-10" transform="translate(1651.859375 0)"/>
+    <use xlink:href="#DejaVuSans-2a" transform="translate(1691.59375 0)"/>
+   </g>
+  </g>
+ </g>
+ <defs>
+  <clipPath id="pdfc3c61db6">
+   <rect x="47.288281" y="47.52" width="243.490909" height="221.76"/>
+  </clipPath>
+  <clipPath id="p12336abb0a">
+   <rect x="339.477372" y="47.52" width="243.490909" height="221.76"/>
+  </clipPath>
+ </defs>
+</svg>


### PR DESCRIPTION
Closes the two gaps the scalability chapter named against itself: no weak-scaling study, and no way to compare the two spatial discretisations. Both are now measured on LUMI-G, up to 16 nodes.

## Weak scaling — 1 to 16 nodes, 8.59 billion cells

Local block held at **exactly** 2048×2048×16 (67.1 M cells per GCD) with `Lz` growing with the rank count. OpenPFC decomposes into z-slabs, so growing only `Lz` keeps the local shape exactly constant; a cubic ladder would need `N ∝ P^(1/3)` and land on non-power-of-two transforms with only approximately equal blocks.

| nodes | GCDs | grid | wall/step | efficiency |
|---|---|---|---|---|
| 1 | 8 | 2048²×128 | 204.5 ms | 100 % |
| 2 | 16 | 2048²×256 | 214.1 ms | 95.6 % |
| 4 | 32 | 2048²×512 | 315.9 ms | 64.7 % |
| 8 | 64 | 2048²×1024 | 398.1 ms | 51.4 % |
| 16 | 128 | **2048³** | 412.4 ms | **49.6 %** |

The shape is the result, not the endpoint: nearly free inside a node, ~30 points to cross onto the fabric, then almost flat while ranks quadruple.

## Strong scaling — 82 % at 16 nodes, and a divisibility trap

1280³, 4 → 16 nodes. **82 % at 16 nodes** over a 4× rank range, against a 768³ curve that fell below 50 % at four nodes. The old curves were grid-limited, not code-limited.

The 12-node point is **38 %** — slower than 8 *and* 16. `1280/96 = 13.33`, so ranks get 13 or 14 z-planes and every step waits for the slowest. I added a 10-node run specifically to test that reading (`1280/80 = 16` exactly); it lands back on the curve at **84.1 %**. The rule: pick a rank count that divides the slab axis.

## A memory boundary

**2048³ cannot run below 16 nodes.** OOM-killed at 32, 64 and 96 GCDs, surviving only at 128. Host-side, not device-side — sampled `MaxRSS` was 6.7–7.1 GB per task for the runs that died against 5.5 GB for the one that lived, pointing at a transient spike during transform setup. Characterised, not diagnosed, and the chapter says so.

## Spectral against finite difference

heat3d is the only app with both solvers on one PDE plus a GPU twin of each.

**Cost at equal grid** (1024³, one node): FD-2 6.73 ms, FD-4 11.46, FD-6 15.01, FD-8 18.64, FD-12 24.69, **spectral 213.82** — 32× a second-order step, 8.7× a twelfth-order one.

**Scaling at equal grid** (1536³, 4→16 nodes; `1536 = 2⁹·3` divides every rank count used, so the divisibility effect above cannot contaminate it):

| method | 4n | 8n | 12n | 16n | eff @16n |
|---|---|---|---|---|---|
| spectral | 283.4 ms | 168.0 | 112.8 | 85.0 | 83.3 % |
| FD-2 | 5.91 | 2.99 | 2.11 | 1.73 | **85.3 %** |
| FD-8 | 15.66 | 8.45 | 6.07 | 4.86 | 80.5 % |

The expected penalty for the spectral all-to-all **does not appear** — all three land within five points of each other. At 1536³/128 GCDs each rank still holds 28 M cells, so the transpose is not yet dominant.

## What the chapter deliberately does *not* say

Combining cost with the measured convergence orders gives a tempting table: FD-4 reaches 1e-6 at N=129 for 0.02 ms while spectral costs 214 ms. **I did not publish that as a recommendation.** The convergence study evolves a *single Fourier mode* — the smoothest field there is and the most favourable possible case for a high-order stencil, whose error constant depends on derivatives the mode does not have. It says nothing about a PFC crystal with content at 2k₀ and 3k₀, or a dendrite tip. The chapter states the three things the data does support without qualification, and names the broadband version as the next measurement.

## Verification

- Every number traces to a Slurm job ID recorded in the CSV headers; `wall_step` is the median over accepted steps after five warm-up, taking the **slowest rank per step** (a step is not done until every rank is).
- The weak ladder's endpoint and the strong study's endpoint are the same problem — 2048³ on 128 GCDs — reached independently, and agree to **1.1 %** (412.4 vs 416.8 ms). That cross-check was designed into the ladder.
- All three figures rendered to PNG and visually inspected.
- Cross-reference check: 44 labels defined, 28 referenced, **no undefined references**.
- `check_doc_links.py`, `check_doc_bash_syntax.py` clean. Quarto is not installed here, so the report was not rendered.
- Timestamp-only churn in four pre-existing SVGs reverted; the diff carries only the three new figures.