### PR TITLE
fix(apps): bistability margin and schema enforcement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -161,6 +161,82 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 
 ### Fixed
 
+- The shipped `allen_cahn` preset demonstrated Allen-Cahn arithmetic rather
+  than Allen-Cahn physics, and the two halves of that could not be fixed
+  separately. Its interface was `eps*sqrt(2M) = 0.76` cells wide -- sub-grid,
+  so the front was pinned by the lattice -- and its driving force sat 6%
+  under the bistability ceiling `F eps^2 < 2/(3 sqrt 3)`, close enough that
+  `driving_force = 20` or `epsilon = 0.3` flips the whole box. It measured
+  `+9%` against the sharp-interface law, which looked like agreement and was
+  two errors of opposite sign cancelling: the lattice slowing the front by
+  ~12% and the finite tilt (the law is the `F eps^2 -> 0` limit) speeding the
+  continuum front by ~26%. The obvious repair -- back the driving force off
+  and leave `eps` alone -- makes it worse, not better: at 0.76 cells the
+  residual walks from `+17%` at the ceiling to `-65%` at a quarter of it, so
+  there is no safe driving force at that resolution. Measured across
+  interface width, margin and grid in
+  `docs/report/data/allen_cahn_resolution_margin.csv`.
+
+  The preset is now `epsilon = 0.75`, `driving_force = 0.25`, `M = 8.0`
+  unchanged, `dt = 0.005`, `256^2`: a 3.0-cell interface and `F eps^2 = 0.141`
+  a factor 2.7 under the ceiling. `M` is kept and the other two are round
+  quarters, so the preset stays recognisable. The grid had to move with them
+  -- a resolved interface at a safe driving force has a critical nucleus
+  `R* = M/v` of 7.1 cells against 0.70 before, and the seed
+  `sigma = 0.055*min(nx,ny)` is only 4.1 cells at `64^2`, so the old default
+  grid now dissolves its own seed rather than growing it.
+
+  The pass criterion moved with the preset, because a slower front makes the
+  curvature term matter: a disc obeys `dR/dt = (3/2) F eps sqrt(2M) - M/R`,
+  and `M/R` is 20% of the answer here and does *not* shrink with the grid
+  (the seed scales with the box, so `R/R*` is nearly grid-independent).
+  Comparing a disc against a flat-front law left a 20% bias that looked like
+  a grid dependence; with the curvature term the residual is 1.6% at the
+  shipped preset and at most 2.3% from `128^2` to `512^2`, so the accepted
+  band tightens from a factor of two to +/-25%. The app also prints `R*`, the
+  distance to the bistability ceiling as a percentage, and warns below a
+  2-cell interface, above half the ceiling, and on a subcritical seed.
+
+  No golden moved: `allen-cahn-cpu-golden` and the CPU-vs-CUDA/HIP parity
+  tests all set every parameter explicitly rather than reading the defaults,
+  and the seed width at their `32^2` is on the `max(2, ...)` floor either
+  way. What did move is `allen-cahn-interface-kinetics`, which now runs
+  `256^2`/`384^2` instead of `64^2`/`128^2` and compares each grid with its
+  own curvature-corrected prediction rather than comparing the two raw
+  speeds -- the old pair agreed to 0.3% by luck, and extending the same
+  comparison to `512^2` spreads them by 10%. Two new cases pin the preset
+  itself (interface width, margin, supercritical seed, dt headroom) and the
+  coupling that forced the joint fix.
+
+- `AluminumPhysics::from_json` skipped its own schema. A guard
+  `if (!params_json.is_null() && !params_json.empty())` meant `"params": {}`
+  -- which is exactly what `apps/aluminumNew/inputs_json/smoke.json` shipped
+  -- silently took the C++ member initialisers while all 25 schema fields
+  were declared `required`. For a calibrated material model that is wrong in
+  both directions: a run's parameters were not recoverable from its input
+  file, and the struct defaults are an uncited second copy of coefficients
+  this repository cites no source for. The parse is unconditional now; an
+  empty or absent `model.params` reports every missing field at once, and
+  `smoke.json` spells all of them out.
+
+  Nine of those 25 fields -- not the four the README named -- were read
+  nowhere. `T_min` and `T_max` are now implemented: they clamp
+  `T_const + T_var`, which the moving-frame profile
+  `T_const + G(x - x0 - Vt)` otherwise leaves unbounded along a 1393-unit
+  domain, and an inverted window or a `T_const` outside it is rejected at
+  load time instead of silently pinning the domain at one end. Every shipped
+  preset is isothermal (`G_grid = V_grid = 0`), so the clamp is a no-op on
+  all of them and the pinned `aluminum-etd-cpu-golden` checksum is unchanged.
+  The other seven named nothing this model computes and were removed from the
+  schema: `alpha_farTol` and `alpha_highOrd` parametrise *tungsten's* `C2`,
+  not the FCC dual-Gaussian peak; `shift_u` and `shift_s` are the vapour
+  shift that produced the `p*_bar`/`q*_bar` coefficients, already applied
+  offline; and `n0`, `n_sol`, `n_vap` are duplicates of values that act in
+  the `initial_conditions` and `boundary_conditions` blocks, where a second
+  copy that nothing reads can disagree with the one that does. Unknown keys
+  are ignored, so inputs carrying the removed seven still load. Guards:
+  `[schema]` and `[temperature]` in `aluminumTest`.
+
 - `wave2d`'s advertised observable, `global_rms_u_interior`, was identically
   zero for every configuration on both CPU drivers. The interior visitor
   trimmed the stencil half-width off each axis of each rank's owned box, and

--- a/apps/allen_cahn/README.md
+++ b/apps/allen_cahn/README.md
@@ -19,13 +19,13 @@ update at two grid sizes and asserts that both reach the same verdict.
 |---|---|
 | **Use case** | A single grain of the favoured phase growing into a matrix of the other under a constant driving force |
 | **Question** | Does the favoured phase actually take over, and by how much? |
-| **Domain** | `nx x ny x 1` slab, `dx = dy = 1` **hard-coded** (not a CLI argument). Defaults `64 x 64` |
-| **Grid/time** | `[--strict] nx ny n_steps [dt] [M] [epsilon] [driving_force] [png_initial] [png_final]`; defaults 5000 steps at `dt = 9e-5`. No output cadence -- at most two PNG snapshots, initial and final |
+| **Domain** | `nx x ny x 1` slab, `dx = dy = 1` **hard-coded** (not a CLI argument). Defaults `256 x 256`. The spacing being fixed matters: the interface can only be resolved by making `eps*sqrt(2M)` large in cells, never by refining the grid |
+| **Grid/time** | `[--strict] nx ny n_steps [dt] [M] [epsilon] [driving_force] [png_initial] [png_final]`; defaults 5000 steps at `dt = 0.005`, 16% of the explicit-Euler diffusive limit `dx^2/(4M) = 0.031`. No output cadence -- at most two PNG snapshots, initial and final |
 | **Boundary conditions** | Periodic in x and y, by separated-layout halo exchange. There is no non-periodic option |
 | **Initial condition** | A single Gaussian nucleus, `phi = -1 + 2*exp(-r^2/(2*sigma^2))` centred in the slab, `sigma = max(2, 0.055*min(nx,ny))`. Deterministic; no noise anywhere |
-| **Key physical parameters** | `M = 8.0`, `epsilon = 0.19`, `driving_force = 10.0`. **Nondimensional and illustrative**; this app states no units and cites no reference model. `epsilon` is as much a numerical parameter as a physical one, since it sets both the interface width and the stiff reaction timestep limit |
-| **Observable** | Interface velocity `dR/dt`, where `R = sqrt(A/pi)` is the equivalent radius of the superlevel-set area `A = |{phi > 0}|`, measured over the **second half** of the run and compared with the sharp-interface prediction `v = (3/2) F eps sqrt(2M)`. `A` is sampled at `t = 0, t/2, 3t/4, t`; the two quarter velocities must agree before `v_late` is judged. Also global `min phi`, `max phi`, `sum phi`; `avg_step_time_s`; optional grayscale PNGs. The verdict prints as `physics_check=PASS|FAIL|SKIPPED` and **does not** set the exit status unless `--strict` is passed |
-| **Model maturity** | numerical verification: **analytical** (loosely) and **regression** -- the end-of-run check compares the measured interface velocity with the sharp-interface solvability result `v = (3/2) F eps sqrt(2M)`, to a factor of two, which is as tight as an interface 0.76 cells wide supports; plus one pinned CPU checksum tied to a named machine and toolchain, CPU-vs-CUDA agreement to `1e-9` and CPU-vs-HIP to `1e-4`. There is no manufactured-solution check. Physical completeness: **canonical** -- the standard non-conserved double-well model with a constant driving force, no elastic/thermal/solutal coupling. Calibration: **none** |
+| **Key physical parameters** | `M = 8.0`, `epsilon = 0.75`, `driving_force = 0.25`. **Nondimensional and illustrative**; this app states no units and cites no reference model. `epsilon` is as much a numerical parameter as a physical one, since it sets both the interface width and the stiff reaction timestep limit. The three are chosen together so that the interface is `eps*sqrt(2M) = 3.0` cells wide and `F*eps^2 = 0.141` sits a factor 2.7 under the bistability ceiling `2/(3 sqrt 3) = 0.385` -- see "Two limits" below. Before 0.2 the preset was `epsilon = 0.19`, `driving_force = 10.0`: 0.76 cells and 6% of margin |
+| **Observable** | Interface velocity `dR/dt`, where `R = sqrt(A/pi)` is the equivalent radius of the superlevel-set area `A = |{phi > 0}|`, measured over the **second half** of the run and compared with the **curvature-corrected** sharp-interface prediction `v = (3/2) F eps sqrt(2M) - M/R`, evaluated at the mean radius of that interval, to `+/-25%`. `A` is sampled at `t = 0, t/2, 3t/4, t`; the two quarter velocities must agree before `v_late` is judged. Also the critical radius `M/v`, the interface width in cells, the distance to the bistability ceiling, global `min phi`, `max phi`, `sum phi`, `avg_step_time_s`, and optional grayscale PNGs. The verdict prints as `physics_check=PASS|FAIL|SKIPPED` and **does not** set the exit status unless `--strict` is passed |
+| **Model maturity** | numerical verification: **analytical** and **regression** -- the end-of-run check compares the measured interface velocity with the sharp-interface solvability result plus the curvature term, `v = (3/2) F eps sqrt(2M) - M/R`, to `+/-25%`; the measured residual is `1.6%` at the shipped preset and at most `2.3%` on any grid from `128^2` to `512^2` (`docs/report/data/allen_cahn_resolution_margin.csv`). Plus one pinned CPU checksum tied to a named machine and toolchain, CPU-vs-CUDA agreement to `1e-9` and CPU-vs-HIP to `1e-4`. There is no manufactured-solution check. Physical completeness: **canonical** -- the standard non-conserved double-well model with a constant driving force, no elastic/thermal/solutal coupling. Calibration: **none** |
 
 ### Why periodic
 
@@ -43,28 +43,65 @@ stayed clear of its own images.
 The app used to require `N1 >= 5*N0`. The seed radius scales with the grid
 (`sigma = 0.055*min(nx,ny)`) but the interface speed does not, so the ratio
 `((R0 + v t)/R0)^2` shrinks as the box grows: the same physics scored 6.08x at
-64^2, 3.50x at 128^2 and 2.55x at 256^2 -- pass, fail, fail. Measured as
-`dR/dt` over the last half of the run the three agree to 5% (12.4 / 12.8 /
-13.1). The last half, because the Gaussian initial condition is far from the
-equilibrium `tanh` and its collapse moves the contour by a distance that
-scales with the seed; a whole-run average inherits exactly the grid dependence
-the area ratio had.
+64^2, 3.50x at 128^2 and 2.55x at 256^2 -- pass, fail, fail. `dR/dt` does not
+have that defect. The last half of the run, because the Gaussian initial
+condition is far from the equilibrium `tanh` and its collapse moves the
+contour by a distance that scales with the seed; a whole-run average inherits
+exactly the grid dependence the area ratio had.
+
+### Why the prediction carries a curvature term
+
+The measured object is a growing *disc*, and Allen-Cahn moves an interface by
+mean curvature as well as by the bulk driving force:
+
+    dR/dt = (3/2) F eps sqrt(2M) - M/R
+
+The second term was ignored while the shipped driving force was large enough
+to make `M/R` about 6% of the answer. It is not ignorable at a driving force
+far enough under the bistability ceiling to be safe: at the current preset
+`M/R` is 20% of the flat-front law, and it does *not* shrink with the grid,
+because the seed scales with the box and so `R/R*` is nearly grid-independent.
+Comparing a disc against a flat-front law would leave a 20% bias that no
+amount of refinement removes -- and it looks exactly like a grid dependence.
+With the curvature term in, `128^2` through `512^2` agree with the prediction
+to `2.3%`.
+
+The same term sets a **critical radius** `R* = M/v = 7.1` cells: a seed
+smaller than that shrinks and vanishes however favourable the bulk driving
+force is. That is why the default grid is `256^2` and not `64^2` -- the seed
+`sigma = 0.055*min(nx,ny)` gives a `4.1`-cell seed at `64^2`, which dissolves.
+The app prints `R*` next to `R0` and warns when the seed is subcritical.
 
 ### Two limits worth knowing before changing the parameters
 
-* **The interface is not resolved.** `eps*sqrt(2M) = 0.76` cells at the shipped
-  preset, i.e. under one grid spacing, so the front is lattice-limited rather
-  than continuum-limited and the measured speed sits some tens of percent off
-  the sharp-interface law (`+11%` at the defaults, `-35%` at
-  `driving_force = 5`). That is why the accepted band is a factor of two either
-  way rather than a percentage. The app prints the width and warns when it is
-  below one cell.
-* **The driving force is close to its ceiling.** A front exists only while
-  `F*eps^2 < 2/(3 sqrt 3)`; above that there is no metastable `phi < 0` phase
-  and the whole domain simply decays. The shipped `F = 10`, `eps = 0.19` gives
-  `0.361` against a limit of `0.385` -- 6% of margin. `driving_force = 20` or
-  `epsilon = 0.3` crosses it and flips the entire box, which the app now says
-  out loud.
+These are **coupled**, which is the single most useful thing to know
+before touching `epsilon`, `M` or `driving_force`. Measurements:
+[`docs/report/data/allen_cahn_resolution_margin.csv`](../../docs/report/data/allen_cahn_resolution_margin.csv).
+
+* **The interface has to span at least a couple of cells.** The equilibrium
+  half-width is `eps*sqrt(2M)`, in cells because `dx = 1` is hard-coded, so
+  resolving the interface means making `eps*sqrt(2M)` large -- refining the
+  grid cannot do it. Below about `1.5` cells the front is pinned by the
+  lattice: at `0.76` cells (the pre-0.2 preset) the measured speed is `-32%`
+  off the continuum law at a safe driving force, at `1.5` cells `+0.05%`, and
+  at `2.0` cells `+1.2%`. The app warns below `2.0` cells.
+* **The driving force has a ceiling.** A front exists only while
+  `F*eps^2 < 2/(3 sqrt 3) = 0.385`; above that there is no metastable
+  `phi < 0` phase and the whole domain simply decays. `driving_force = 20` or
+  `epsilon = 1.5` crosses it and flips the entire box, which the app says out
+  loud. Nearing the ceiling is bad well before crossing it: at 94% of it the
+  matrix well has moved to `phi = -0.69` and retains 1.5% of the symmetric
+  barrier depth, and the `F eps^2 -> 0` law the app checks against is 26%
+  slow.
+* **Why they are coupled.** The pre-0.2 preset sat 6% under the ceiling *and*
+  measured `+9%` against the flat law, which looked like agreement. It was
+  two large errors of opposite sign: the lattice pinning the front by ~12%
+  and the finite tilt speeding the continuum front by ~26%. Backing the
+  driving force off -- the obvious way to buy margin -- removes only one of
+  them, so the residual walks from `+17%` at the ceiling through `-6%` at
+  70% of it to `-65%` at a quarter of it. There is no safe driving force at a
+  0.76-cell interface. The resolution had to be fixed first; once it was, a
+  factor-2.7 margin cost nothing.
 
 ## Binaries
 
@@ -91,15 +128,15 @@ Executable: `build/apps/allen_cahn/allen_cahn`.
 mpirun -n <P> ./allen_cahn [--strict] <nx> <ny> <n_steps> [dt] [M] [epsilon] [driving_force] [png_initial] [png_final]
 ```
 
-Defaults if omitted: `nx=ny=64`, `n_steps=5000`, `dt=0.00009`, `M=8.0`, `epsilon=0.19`, `driving_force=10.0`.
-The app samples the global visible seed area (cells with `phi > 0`) at `t = 0`, `t/2`, `3t/4` and the end, converts each to an equivalent radius, and reports the interface velocity over the last half of the run against `(3/2) F eps sqrt(2M)`. The verdict prints as `physics_check=`; the exit status reports whether the *run* finished, so a deliberately short run is not a failed process. Pass `--strict` to have a `FAIL` verdict (never a `SKIPPED` one) set the exit status instead. The optional positive `driving_force` favors the `phi≈+1` seed over the `phi≈-1` matrix. If you pass one PNG path, it writes the final field; if two, the first is the initial snapshot and the second the final (grayscale, rank 0).
+Defaults if omitted: `nx=ny=256`, `n_steps=5000`, `dt=0.005`, `M=8.0`, `epsilon=0.75`, `driving_force=0.25`.
+The app samples the global visible seed area (cells with `phi > 0`) at `t = 0`, `t/2`, `3t/4` and the end, converts each to an equivalent radius, and reports the interface velocity over the last half of the run against `(3/2) F eps sqrt(2M) - M/R`. The verdict prints as `physics_check=`; the exit status reports whether the *run* finished, so a deliberately short run is not a failed process. Pass `--strict` to have a `FAIL` verdict (never a `SKIPPED` one) set the exit status instead. The optional positive `driving_force` favors the `phi≈+1` seed over the `phi≈-1` matrix. If you pass one PNG path, it writes the final field; if two, the first is the initial snapshot and the second the final (grayscale, rank 0).
 The reported step timing measures the time-stepping loop only, after an MPI barrier and before PNG output or verification; `avg_step_time_s` is based on the slowest rank.
 
 Example:
 
 ```bash
 cd build
-mpirun -n 4 ./apps/allen_cahn/allen_cahn 128 128 5000 0.00009 8.0 0.19 10.0 initial.png final.png
+mpirun -n 4 ./apps/allen_cahn/allen_cahn 256 256 5000 0.005 8.0 0.75 0.25 initial.png final.png
 ```
 
 ## See also

--- a/apps/allen_cahn/include/allen_cahn/common.hpp
+++ b/apps/allen_cahn/include/allen_cahn/common.hpp
@@ -8,6 +8,7 @@
 #include <cmath>
 #include <cstdint>
 #include <cstdlib>
+#include <limits>
 #include <iostream>
 #include <mpi.h>
 #include <string>
@@ -22,9 +23,40 @@
 
 namespace allen_cahn {
 
+/**
+ * @brief Shipped preset and the thresholds that keep it honest.
+ *
+ * The preset moved in 0.2 from `64^2, dt=9e-5, eps=0.19, F=10` to the values
+ * below, for two coupled reasons measured in
+ * `docs/report/data/allen_cahn_resolution_margin.csv`:
+ *
+ * 1. **The old interface was sub-grid.** `eps*sqrt(2M) = 0.76` cells, so the
+ *    front was pinned by the lattice rather than set by the continuum
+ *    physics. Against the curvature-corrected sharp-interface law it ran
+ *    `-32%` slow at a comfortable driving force.
+ * 2. **The old driving force was 6% under the bistability ceiling** — and
+ *    that was load-bearing, not incidental. Backing `F` off at
+ *    `eps = 0.19` walks the error from `+17%` (at the ceiling) to `-65%` (a
+ *    quarter of it): at a 0.76-cell interface the *only* driving force that
+ *    reproduces the continuum law is one so large that the double well has
+ *    almost stopped being a double well. The margin cannot be fixed on its
+ *    own; the resolution has to be fixed first.
+ *
+ * At `eps = 0.75` the interface is 3.0 cells wide, `F` sits a factor 2.7
+ * under the ceiling, and the measured `dR/dt` matches the curvature-corrected
+ * law to 2.3% on every grid from `128^2` to `512^2`.
+ */
 struct RunConfig {
-  int nx_glob = 64;
-  int ny_glob = 64;
+  /**
+   * `256^2`, not `64^2`. A resolved interface forces a much larger critical
+   * nucleus: `R* = M/v = delta/(3 F eps^2)`, which is 7.1 cells here against
+   * 0.70 for the old preset. The seed (`seed_radius_cells`) has to clear
+   * `R*` by a healthy factor or it dissolves instead of growing, and at
+   * `64^2` it does not — the seed is 4.1 cells and vanishes. `256^2` puts a
+   * 16.7-cell seed against a 7.1-cell critical radius.
+   */
+  int nx_glob = 256;
+  int ny_glob = 256;
   /**
    * Long enough for the front to outrun the Gaussian initial condition and
    * settle into steady propagation, which is what the built-in check measures.
@@ -32,11 +64,21 @@ struct RunConfig {
    * number the transient dominates.
    */
   int n_steps = 5000;
-  double dt = 0.00009;
+  /**
+   * 16% of the explicit-Euler diffusive limit `dx^2/(4M) = 0.031` (the
+   * reaction limit `~eps^2 = 0.56` is far looser at this `eps`). The
+   * superlevel counts are unchanged from `dt/8`, and `dt = 0.031` blows up.
+   */
+  double dt = 0.005;
   double M = 8.0;
-  double epsilon = 0.19;
-  /** Positive bulk driving term that favors the φ≈+1 seed over the φ≈-1 matrix. */
-  double driving_force = 10.0;
+  /** Sets the interface width `eps*sqrt(2M) = 3.0` cells at `dx = 1`. */
+  double epsilon = 0.75;
+  /**
+   * Positive bulk driving term that favors the φ≈+1 seed over the φ≈-1
+   * matrix. `F eps^2 = 0.141` against the bistability ceiling `0.385`, i.e.
+   * a factor 2.7 of margin (37% of the way to the ceiling).
+   */
+  double driving_force = 0.25;
   /** If non-empty, gather the final scalar field on rank 0 and write a grayscale
    * PNG. */
   std::string png_output;
@@ -48,19 +90,47 @@ struct RunConfig {
   /** Superlevel for the seed-area metric: φ > 0 matches the visible seed in PNGs. */
   static constexpr double kLevelSetThreshold = 0.0;
   /**
-   * Band around the sharp-interface prediction that `v_late` must land in.
+   * Band around the curvature-corrected sharp-interface prediction that
+   * `v_late` must land in.
    *
-   * Deliberately a factor of two either way, not a percentage. The shipped
-   * preset has an interface only `eps*sqrt(2M) = 0.76` cells wide (see
-   * `interface_width_cells`), so the front is lattice-limited rather than
-   * asymptotic and the measured speed sits a few tens of percent off the
-   * continuum law — measured `+11%` at the default parameters and `-35%` at
-   * `driving_force = 5`. A factor-of-two band still separates "a front
-   * propagates at roughly the predicted speed" from every failure mode that
-   * matters: no growth, the wrong sign, or the whole domain flipping.
+   * ±25%, where it used to be a factor of two either way. The factor of two
+   * was the price of a 0.76-cell interface compared against a *flat*-front
+   * law; both halves of that are now fixed, so the band can describe the
+   * physics instead of the discretisation. What ±25% has to cover:
+   *
+   * - the finite-tilt correction, `<=7%` at the shipped margin — the
+   *   `(3/2) F eps sqrt(2M)` law is the `F eps^2 -> 0` limit, and the exact
+   *   travelling wave of the tilted cubic is faster than it by
+   *   `1 + O((F eps^2)^2)`;
+   * - the lattice correction, `<=3%` for `eps*sqrt(2M) >= 2` cells;
+   * - the quantisation of a superlevel *cell count* into a radius.
+   *
+   * Measured residual at the shipped preset: `1.6%`, and at most `2.3%` on
+   * any grid from `128^2` to `512^2`.
    */
-  static constexpr double kVelocityBandLo = 0.5;
-  static constexpr double kVelocityBandHi = 2.0;
+  static constexpr double kVelocityBandLo = 0.75;
+  static constexpr double kVelocityBandHi = 1.25;
+  /**
+   * Interface width, in cells, below which the front is lattice-limited.
+   *
+   * At `eps*sqrt(2M) = 0.76` the measured speed is `-32%` off the
+   * curvature-corrected law; at `1.5` cells it is `+0.05%`, at `2.0` cells
+   * `+1.2%`. Two cells is the first round number on the flat part of that
+   * curve. The app warns below it rather than refusing to run — an
+   * under-resolved run is a legitimate thing to ask for, it just is not a
+   * measurement of the continuum physics.
+   */
+  static constexpr double kMinInterfaceWidthCells = 2.0;
+  /**
+   * How far towards the bistability ceiling a preset may sit.
+   *
+   * `F eps^2` must stay under `2/(3 sqrt 3)` for the unfavoured phase to
+   * exist at all (`max_bistable_driving_force`). Half of that leaves the
+   * matrix well at `phi = -0.88` with 34% of the symmetric barrier depth,
+   * and leaves room for a user to double `F` or add 40% to `eps` before the
+   * box flips. The shipped preset sits at `0.37`, comfortably inside.
+   */
+  static constexpr double kMaxDrivingForceFraction = 0.5;
   /** Quarter-to-quarter agreement required before `v_late` counts as steady. */
   static constexpr double kSteadyTolerance = 0.25;
   /** Below this the last-half displacement is swamped by area quantisation. */
@@ -129,6 +199,23 @@ inline RunConfig parse_args(int argc, char **argv) {
   return c;
 }
 
+/** Gaussian width of the seed, in cells: 5.5% of the shorter side, min 2. */
+[[nodiscard]] inline double seed_sigma_cells(int nx, int ny) noexcept {
+  return std::max(2.0, 0.055 * static_cast<double>(std::min(nx, ny)));
+}
+
+/**
+ * @brief Radius of the visible seed at t=0, in cells.
+ *
+ * The IC is `phi = -1 + 2 exp(-r^2/(2 sigma^2))`, so the `phi > 0` contour
+ * the app measures sits at `r = sigma sqrt(2 ln 2)`. Worth having as a
+ * function rather than a comment: it has to be compared with
+ * `critical_radius_cells` before a preset can be said to demonstrate growth.
+ */
+[[nodiscard]] inline double seed_radius_cells(int nx, int ny) noexcept {
+  return seed_sigma_cells(nx, ny) * std::sqrt(2.0 * std::log(2.0));
+}
+
 /**
  * @brief Phase field at t=0: one "grain" as a Gaussian bump on a φ≈-1 matrix.
  *
@@ -149,8 +236,7 @@ inline void fill_initial_condition(std::vector<double> *u,
   const int sxy = nx * ny;
   const double cx = 0.5 * static_cast<double>(gsz[0] - 1);
   const double cy = 0.5 * static_cast<double>(gsz[1] - 1);
-  const int gmin = std::min(gsz[0], gsz[1]);
-  const double sigma = std::max(2.0, 0.055 * static_cast<double>(gmin));
+  const double sigma = seed_sigma_cells(gsz[0], gsz[1]);
   const double denom = 2.0 * sigma * sigma;
   for (int iz = 0; iz < nz; ++iz) {
     for (int iy = 0; iy < ny; ++iy) {
@@ -209,9 +295,14 @@ inline std::int64_t global_area_cells(MPI_Comm comm, std::int64_t n_local) {
  * @brief Equilibrium interface half-thickness `eps*sqrt(2M)`, in cells.
  *
  * The travelling-wave profile of `phi_t = M phi_xx - (phi^3 - phi)/eps^2` is
- * `tanh(x / (eps*sqrt(2M)))`. Below one cell the front is pinned by the
- * lattice rather than set by the continuum physics, and every kinetic number
- * this app reports acquires a systematic error of tens of percent.
+ * `tanh(x / (eps*sqrt(2M)))`. `dx` is hard-coded to 1 in this app, so this is
+ * the only knob that resolves the interface: refining the grid cannot. Below
+ * roughly 1.5 cells the front is pinned by the lattice rather than set by the
+ * continuum physics, and every kinetic number the app reports acquires a
+ * systematic error of tens of percent — measured `-32%` at 0.76 cells,
+ * `+0.05%` at 1.5 and `+1.2%` at 2.0
+ * (`docs/report/data/allen_cahn_resolution_margin.csv`). See
+ * `RunConfig::kMinInterfaceWidthCells`.
  */
 [[nodiscard]] inline double interface_width_cells(double M, double epsilon,
                                                   double dx) noexcept {
@@ -248,6 +339,59 @@ inline std::int64_t global_area_cells(MPI_Comm comm, std::int64_t n_local) {
   return 2.0 / (3.0 * std::sqrt(3.0)) / (epsilon * epsilon);
 }
 
+/**
+ * @brief How far towards the bistability ceiling a parameter set sits, in [0,1).
+ *
+ * `F eps^2 / (2/(3 sqrt 3))`. One number instead of two, so a preset can be
+ * compared with `RunConfig::kMaxDrivingForceFraction` without repeating the
+ * constant. At 1 the double well has degenerated into a single well.
+ */
+[[nodiscard]] inline double driving_force_fraction(double epsilon,
+                                                   double F) noexcept {
+  return F * epsilon * epsilon / (2.0 / (3.0 * std::sqrt(3.0)));
+}
+
+/**
+ * @brief Critical nucleus radius `R* = M / v_flat`, in cells at `dx`.
+ *
+ * A circular seed obeys `dR/dt = v_flat - M/R` (see
+ * `curvature_corrected_velocity`), so a seed smaller than `R*` shrinks and
+ * vanishes however favourable the bulk driving force is. This is the
+ * constraint that sets the default grid: `R*` scales as `1/F`, so buying
+ * bistability margin by lowering `F` makes the critical nucleus bigger, and
+ * the seed — which scales with the box — has to keep up.
+ */
+[[nodiscard]] inline double critical_radius_cells(double M, double epsilon,
+                                                  double F, double dx) noexcept {
+  const double v = sharp_interface_velocity(M, epsilon, F);
+  if (v == 0.0) {
+    return std::numeric_limits<double>::infinity();
+  }
+  return M / v / dx;
+}
+
+/**
+ * @brief Normal velocity of a *circular* front: `v_flat - M/R`.
+ *
+ * Allen–Cahn moves an interface by mean curvature as well as by the bulk
+ * driving force, `v_n = -M kappa + v_flat`, and for a disc `kappa = 1/R`.
+ * The app measures `dR/dt` of a disc, so this — not the flat-front law — is
+ * what it has to be compared with.
+ *
+ * Ignoring it was harmless while `F = 10` made `R_crit/R` about 8%; at a driving
+ * force far enough under the bistability ceiling to be safe, `R_crit/R` is 20%
+ * at the shipped grid and *does not shrink with the grid* (the seed scales
+ * with the box, so `R/R*` is nearly grid-independent). Comparing against the
+ * flat law would leave a 20% bias that no amount of refinement removes.
+ */
+[[nodiscard]] inline double curvature_corrected_velocity(double v_flat, double M,
+                                                         double radius) noexcept {
+  if (radius <= 0.0) {
+    return v_flat;
+  }
+  return v_flat - M / radius;
+}
+
 /** Superlevel areas sampled at t=0, t/2, 3t/4 and the end of the run. */
 struct AreaSamples {
   std::int64_t initial = 0;
@@ -271,8 +415,14 @@ enum class CheckVerdict { Pass, Fail, Skipped };
  * from the equilibrium `tanh`, and the front's first job is to sharpen. That
  * transient moves the contour by a distance proportional to the seed width, so
  * a whole-run average is grid-dependent for exactly the same reason the area
- * ratio is. Measured over the last half instead, 64^2 / 128^2 / 256^2 agree to
- * 5%.
+ * ratio is.
+ *
+ * `v_late` is compared with `v_predicted = v_theory - M/R`, not with
+ * `v_theory`: the measured object is a growing *disc*, and Allen–Cahn moves
+ * an interface by curvature as well as by the bulk driving force. With that
+ * term in, 128^2 / 192^2 / 256^2 / 384^2 / 512^2 agree with the prediction to
+ * 2.3%; without it the same runs sit 41% / 25% / 20% / 15% / 12% below the
+ * flat-front law — a spread that looks like a grid dependence and is not one.
  */
 struct InterfaceKinetics {
   double r_initial = 0.0;
@@ -284,7 +434,12 @@ struct InterfaceKinetics {
   /// dR/dt over [t/2, 3t/4] and [3t/4, t]; equal means steady propagation.
   double v_third_quarter = 0.0;
   double v_fourth_quarter = 0.0;
+  /// Flat-front law `(3/2) F eps sqrt(2M)`; reported, but not what is checked.
   double v_theory = 0.0;
+  /// `v_theory - M/R` at the mean radius of the last half: what *is* checked.
+  double v_predicted = 0.0;
+  /// `M / v_theory`: a seed below this shrinks whatever the driving force.
+  double r_critical = 0.0;
   double interface_width = 0.0;
   bool steady = false;
   CheckVerdict verdict = CheckVerdict::Skipped;
@@ -299,7 +454,15 @@ analyse_interface_kinetics(const AreaSamples &a, const RunConfig &cfg, double dx
   k.r_three_quarter = equivalent_radius(a.three_quarter, dx);
   k.r_final = equivalent_radius(a.final_, dx);
   k.v_theory = sharp_interface_velocity(cfg.M, cfg.epsilon, cfg.driving_force);
+  // In the same length units as r_half / r_final, hence the dx back-multiply.
+  k.r_critical =
+      critical_radius_cells(cfg.M, cfg.epsilon, cfg.driving_force, dx) * dx;
   k.interface_width = interface_width_cells(cfg.M, cfg.epsilon, dx);
+  // The prediction is evaluated at the mean radius over the interval the
+  // measurement covers, which is the last half of the run. Using R_final
+  // instead would compare a mean velocity with an instantaneous one.
+  k.v_predicted = curvature_corrected_velocity(k.v_theory, cfg.M,
+                                               0.5 * (k.r_half + k.r_final));
 
   const double dt_half = 0.5 * static_cast<double>(cfg.n_steps) * cfg.dt;
   const double dt_quarter = 0.5 * dt_half;
@@ -321,6 +484,17 @@ analyse_interface_kinetics(const AreaSamples &a, const RunConfig &cfg, double dx
     k.reason = "no seed at t=0 (N0 == 0)";
     return k;
   }
+  if (a.final_ <= 0) {
+    // Distinguished from "the front is slow": a seed under the critical
+    // radius dissolves no matter how long the run is, and the fix is a
+    // bigger box or a bigger driving force, not more steps.
+    k.verdict = CheckVerdict::Fail;
+    k.reason = k.r_initial < k.r_critical
+                   ? "the seed dissolved: R0 is below the critical radius "
+                     "M/v, so curvature beats the driving force"
+                   : "the seed dissolved (N1 == 0)";
+    return k;
+  }
   if (cfg.n_steps < RunConfig::kMinStepsForKinetics) {
     k.verdict = CheckVerdict::Skipped;
     k.reason = "run shorter than " +
@@ -335,7 +509,7 @@ analyse_interface_kinetics(const AreaSamples &a, const RunConfig &cfg, double dx
     // physics' is settled by asking how far the front was supposed to go: if
     // even the prediction is sub-cell there is nothing to measure, otherwise
     // the front should have moved and did not.
-    if (std::abs(k.v_theory) * dt_half < floor_distance) {
+    if (std::abs(k.v_predicted) * dt_half < floor_distance) {
       k.verdict = CheckVerdict::Skipped;
       k.reason = "predicted advance over the last half of the run is under one "
                  "cell: nothing measurable at this dt/n_steps";
@@ -352,10 +526,11 @@ analyse_interface_kinetics(const AreaSamples &a, const RunConfig &cfg, double dx
                "(not yet steady); run longer";
     return k;
   }
-  // min/max rather than lo/hi directly: a negative driving force predicts a
-  // *shrinking* seed, and the band has to bracket that too.
-  const double bound_a = RunConfig::kVelocityBandLo * k.v_theory;
-  const double bound_b = RunConfig::kVelocityBandHi * k.v_theory;
+  // min/max rather than lo/hi directly: a negative driving force, or a
+  // subcritical seed, predicts a *shrinking* seed and the band has to
+  // bracket that too.
+  const double bound_a = RunConfig::kVelocityBandLo * k.v_predicted;
+  const double bound_b = RunConfig::kVelocityBandHi * k.v_predicted;
   if (k.v_late < std::min(bound_a, bound_b) ||
       k.v_late > std::max(bound_a, bound_b)) {
     k.verdict = CheckVerdict::Fail;
@@ -363,7 +538,7 @@ analyse_interface_kinetics(const AreaSamples &a, const RunConfig &cfg, double dx
     return k;
   }
   k.verdict = CheckVerdict::Pass;
-  k.reason = "steady interface speed consistent with (3/2) F eps sqrt(2M)";
+  k.reason = "steady interface speed consistent with (3/2) F eps sqrt(2M) - M/R";
   return k;
 }
 
@@ -393,25 +568,42 @@ inline void report_interface_kinetics(int rank, const AreaSamples &a,
             << k.v_fourth_quarter << " (steady=" << (k.steady ? "yes" : "no")
             << ")\n";
   std::cout << "Sharp-interface prediction (3/2) F eps sqrt(2M): v_theory="
-            << k.v_theory << ", accepted band ["
-            << std::min(RunConfig::kVelocityBandLo * k.v_theory,
-                        RunConfig::kVelocityBandHi * k.v_theory)
+            << k.v_theory << "\n";
+  std::cout << "Critical radius M/v_theory = " << k.r_critical
+            << " (R0=" << k.r_initial << ")";
+  if (k.r_initial < k.r_critical) {
+    std::cout << "  [WARNING: the seed is subcritical — curvature beats the "
+                 "driving force and it will dissolve]";
+  }
+  std::cout << "\n";
+  std::cout << "Curvature-corrected prediction v_theory - M/R: v_predicted="
+            << k.v_predicted << ", accepted band ["
+            << std::min(RunConfig::kVelocityBandLo * k.v_predicted,
+                        RunConfig::kVelocityBandHi * k.v_predicted)
             << ", "
-            << std::max(RunConfig::kVelocityBandLo * k.v_theory,
-                        RunConfig::kVelocityBandHi * k.v_theory)
+            << std::max(RunConfig::kVelocityBandLo * k.v_predicted,
+                        RunConfig::kVelocityBandHi * k.v_predicted)
             << "]\n";
   std::cout << "Interface width eps*sqrt(2M) = " << k.interface_width << " cells";
-  if (k.interface_width < 1.0) {
-    std::cout << "  [WARNING: below one cell — the front is lattice-limited, "
-                 "not continuum-limited]";
+  if (k.interface_width < RunConfig::kMinInterfaceWidthCells) {
+    std::cout << "  [WARNING: under " << RunConfig::kMinInterfaceWidthCells
+              << " cells — the front is lattice-limited, not "
+                 "continuum-limited, and the speed can be tens of percent off]";
   }
   std::cout << "\n";
   const double f_max = max_bistable_driving_force(cfg.epsilon);
+  const double fraction = driving_force_fraction(cfg.epsilon, cfg.driving_force);
   std::cout << "Bistability limit: driving_force=" << cfg.driving_force << " vs "
-            << "2/(3 sqrt 3)/eps^2 = " << f_max;
+            << "2/(3 sqrt 3)/eps^2 = " << f_max << " (at " << 100.0 * fraction
+            << "% of it)";
   if (cfg.driving_force >= f_max) {
     std::cout << "  [VIOLATED: phi<0 is not metastable, the whole domain decays "
                  "and there is no front]";
+  } else if (fraction > RunConfig::kMaxDrivingForceFraction) {
+    std::cout << "  [WARNING: over "
+              << 100.0 * RunConfig::kMaxDrivingForceFraction
+              << "% of the ceiling — the matrix well is shallow and the "
+                 "sharp-interface law is no longer asymptotic]";
   }
   std::cout << "\n";
   std::cout << "physics_check=" << to_string(k.verdict) << " (" << k.reason

--- a/apps/allen_cahn/tests/test_allen_cahn_interface_kinetics.cpp
+++ b/apps/allen_cahn/tests/test_allen_cahn_interface_kinetics.cpp
@@ -18,6 +18,12 @@
  * condition is far from the equilibrium `tanh` and its collapse moves the
  * contour by a distance that scales with the seed, so a whole-run average
  * inherits the same grid dependence the area ratio had.
+ *
+ * Since 0.2 this file also pins the *preset*, not just the criterion. A
+ * canonical demonstration whose interface is 0.76 cells wide and whose
+ * driving force is 6% under the bistability ceiling is not a demonstration
+ * of Allen–Cahn; it is a demonstration of two large errors cancelling. See
+ * `docs/report/data/allen_cahn_resolution_margin.csv` for the measurements.
  */
 
 #define CATCH_CONFIG_RUNNER
@@ -25,6 +31,7 @@
 #include <catch2/catch_test_macros.hpp>
 #include <catch2/matchers/catch_matchers_floating_point.hpp>
 
+#include <algorithm>
 #include <cmath>
 #include <cstdint>
 #include <iostream>
@@ -113,18 +120,66 @@ TEST_CASE("equivalent_radius inverts the area of a disc",
 
 TEST_CASE("sharp-interface velocity follows (3/2) F eps sqrt(2M)",
           "[AllenCahn][kinetics][unit]") {
-  // Shipped preset: M = 8, eps = 0.19, F = 10.
-  REQUIRE_THAT(allen_cahn::sharp_interface_velocity(8.0, 0.19, 10.0),
-               WithinRel(1.5 * 10.0 * 0.19 * 4.0, 1e-12));
+  // Shipped preset: M = 8, eps = 0.75, F = 0.25.
+  REQUIRE_THAT(allen_cahn::sharp_interface_velocity(8.0, 0.75, 0.25),
+               WithinRel(1.5 * 0.25 * 0.75 * 4.0, 1e-12));
   // Linear in the driving force, so no driving force means no front.
-  REQUIRE_THAT(allen_cahn::sharp_interface_velocity(8.0, 0.19, 0.0),
+  REQUIRE_THAT(allen_cahn::sharp_interface_velocity(8.0, 0.75, 0.0),
                WithinAbs(0.0, 1e-15));
-  // Interface half-width, in cells: below one the front is lattice-limited.
-  REQUIRE_THAT(allen_cahn::interface_width_cells(8.0, 0.19, 1.0),
-               WithinRel(0.76, 1e-9));
-  // The shipped preset sits just under the bistability limit — 6% of margin.
-  REQUIRE(10.0 < allen_cahn::max_bistable_driving_force(0.19));
-  REQUIRE(10.0 > 0.9 * allen_cahn::max_bistable_driving_force(0.19));
+  // Interface half-width, in cells.
+  REQUIRE_THAT(allen_cahn::interface_width_cells(8.0, 0.75, 1.0),
+               WithinRel(3.0, 1e-9));
+  // Curvature correction: a disc of radius R moves at v_flat - M/R, so a
+  // disc of exactly the critical radius does not move at all.
+  const double v_flat = allen_cahn::sharp_interface_velocity(8.0, 0.75, 0.25);
+  const double r_star = allen_cahn::critical_radius_cells(8.0, 0.75, 0.25, 1.0);
+  REQUIRE_THAT(r_star, WithinRel(8.0 / v_flat, 1e-12));
+  REQUIRE_THAT(allen_cahn::curvature_corrected_velocity(v_flat, 8.0, r_star),
+               WithinAbs(0.0, 1e-12));
+  REQUIRE(allen_cahn::curvature_corrected_velocity(v_flat, 8.0, 0.5 * r_star) < 0.0);
+  // A flat front (R -> infinity) recovers the uncorrected law.
+  REQUIRE_THAT(allen_cahn::curvature_corrected_velocity(v_flat, 8.0, 1e12),
+               WithinRel(v_flat, 1e-9));
+}
+
+/**
+ * @brief The shipped preset has to be a preset a reader can trust.
+ *
+ * Both halves of this failed before the 0.2 preset move (`eps = 0.19`,
+ * `F = 10`, `64^2`): the interface was 0.76 cells wide and the driving force
+ * sat at 94% of the bistability ceiling. Neither was fixable alone — see
+ * "a sub-grid interface needs a near-critical driving force" below.
+ */
+TEST_CASE("the shipped preset resolves its interface and keeps a margin",
+          "[AllenCahn][kinetics][unit][preset]") {
+  const allen_cahn::RunConfig cfg;
+  constexpr double dx = 1.0;
+
+  // 1. The interface spans enough cells for the discrete Laplacian to see it.
+  const double width = allen_cahn::interface_width_cells(cfg.M, cfg.epsilon, dx);
+  INFO("interface width = " << width << " cells");
+  REQUIRE(width >= allen_cahn::RunConfig::kMinInterfaceWidthCells);
+
+  // 2. The double well is still a double well, with room to spare.
+  const double fraction =
+      allen_cahn::driving_force_fraction(cfg.epsilon, cfg.driving_force);
+  INFO("F eps^2 is at " << 100.0 * fraction << "% of the bistability ceiling");
+  REQUIRE(fraction < 1.0);
+  REQUIRE(fraction <= allen_cahn::RunConfig::kMaxDrivingForceFraction);
+
+  // 3. The seed the app plants at the default grid is supercritical, so the
+  //    demonstration demonstrates growth rather than dissolution. Buying
+  //    margin in (2) costs exactly this: R* scales as 1/F.
+  const double r0 = allen_cahn::seed_radius_cells(cfg.nx_glob, cfg.ny_glob);
+  const double r_star =
+      allen_cahn::critical_radius_cells(cfg.M, cfg.epsilon, cfg.driving_force, dx);
+  INFO("seed radius " << r0 << " cells vs critical radius " << r_star);
+  REQUIRE(r0 > 2.0 * r_star);
+
+  // 4. Explicit Euler is stable with room to spare at the shipped dt.
+  const double dt_diffusive = dx * dx / (4.0 * cfg.M);
+  const double dt_reaction = cfg.epsilon * cfg.epsilon;
+  REQUIRE(cfg.dt < 0.25 * std::min(dt_diffusive, dt_reaction));
 }
 
 TEST_CASE("a run too short to measure is skipped, not failed",
@@ -143,17 +198,26 @@ TEST_CASE("a run too short to measure is skipped, not failed",
 
 TEST_CASE("a seed that does not grow fails the check",
           "[AllenCahn][kinetics][unit]") {
+  // Explicit parameters rather than the shipped preset: this exercises the
+  // analyser, and it should not have to be re-tuned every time the preset
+  // moves. Fast front, so the curvature correction is small and the numbers
+  // below stay readable: v_flat = 11.4, R* = M/v = 0.70 cells.
   allen_cahn::RunConfig cfg;
   cfg.n_steps = 5000;
+  cfg.dt = 0.00009;
+  cfg.M = 8.0;
+  cfg.epsilon = 0.19;
+  cfg.driving_force = 10.0;
   allen_cahn::AreaSamples a;
   a.initial = 52;
   a.half = 52;
   a.three_quarter = 52;
   a.final_ = 52;
   const auto k = allen_cahn::analyse_interface_kinetics(a, cfg, kDx);
-  // The theory says this front should have advanced ~2.6 cells over the last
+  // The theory says this front should have advanced ~2.4 cells over the last
   // half of the run. It advanced none, so this is the physics failing, not
   // the run being too short.
+  REQUIRE(k.v_predicted > 0.0);
   REQUIRE(k.verdict == allen_cahn::CheckVerdict::Fail);
   REQUIRE_THAT(k.v_late, WithinAbs(0.0, 1e-15));
 
@@ -165,17 +229,39 @@ TEST_CASE("a seed that does not grow fails the check",
   REQUIRE(unmeasurable.verdict == allen_cahn::CheckVerdict::Skipped);
 
   // A front that advances steadily, by more than a cell, but at well under
-  // half the predicted speed is a genuine failure — not a measurement floor.
+  // the predicted speed is a genuine failure — not a measurement floor.
   a.half = 100;          // R = 5.642
   a.three_quarter = 121; // R = 6.206
   a.final_ = 144;        // R = 6.770, so dR = 1.13 cells over the last half
   const auto slow = allen_cahn::analyse_interface_kinetics(a, cfg, kDx);
   REQUIRE(slow.steady);
   REQUIRE(slow.r_final - slow.r_half > allen_cahn::RunConfig::kMinMeasurableAdvanceCells);
-  REQUIRE(slow.v_late < allen_cahn::RunConfig::kVelocityBandLo * slow.v_theory);
+  REQUIRE(slow.v_late < allen_cahn::RunConfig::kVelocityBandLo * slow.v_predicted);
   REQUIRE(slow.verdict == allen_cahn::CheckVerdict::Fail);
   REQUIRE(slow.reason.find("outside the sharp-interface band") !=
           std::string::npos);
+}
+
+TEST_CASE("a subcritical seed is reported as dissolved, not as a slow front",
+          "[AllenCahn][kinetics][unit]") {
+  // Explicit parameters, so this keeps testing the analyser if the preset
+  // moves again: M = 8, eps = 0.75, F = 0.25 gives v_flat = 1.125 and a
+  // critical radius M/v = 7.11 cells.
+  allen_cahn::RunConfig cfg;
+  cfg.n_steps = 5000;
+  cfg.dt = 0.005;
+  cfg.M = 8.0;
+  cfg.epsilon = 0.75;
+  cfg.driving_force = 0.25;
+  allen_cahn::AreaSamples a;
+  a.initial = 52; // R0 = 4.07 cells, against a critical radius of 7.11
+  a.half = 20;
+  a.three_quarter = 4;
+  a.final_ = 0;
+  const auto k = allen_cahn::analyse_interface_kinetics(a, cfg, kDx);
+  REQUIRE(k.r_initial < k.r_critical);
+  REQUIRE(k.verdict == allen_cahn::CheckVerdict::Fail);
+  REQUIRE(k.reason.find("below the critical radius") != std::string::npos);
 }
 
 TEST_CASE("an empty seed fails rather than dividing by zero",
@@ -188,35 +274,105 @@ TEST_CASE("an empty seed fails rather than dividing by zero",
   REQUIRE(k.reason.find("N0 == 0") != std::string::npos);
 }
 
-TEST_CASE("the pass criterion is the same at 64^2 and 128^2",
+/**
+ * @brief The criterion has to describe the physics at every box size.
+ *
+ * Two grids, and the quantity that must agree is `v_late / v_predicted`, not
+ * `v_late` itself: the seed scales with the box, so a bigger box measures a
+ * bigger disc, and a bigger disc really does grow faster (`v = v_flat -
+ * M/R`). Requiring the raw speeds to match would be requiring the physics to
+ * be wrong.
+ *
+ * The old preset hid this. At `eps = 0.19, F = 10` the raw speeds at `64^2`
+ * and `128^2` agree to 0.3% — but only because `M/R` was 6% of a very fast
+ * front there; extend the same comparison to `512^2` and the raw speeds
+ * spread by 10% while the residual against the flat law grows monotonically
+ * from `+19%` to `+22%`. The pair the old test picked was the one pair that
+ * happened to agree.
+ */
+TEST_CASE("the pass criterion is the same at 256^2 and 384^2",
           "[AllenCahn][kinetics][integration]") {
   int nproc = 1;
   MPI_Comm_size(MPI_COMM_WORLD, &nproc);
   REQUIRE(nproc == 1);
 
-  allen_cahn::RunConfig small;
-  small.nx_glob = 64;
-  small.ny_glob = 64;
+  allen_cahn::RunConfig small; // shipped preset: 256^2
   allen_cahn::RunConfig large;
-  large.nx_glob = 128;
-  large.ny_glob = 128;
+  large.nx_glob = 384;
+  large.ny_glob = 384;
 
   const auto k_small =
       allen_cahn::analyse_interface_kinetics(run_and_sample(small), small, kDx);
   const auto k_large =
       allen_cahn::analyse_interface_kinetics(run_and_sample(large), large, kDx);
 
-  std::cout << "interface velocity 64^2: " << k_small.v_late
-            << "  128^2: " << k_large.v_late
-            << "  theory: " << k_small.v_theory << '\n';
+  std::cout << "interface velocity 256^2: " << k_small.v_late << " (predicted "
+            << k_small.v_predicted << ")  384^2: " << k_large.v_late
+            << " (predicted " << k_large.v_predicted
+            << ")  flat-front law: " << k_small.v_theory << '\n';
 
   // The whole point: same physics, same verdict, whatever the box size.
   REQUIRE(k_small.verdict == allen_cahn::CheckVerdict::Pass);
   REQUIRE(k_large.verdict == allen_cahn::CheckVerdict::Pass);
 
-  // And the measured speeds agree, which the area ratio never did (6.08 vs
-  // 3.50 for these two grids).
-  REQUIRE_THAT(k_large.v_late, WithinRel(k_small.v_late, 0.10));
+  // Both grids sit on the curvature-corrected law to a few percent. Measured
+  // on this machine: +1.6% and +1.3%.
+  REQUIRE_THAT(k_small.v_late, WithinRel(k_small.v_predicted, 0.05));
+  REQUIRE_THAT(k_large.v_late, WithinRel(k_large.v_predicted, 0.05));
+
+  // ... and they agree with *each other* on how far off the law they are,
+  // which the raw speeds (0.89 vs 0.95, 6.6% apart) do not.
+  const double bias_small = k_small.v_late / k_small.v_predicted;
+  const double bias_large = k_large.v_late / k_large.v_predicted;
+  REQUIRE_THAT(bias_large, WithinRel(bias_small, 0.03));
+}
+
+/**
+ * @brief Why the bistability margin could not be fixed on its own.
+ *
+ * The pre-0.2 preset sat 6% under the bistability ceiling. The obvious fix —
+ * leave `eps = 0.19` and back the driving force off — does not work, and
+ * this is the measurement that says so. At a 0.76-cell interface the lattice
+ * pins the front: at the *same* margin fraction the shipped preset now uses,
+ * a seed on a `64^2` box barely moves and the check fails, where the
+ * resolved preset tracks the continuum law to 2%. The resolution had to be
+ * fixed first, and fixing it is what made the margin affordable.
+ */
+TEST_CASE("a sub-grid interface needs a near-critical driving force",
+          "[AllenCahn][kinetics][integration]") {
+  int nproc = 1;
+  MPI_Comm_size(MPI_COMM_WORLD, &nproc);
+  REQUIRE(nproc == 1);
+
+  const allen_cahn::RunConfig shipped;
+  const double fraction = allen_cahn::driving_force_fraction(
+      shipped.epsilon, shipped.driving_force);
+
+  allen_cahn::RunConfig subgrid; // the pre-0.2 geometry
+  subgrid.nx_glob = 64;
+  subgrid.ny_glob = 64;
+  // 20000 steps, four times the shipped run: long enough that "the front did
+  // not move" cannot be blamed on the run being short.
+  subgrid.n_steps = 20000;
+  subgrid.dt = 0.00009;
+  subgrid.M = 8.0;
+  subgrid.epsilon = 0.19;
+  // Same distance from the ceiling as the shipped preset, at the old eps.
+  subgrid.driving_force =
+      fraction * allen_cahn::max_bistable_driving_force(subgrid.epsilon);
+
+  REQUIRE(allen_cahn::interface_width_cells(subgrid.M, subgrid.epsilon, kDx) <
+          allen_cahn::RunConfig::kMinInterfaceWidthCells);
+
+  const auto k =
+      allen_cahn::analyse_interface_kinetics(run_and_sample(subgrid), subgrid, kDx);
+  std::cout << "sub-grid interface (0.76 cells) at the shipped margin: v_late="
+            << k.v_late << " vs predicted " << k.v_predicted << '\n';
+
+  // Not a pass. The front is there, it is just not moving at the speed the
+  // continuum law says it should.
+  REQUIRE(k.verdict != allen_cahn::CheckVerdict::Pass);
+  REQUIRE(k.v_late < 0.75 * k.v_predicted);
 }
 
 int main(int argc, char *argv[]) {

--- a/apps/aluminumNew/README.md
+++ b/apps/aluminumNew/README.md
@@ -32,7 +32,7 @@ initial-condition catalog. That is a rot check, not a physics check.
 | **Grid/time** | `t` in `[0, 2000]`, `dt = 1` (2000 steps), field dump every 200 |
 | **Boundary conditions** | Periodic on all three axes (the FFT has no other mode), plus a stationary `fixed` sigmoid density-reservoir band pulling `psi` between `-1.297` and `-0.006` near the high-`x` end -- see "Why periodic" below |
 | **Initial condition** | Uniform `psi = -0.006`, then `seed_grid_fcc`: a `2 x 1` row of FCC seeds of radius 120 at `x = 130`, amplitude 0.4, `rho = -0.036`, each jittered by `+/-0.2 R` and randomly oriented. Each seed is built from four `<111>` wave vectors, unlike tungsten's six `{110}` |
-| **Key physical parameters** | `T_const = 980`, `T0 = 89285` (no unit is stated anywhere in this app); `n_sol = -0.036`, `n_vap = -1.297`; `Bx = 0.81790`, `alpha = 0.20`; barred polynomial coefficients. **`G_grid = V_grid = 0`, so the shipped run is isothermal** -- the moving-frame machinery is present and tested but no shipped preset exercises it. Reduced PFC units throughout, with no SI mapping in this repository |
+| **Key physical parameters** | `T_const = 980` clamped into `[T_min, T_max] = [780, 1280]`, `T0 = 89285` (no unit is stated anywhere in this app); `Bx = 0.81790`, `alpha = 0.20`; barred polynomial coefficients. The coexistence densities `-0.036` / `-1.297` live in the `initial_conditions` / `boundary_conditions` blocks, not in `model.params`. **`G_grid = V_grid = 0`, so the shipped run is isothermal** -- the moving-frame machinery is present and tested but no shipped preset exercises it, and the temperature clamp is therefore a no-op on every shipped preset. Reduced PFC units throughout, with no SI mapping in this repository |
 | **Observable** | `SPECTRAL_CHECKSUM` `sum`/`sumsq`/`l2` of `psi`; the summed free energy (`last_free_energy_sum`), which this app computes per cell and `tungsten` does not; binary field dumps |
 | **Model maturity** | numerical verification: **regression** -- the operators, the pointwise nonlinearity and the free-energy density are checked to `1e-14` against an independently written reference formula, and one synthetic case is pinned; there is no closed-form solution of the model. Physical completeness: **extended** -- the tungsten equation of state plus a separate correlation kernel `P(k)` and a travelling temperature field. Calibration: **representative**, with the same caveat as tungsten: no source is cited anywhere in this repository for any aluminium coefficient |
 
@@ -86,21 +86,50 @@ directional-solidification cell rather than a bulk sample. Nothing in the model
 represents convection in the melt, solute partitioning, or a second chemical
 component.
 
-### Caveat: `T_min` and `T_max` do nothing
+### `model.params` is enforced, and every field in it is read
 
-The schema declares both as **required** and every shipped input and test
-supplies them, but no code reads them. There is no clamping of the temperature
-field anywhere in this application. `alpha_farTol` and `alpha_highOrd` are
-likewise required but unused here -- the FCC correlation peak does not
-reference them (they do matter for `apps/tungsten`).
+Two things were wrong here before 0.2, and they were the same thing seen from
+two sides.
 
-### Caveat: the temperature profile
+**The loader skipped the schema.** `AluminumPhysics::from_json` was guarded by
+`if (!params_json.is_null() && !params_json.empty())`, so `"params": {}` --
+which is what `inputs_json/smoke.json` shipped -- took the C++ member
+initialisers while the schema declared all twenty-five fields `required`. For
+a calibrated material model that is the wrong default in both directions: the
+parameters of a run were not recoverable from its input file, and the struct
+defaults are an uncited second copy of coefficients this repository cites no
+source for. The parse is now unconditional; an empty or absent `model.params`
+reports every missing field at once, and `smoke.json` spells them out.
+
+**Nine of the twenty-five fields were read nowhere** -- not the four the
+`T_min`/`T_max` caveat used to name. They were resolved two ways:
+
+| Field | Resolution |
+|---|---|
+| `T_min`, `T_max` | **Implemented.** They now clamp `T_const + T_var` (see below). |
+| `alpha_farTol`, `alpha_highOrd` | **Removed.** They parametrise *tungsten's* `C2`; the FCC dual-Gaussian peak here has no far-field tolerance and no higher-order exponent. |
+| `shift_u`, `shift_s` | **Removed.** They are the vapour shift that *produced* the `p*_bar` / `q*_bar` coefficients; the `_bar` names say it is already applied. |
+| `n0`, `n_sol`, `n_vap` | **Removed** from `model.params`. They act in the `initial_conditions` and `boundary_conditions` blocks, which carry their own copies (`constant.n0`, `seed_grid_fcc.rho`, `fixed.rho_low`/`rho_high`). A second copy that nothing reads can disagree with the one that acts. |
+
+Unknown keys are ignored, so an input that still carries the removed seven
+loads unchanged -- but it no longer implies that they do anything.
+
+### The temperature profile, and its clamp
 
 `temperature_variation(x, t)` returns `G_grid * (x_unwrapped - x_initial -
-V_grid * t)` -- a departure, with no `T0` offset and no clamp. The pointwise
-nonlinearity then uses `T_const + T_var`. `x_unwrapped` is `x` unwrapped
-relative to the tracked front position, so the profile follows the front around
-the periodic box.
+V_grid * t)` -- a departure, with no `T0` offset. `x_unwrapped` is `x`
+unwrapped relative to the tracked front position, so the profile follows the
+front around the periodic box. The pointwise nonlinearity then uses
+`T_const + T_var`.
+
+That is a straight line in `x` with no bound of its own, so on a domain 1393
+reduced units long any non-trivial `G_grid` drives it arbitrarily far from
+`T_const`. `clamp_temperature` now holds `T_const + T_var` inside
+`[T_min, T_max]`, and `T_min < T_max` with `T_const` inside the window is
+checked at load time (`validate_temperature_window`) rather than silently
+freezing the domain at one end. **Both shipped presets are isothermal
+(`G_grid = V_grid = 0`), so the clamp is a no-op on them and no pinned
+checksum moved.**
 
 ## Build
 

--- a/apps/aluminumNew/aluminumNew.json
+++ b/apps/aluminumNew/aluminumNew.json
@@ -2,10 +2,7 @@
     "model": {
         "name": "aluminum",
         "params": {
-            "n0": -0.0060,
             "alpha": 0.20,
-            "n_sol": -0.036,
-            "n_vap": -1.297,
             "T_const": 980,
             "T_min": 780,
             "T_max": 1280,
@@ -14,12 +11,8 @@
             "G_grid": 0,
             "V_grid": 0,
             "x_initial": 130,
-            "alpha_farTol": 0.001,
-            "alpha_highOrd": 0,
             "lambda": 0.22,
             "stabP": 0.0,
-            "shift_u": 1.0,
-            "shift_s": 0.0,
             "p2_bar": 0.8286531831,
             "p3_bar": -0.04204863,
             "p4_bar": 0.007533,

--- a/apps/aluminumNew/aluminumNew.toml
+++ b/apps/aluminumNew/aluminumNew.toml
@@ -8,17 +8,11 @@
 name = "aluminum"
 
 [model.params]
-# Average density
-n0 = -0.0060
-
 # Correlation function width
 alpha = 0.20
 
-# Phase coexistence densities
-n_sol = -0.036
-n_vap = -1.297
-
-# Temperature parameters
+# Temperature parameters. T_min / T_max clamp T_const + T_var (they were
+# declared required and read nowhere before 0.2; see apps/aluminumNew/README.md).
 T_const = 980
 T_min = 780
 T_max = 1280
@@ -30,19 +24,14 @@ G_grid = 0
 V_grid = 0
 x_initial = 130
 
-# Correlation function parameters
-alpha_farTol = 0.001
-alpha_highOrd = 0
-
 # Mean-field filtering
 lambda = 0.22
 
 # Numerical stability
 stabP = 0.0
 
-# Vapor model parameters
-shift_u = 1.0
-shift_s = 0.0
+# Shifted (barred) free-energy coefficients. The vapour shift that produced
+# them is applied offline; shift_u / shift_s are no longer inputs.
 p2_bar = 0.8286531831
 p3_bar = -0.04204863
 p4_bar = 0.007533

--- a/apps/aluminumNew/aluminumTest.cpp
+++ b/apps/aluminumNew/aluminumTest.cpp
@@ -19,18 +19,17 @@ using json = nlohmann::json;
 namespace {
 pfc::MPI_Worker g_mpi(0, nullptr, MPI_COMM_WORLD, false);
 
+/// Every field the schema declares, and nothing it does not. The schema is
+/// enforced since 0.2, so an incomplete block here is a load failure.
 json aluminum_params_json() {
-  return {{"n0", -0.0060},           {"alpha", 0.20},
-          {"n_sol", -0.036},         {"n_vap", -1.297},
-          {"T_const", 980.0},        {"T_min", 780.0},
-          {"T_max", 1280.0},         {"T0", 89285.0},
-          {"Bx", 0.817900686921996}, {"G_grid", 0.0},
-          {"V_grid", 0.0},           {"x_initial", 130.0},
-          {"alpha_farTol", 0.001},   {"alpha_highOrd", 0},
-          {"lambda", 0.22},          {"stabP", 0.0},
-          {"shift_u", 1.0},          {"shift_s", 0.0},
-          {"p2_bar", 0.8286531831},  {"p3_bar", -0.04204863},
-          {"p4_bar", 0.007533},      {"q20_bar", 0.016531729105214},
+  return {{"alpha", 0.20},           {"T_const", 980.0},
+          {"T_min", 780.0},          {"T_max", 1280.0},
+          {"T0", 89285.0},           {"Bx", 0.817900686921996},
+          {"G_grid", 0.0},           {"V_grid", 0.0},
+          {"x_initial", 130.0},      {"lambda", 0.22},
+          {"stabP", 0.0},            {"p2_bar", 0.8286531831},
+          {"p3_bar", -0.04204863},   {"p4_bar", 0.007533},
+          {"q20_bar", 0.016531729105214},
           {"q21_bar", 5.467},        {"q30_bar", 1.7152418049986},
           {"q31_bar", 0.45},         {"q40_bar", 0.787482}};
 }

--- a/apps/aluminumNew/include/aluminum/aluminum_physics.hpp
+++ b/apps/aluminumNew/include/aluminum/aluminum_physics.hpp
@@ -22,6 +22,8 @@
  */
 
 #include <cmath>
+#include <stdexcept>
+#include <string>
 #include <nlohmann/json.hpp>
 #include <openpfc/kernel/data/box3i.hpp>
 #include <openpfc/kernel/data/domain.hpp>
@@ -34,26 +36,51 @@
 
 namespace aluminum {
 
-/** Public JSON-shaped values for `ParameterSchema` (`aluminumNew.json`). */
+/**
+ * @brief Public JSON-shaped values for `ParameterSchema` (`aluminumNew.json`).
+ *
+ * Every field here is **read by the model**. That was not true before 0.2:
+ * nine of the twenty-five declared fields were `required` and consumed
+ * nowhere, which meant a configuration could not be read as a statement of
+ * what the run would do. They were resolved one of two ways.
+ *
+ * *Implemented* — `T_min` / `T_max` now clamp the temperature (see
+ * `AluminumPointwise::clamp_temperature`). The pair names an obvious bound
+ * on a quantity the model already computes, the shipped values bracket
+ * `T_const = 980`, and the moving-frame profile `T_const + G(x - x0 - Vt)`
+ * is otherwise unbounded along a 1393-unit domain. Every shipped preset has
+ * `G_grid = 0`, so the clamp is a no-op on them and no pinned result moved.
+ *
+ * *Removed* — the other seven named nothing this model computes:
+ * - `alpha_farTol`, `alpha_highOrd` parametrise **tungsten's** `C2`
+ *   construction. The FCC dual-Gaussian peak here (`fcc_correlation_peak`)
+ *   has no far-field tolerance and no higher-order exponent to set.
+ * - `shift_u`, `shift_s` are the vapour shift that *produced* the `p*_bar` /
+ *   `q*_bar` coefficients. The `_bar` names say the shift is already
+ *   applied; supplying it again suggested the app re-derived them.
+ * - `n0`, `n_sol`, `n_vap` are real quantities, but they act in the
+ *   `initial_conditions` and `boundary_conditions` blocks, which carry their
+ *   own copies (`constant.n0`, `seed_grid_fcc.rho`, `fixed.rho_low/high`).
+ *   A second copy under `model.params` that nothing reads is worse than an
+ *   unused parameter: it can disagree with the one that acts.
+ *
+ * Unknown keys are ignored by `ParameterSchema`, so inputs that still carry
+ * the removed seven load unchanged.
+ */
 struct AluminumSchemaValues {
-  double n0{-0.0060};
-  double n_sol{-0.036};
-  double n_vap{-1.297};
   double T0{89285.0};
   double Bx{0.817900686921996};
   double T_const{980.0};
+  /** Upper clamp on `T_const + T_var`; must exceed `T_min`. */
   double T_max{1280.0};
+  /** Lower clamp on `T_const + T_var`; must be below `T_max`. */
   double T_min{780.0};
   double G_grid{0.0};
   double V_grid{0.0};
   double x_initial{130.0};
   double alpha{0.20};
-  double alpha_farTol{0.001};
-  int alpha_highOrd{0};
   double lambda{0.22};
   double stabP{0.0};
-  double shift_u{1.0};
-  double shift_s{0.0};
   double p2_bar{0.8286531831};
   double p3_bar{-0.04204863};
   double p4_bar{0.007533};
@@ -84,8 +111,37 @@ struct AluminumParams : AluminumSchemaValues {
   }
 };
 
+/**
+ * @brief Cross-field validation `ParameterSchema` cannot express.
+ *
+ * The schema checks one field at a time, so it can bound `T_min` but not
+ * relate it to `T_max` or to `T_const`. Since 0.2 those bounds actually
+ * clamp the temperature, an inverted or non-bracketing pair silently
+ * freezes the whole domain at one end of the range rather than being
+ * harmlessly ignored — so it has to be rejected here.
+ *
+ * @throws std::invalid_argument if `T_min < T_max` does not hold, or if
+ *         `T_const` sits outside `[T_min, T_max]`.
+ */
+inline void validate_temperature_window(const AluminumSchemaValues &v) {
+  if (!(v.T_min < v.T_max)) {
+    throw std::invalid_argument(
+        "Invalid configuration: T_min (" + std::to_string(v.T_min) +
+        ") must be strictly below T_max (" + std::to_string(v.T_max) +
+        "); they clamp the temperature field.");
+  }
+  if (v.T_const < v.T_min || v.T_const > v.T_max) {
+    throw std::invalid_argument(
+        "Invalid configuration: T_const (" + std::to_string(v.T_const) +
+        ") is outside the clamp window [" + std::to_string(v.T_min) + ", " +
+        std::to_string(v.T_max) +
+        "]; the whole domain would sit pinned at one end of it.");
+  }
+}
+
 inline void apply_schema_values(const AluminumSchemaValues &v,
                                 AluminumParams &p) {
+  validate_temperature_window(v);
   static_cast<AluminumSchemaValues &>(p) = v;
   p.recompute_derived();
 }
@@ -93,24 +149,17 @@ inline void apply_schema_values(const AluminumSchemaValues &v,
 inline pfc::sim::ParameterSchema<AluminumSchemaValues> make_aluminum_schema() {
   pfc::sim::ParameterSchema<AluminumSchemaValues> s;
   s.model_name("Aluminum")
-      .real(&AluminumSchemaValues::n0, {.name = "n0", .description = "average density", .required = true})
-      .real(&AluminumSchemaValues::n_sol, {.name = "n_sol", .description = "solid coexistence density", .required = true})
-      .real(&AluminumSchemaValues::n_vap, {.name = "n_vap", .description = "vapor coexistence density", .required = true})
       .real(&AluminumSchemaValues::T0, {.name = "T0", .description = "reference temperature", .required = true, .min = 0.0})
       .real(&AluminumSchemaValues::Bx, {.name = "Bx", .description = "peak coefficient", .required = true})
       .real(&AluminumSchemaValues::T_const, {.name = "T_const", .description = "constant temperature", .required = true})
-      .real(&AluminumSchemaValues::T_max, {.name = "T_max", .description = "max temperature", .required = true})
-      .real(&AluminumSchemaValues::T_min, {.name = "T_min", .description = "min temperature", .required = true})
+      .real(&AluminumSchemaValues::T_max, {.name = "T_max", .description = "upper clamp on T_const + T_var", .required = true})
+      .real(&AluminumSchemaValues::T_min, {.name = "T_min", .description = "lower clamp on T_const + T_var", .required = true})
       .real(&AluminumSchemaValues::G_grid, {.name = "G_grid", .description = "thermal gradient", .required = true})
       .real(&AluminumSchemaValues::V_grid, {.name = "V_grid", .description = "frame velocity", .required = true})
       .real(&AluminumSchemaValues::x_initial, {.name = "x_initial", .description = "initial front position", .required = true})
-      .real(&AluminumSchemaValues::alpha, {.name = "alpha", .description = "C2 peak width", .required = true})
-      .real(&AluminumSchemaValues::alpha_farTol, {.name = "alpha_farTol", .description = "k=1 far tolerance", .required = true})
-      .integer(&AluminumSchemaValues::alpha_highOrd, {.name = "alpha_highOrd", .description = "higher-order Gaussian power", .required = true})
+      .real(&AluminumSchemaValues::alpha, {.name = "alpha", .description = "FCC correlation peak width", .required = true})
       .real(&AluminumSchemaValues::lambda, {.name = "lambda", .description = "mean-field filter strength", .required = true})
       .real(&AluminumSchemaValues::stabP, {.name = "stabP", .description = "ETD stabilization", .required = true})
-      .real(&AluminumSchemaValues::shift_u, {.name = "shift_u", .description = "vapor shift u", .required = true})
-      .real(&AluminumSchemaValues::shift_s, {.name = "shift_s", .description = "vapor shift s", .required = true})
       .real(&AluminumSchemaValues::p2_bar, {.name = "p2_bar", .description = "shifted p2", .required = true})
       .real(&AluminumSchemaValues::p3_bar, {.name = "p3_bar", .description = "shifted p3", .required = true})
       .real(&AluminumSchemaValues::p4_bar, {.name = "p4_bar", .description = "shifted p4", .required = true})
@@ -155,16 +204,28 @@ struct AluminumPhysics {
     return make_aluminum_schema();
   }
 
-  /// JSON `model.params` + geometry → physics (used by `SpectralETDSession`).
+  /**
+   * @brief JSON `model.params` + geometry → physics (for `SpectralETDSession`).
+   *
+   * The parse is unconditional. It used to be guarded by
+   * `!params_json.is_null() && !params_json.empty()`, which meant
+   * `"params": {}` — or no `model.params` block at all — quietly took the
+   * C++ member initialisers while the schema declared every field
+   * `required`. For a calibrated material model that is the wrong default in
+   * both directions: a run's parameters were not recoverable from its input
+   * file, and the struct defaults are an uncited second copy of coefficients
+   * the repository cites no source for. `required` now means required, and
+   * an empty block reports all of the missing fields at once.
+   *
+   * @throws std::invalid_argument listing every missing or invalid field.
+   */
   static AluminumPhysics from_json(const nlohmann::json &params_json,
                                    const pfc::Domain &domain_in,
                                    const pfc::Box3i &box_in) {
     AluminumPhysics p;
     p.domain = domain_in;
     p.box = box_in;
-    if (!params_json.is_null() && !params_json.empty()) {
-      apply_aluminum_json(params_json, p.params);
-    }
+    apply_aluminum_json(params_json, p.params);
     return p;
   }
 
@@ -208,6 +269,8 @@ struct AluminumPhysics {
             .q4_bar = params.q4_bar,
             .T0 = params.T0,
             .T_const = params.T_const,
+            .T_min = params.T_min,
+            .T_max = params.T_max,
             .stabP = params.stabP,
             .G_grid = params.G_grid,
             .V_grid = params.V_grid,

--- a/apps/aluminumNew/include/aluminum/aluminum_pointwise.hpp
+++ b/apps/aluminumNew/include/aluminum/aluminum_pointwise.hpp
@@ -11,7 +11,8 @@
  * @details
  * Temperature varies along x in a frame moving with the solidification front:
  * \f$T_{\mathrm{var}}(x,t) = G\,(x' - x_0 - V t)\f$ with \f$x'\f$ the periodic
- * unwrap of \f$x\f$ against the front position. Every constant the kernel
+ * unwrap of \f$x\f$ against the front position, held inside
+ * \f$[T_{\min}, T_{\max}]\f$ by `clamp_temperature`. Every constant the kernel
  * needs is stored by value so the functor can be passed to a GPU kernel;
  * `AluminumPhysics::pointwise()` fills it from `AluminumParams`.
  *
@@ -37,6 +38,9 @@ struct AluminumPointwise {
   double q4_bar{};
   double T0{1.0};
   double T_const{};
+  /// Clamp window on the absolute temperature; inactive unless T_min < T_max.
+  double T_min{};
+  double T_max{};
   double stabP{};
   double G_grid{};
   double V_grid{};
@@ -44,11 +48,42 @@ struct AluminumPointwise {
   double front_x{};  ///< current front position (`m_xpos`)
   double length_x{}; ///< periodic length of the domain along x
 
+  /**
+   * @brief Hold the absolute temperature inside `[T_min, T_max]`.
+   *
+   * @param t_var departure from `T_const`, as `temperature_variation` builds
+   *              it; returns the departure again, clamped.
+   *
+   * The profile `T_const + G (x - x0 - V t)` is a straight line in `x` with
+   * no bound of its own, so on a domain 1393 reduced units long any
+   * non-trivial `G` drives it arbitrarily far from `T_const`. `T_min` and
+   * `T_max` were declared required and read nowhere until 0.2; this is what
+   * they now mean. Both shipped presets are isothermal (`G_grid = 0`), so
+   * every pinned checksum is unaffected.
+   *
+   * Inactive when `T_max <= T_min` — that combination is rejected at load
+   * time by `validate_temperature_window`, so it can only arise from a
+   * hand-built `AluminumPointwise`, where doing nothing is the safe answer.
+   */
+  OPENPFC_HD double clamp_temperature(double t_var) const {
+    if (!(T_min < T_max)) {
+      return t_var;
+    }
+    const double t_abs = T_const + t_var;
+    if (t_abs < T_min) {
+      return T_min - T_const;
+    }
+    if (t_abs > T_max) {
+      return T_max - T_const;
+    }
+    return t_var;
+  }
+
   OPENPFC_HD double temperature_variation(double x, double t) const {
     const double fullruns = std::floor(front_x / length_x) * length_x;
     const double steppoint = std::fmod(front_x, length_x);
     const double dist = x + fullruns - (x > steppoint) * length_x;
-    return G_grid * (dist - x_initial - V_grid * t);
+    return clamp_temperature(G_grid * (dist - x_initial - V_grid * t));
   }
 
   OPENPFC_HD double nonlinearity(double psi, double psi_mf, double p_star,

--- a/apps/aluminumNew/inputs_json/smoke.json
+++ b/apps/aluminumNew/inputs_json/smoke.json
@@ -1,5 +1,28 @@
 {
-    "model": {"name": "aluminum", "params": {}},
+    "model": {
+        "name": "aluminum",
+        "params": {
+            "T0": 89285.0,
+            "Bx": 0.817900686921996,
+            "T_const": 980.0,
+            "T_min": 780.0,
+            "T_max": 1280.0,
+            "G_grid": 0.0,
+            "V_grid": 0.0,
+            "x_initial": 130.0,
+            "alpha": 0.20,
+            "lambda": 0.22,
+            "stabP": 0.0,
+            "p2_bar": 0.8286531831,
+            "p3_bar": -0.04204863,
+            "p4_bar": 0.007533,
+            "q20_bar": 0.016531729105214,
+            "q21_bar": 5.467,
+            "q30_bar": 1.7152418049986,
+            "q31_bar": 0.45,
+            "q40_bar": 0.787482
+        }
+    },
     "domain": {"Lx": 16, "Ly": 16, "Lz": 16, "dx": 1.3603495232, "dy": 1.3603495232, "dz": 1.3603495232, "origin": "corner"},
     "timestepping": {"t0": 0.0, "t1": 0.1, "dt": 0.01, "saveat": 0.05},
     "initial_conditions": [{"target": "psi", "type": "constant", "n0": -0.006}],

--- a/apps/aluminumNew/tests/test_aluminum_etd_gpu.cpp
+++ b/apps/aluminumNew/tests/test_aluminum_etd_gpu.cpp
@@ -27,18 +27,17 @@ using nlohmann::json;
 
 namespace {
 
+/// Every field the schema declares, and nothing it does not. The schema is
+/// enforced since 0.2, so an incomplete block here is a load failure.
 json model_params() {
-  return {{"n0", -0.0060},           {"alpha", 0.20},
-          {"n_sol", -0.036},         {"n_vap", -1.297},
-          {"T_const", 980.0},        {"T_min", 780.0},
-          {"T_max", 1280.0},         {"T0", 89285.0},
-          {"Bx", 0.817900686921996}, {"G_grid", 0.0},
-          {"V_grid", 0.0},           {"x_initial", 130.0},
-          {"alpha_farTol", 0.001},   {"alpha_highOrd", 0},
-          {"lambda", 0.22},          {"stabP", 0.0},
-          {"shift_u", 1.0},          {"shift_s", 0.0},
-          {"p2_bar", 0.8286531831},  {"p3_bar", -0.04204863},
-          {"p4_bar", 0.007533},      {"q20_bar", 0.016531729105214},
+  return {{"alpha", 0.20},           {"T_const", 980.0},
+          {"T_min", 780.0},          {"T_max", 1280.0},
+          {"T0", 89285.0},           {"Bx", 0.817900686921996},
+          {"G_grid", 0.0},           {"V_grid", 0.0},
+          {"x_initial", 130.0},      {"lambda", 0.22},
+          {"stabP", 0.0},            {"p2_bar", 0.8286531831},
+          {"p3_bar", -0.04204863},   {"p4_bar", 0.007533},
+          {"q20_bar", 0.016531729105214},
           {"q21_bar", 5.467},        {"q30_bar", 1.7152418049986},
           {"q31_bar", 0.45},         {"q40_bar", 0.787482}};
 }

--- a/apps/aluminumNew/tests/test_aluminum_physics.cpp
+++ b/apps/aluminumNew/tests/test_aluminum_physics.cpp
@@ -17,11 +17,9 @@ using nlohmann::json;
 
 namespace {
 
+/// Every field the schema declares, and nothing it does not.
 json aluminum_params_json() {
-  return {{"n0", -0.0060},
-          {"alpha", 0.20},
-          {"n_sol", -0.036},
-          {"n_vap", -1.297},
+  return {{"alpha", 0.20},
           {"T_const", 980.0},
           {"T_min", 780.0},
           {"T_max", 1280.0},
@@ -30,12 +28,8 @@ json aluminum_params_json() {
           {"G_grid", 0.0},
           {"V_grid", 0.0},
           {"x_initial", 130.0},
-          {"alpha_farTol", 0.001},
-          {"alpha_highOrd", 0},
           {"lambda", 0.22},
           {"stabP", 0.0},
-          {"shift_u", 1.0},
-          {"shift_s", 0.0},
           {"p2_bar", 0.8286531831},
           {"p3_bar", -0.04204863},
           {"p4_bar", 0.007533},
@@ -67,12 +61,12 @@ TEST_CASE("AluminumPhysics schema round-trips JSON params",
           "[aluminum][physics][schema]") {
   auto schema = aluminum::AluminumPhysics<>::schema();
   json j = aluminum_params_json();
-  j["n0"] = -0.01;
+  j["alpha"] = 0.25;
   const auto vals = schema.parse(j);
-  REQUIRE(vals.n0 == Approx(-0.01));
+  REQUIRE(vals.alpha == Approx(0.25));
   aluminum::AluminumParams p;
   aluminum::apply_schema_values(vals, p);
-  REQUIRE(p.n0 == Approx(-0.01));
+  REQUIRE(p.alpha == Approx(0.25));
   REQUIRE(p.tau_const == Approx(980.0 / 89285.0));
   REQUIRE(p.q4_bar == Approx(p.q40_bar));
   REQUIRE(p.m_xpos == Approx(130.0));
@@ -83,6 +77,103 @@ TEST_CASE("AluminumPhysics schema rejects missing G_grid",
   json j = aluminum_params_json();
   j.erase("G_grid");
   REQUIRE_THROWS_AS(aluminum::make_aluminum_schema().parse(j),
+                    std::invalid_argument);
+}
+
+/**
+ * @brief `required` has to mean required at the door the app actually uses.
+ *
+ * `from_json` used to skip the schema entirely for `"params": {}`, so a
+ * configuration could declare nothing and silently inherit the C++ member
+ * initialisers — uncited coefficients that no input file records. The schema
+ * said all twenty-five fields were required; the loader disagreed with it.
+ */
+TEST_CASE("AluminumPhysics::from_json enforces its own schema",
+          "[aluminum][physics][schema]") {
+  const auto domain = pfc::domain::create({8, 8, 8});
+  const auto box = pfc::Box3i::from_bounds({0, 0, 0}, {7, 7, 7});
+
+  SECTION("an empty params block is rejected, not defaulted") {
+    REQUIRE_THROWS_AS(
+        aluminum::AluminumPhysics<>::from_json(json::object(), domain, box),
+        std::invalid_argument);
+  }
+  SECTION("a missing params block is rejected too") {
+    REQUIRE_THROWS_AS(
+        aluminum::AluminumPhysics<>::from_json(json(), domain, box),
+        std::invalid_argument);
+  }
+  SECTION("one missing field is enough") {
+    json j = aluminum_params_json();
+    j.erase("Bx");
+    REQUIRE_THROWS_AS(aluminum::AluminumPhysics<>::from_json(j, domain, box),
+                      std::invalid_argument);
+  }
+  SECTION("a complete block still loads and is used") {
+    json j = aluminum_params_json();
+    j["Bx"] = 0.5;
+    const auto phys = aluminum::AluminumPhysics<>::from_json(j, domain, box);
+    REQUIRE(phys.params.Bx == Approx(0.5));
+  }
+}
+
+/**
+ * @brief `T_min` / `T_max` clamp the temperature instead of doing nothing.
+ *
+ * Before 0.2 both were declared required and read nowhere, so a
+ * `G_grid != 0` run drove `T_const + T_var` arbitrarily far along `x` with
+ * nothing to stop it. Every shipped preset is isothermal, so the clamp does
+ * not move any pinned checksum.
+ */
+TEST_CASE("AluminumPhysics clamps the temperature into [T_min, T_max]",
+          "[aluminum][physics][temperature]") {
+  const double t_hot = 1280.0 - 980.0;  //  T_max - T_const =  300
+  const double t_cold = 780.0 - 980.0;  //  T_min - T_const = -200
+
+  aluminum::AluminumPhysics<> phys;
+  json j = aluminum_params_json();
+  j["G_grid"] = 10.0; // steep enough to run off both ends of the window
+  aluminum::apply_aluminum_json(j, phys.params);
+  phys.domain = pfc::domain::create({128, 8, 8});
+  const auto pw = phys.pointwise();
+
+  // Both directions, on the departure the moving-frame profile produces.
+  REQUIRE(pw.clamp_temperature(970.0) == Approx(t_hot));
+  REQUIRE(pw.clamp_temperature(-1300.0) == Approx(t_cold));
+  REQUIRE(pw.clamp_temperature(100.0) == Approx(100.0)); // inside: untouched
+
+  // And through the profile itself. Open the window wide to see what the
+  // unclamped profile would have done at the same point.
+  json wide = j;
+  wide["T_min"] = -1.0e9;
+  wide["T_max"] = 1.0e9;
+  aluminum::AluminumPhysics<> unbounded;
+  aluminum::apply_aluminum_json(wide, unbounded.params);
+  unbounded.domain = phys.domain;
+  const double raw = unbounded.temperature_variation(10.0, 0.0);
+  INFO("unclamped departure at x=10 is " << raw);
+  REQUIRE(raw < t_cold);
+  REQUIRE(phys.temperature_variation(10.0, 0.0) == Approx(t_cold));
+
+  // The clamp is on the *absolute* temperature, so it is the nonlinearity
+  // that sees the bounded value, not just the reported one.
+  REQUIRE(phys.nonlinearity(0.1, 0.05, 0.2,
+                            phys.temperature_variation(10.0, 0.0)) ==
+          Approx(phys.nonlinearity(0.1, 0.05, 0.2, t_cold)));
+}
+
+TEST_CASE("AluminumPhysics rejects a temperature window that cannot clamp",
+          "[aluminum][physics][temperature][schema]") {
+  json inverted = aluminum_params_json();
+  inverted["T_min"] = 1280.0;
+  inverted["T_max"] = 780.0;
+  aluminum::AluminumParams p;
+  REQUIRE_THROWS_AS(aluminum::apply_aluminum_json(inverted, p),
+                    std::invalid_argument);
+
+  json off_window = aluminum_params_json();
+  off_window["T_const"] = 1500.0;
+  REQUIRE_THROWS_AS(aluminum::apply_aluminum_json(off_window, p),
                     std::invalid_argument);
 }
 

--- a/docs/report/04_aluminum.qmd
+++ b/docs/report/04_aluminum.qmd
@@ -41,12 +41,14 @@ Three inputs ship. `aluminumNew.json` is a large demonstration case
 to run on one core in a few minutes, and is what @fig-al-nucleus is rendered
 from; `inputs_json/smoke.json` is a $16^3$ sanity file, not referenced by CMake
 or by any test, whose initial condition is a **constant** field — it contains
-no seed and never develops any structure. None of the three is a verification
-preset: the pinned checksum in the test suite runs a **separate synthetic
-$32^3$ configuration built in C++** (`X0 = 8`, radius 4, `rseed = 42`), not any
-of these files. `tests/test_aluminum_inputs.cpp` does check that all three load
-through the schema and the initial-condition catalog, which is a rot check, not
-a physics check.
+no seed and never develops any structure. `smoke.json` used to carry an empty
+`model.params` block and rely on the loader skipping the schema entirely; it
+now spells every parameter out, because the loader no longer skips it. None of
+the three is a verification preset: the pinned checksum in the test suite runs
+a **separate synthetic $32^3$ configuration built in C++** (`X0 = 8`, radius 4,
+`rseed = 42`), not any of these files. `tests/test_aluminum_inputs.cpp` does
+check that all three load through the schema and the initial-condition
+catalog, which is a rot check, not a physics check.
 
 | Item | Description |
 |---|---|
@@ -55,7 +57,7 @@ a physics check.
 | Grid | $t \in [0, 2000]$ at $\Delta t = 1$ (2000 steps), field dump every 200 |
 | Boundary conditions | Periodic on all three axes (the FFT has no other mode), plus a stationary `fixed` density-reservoir band pulling $\psi$ between $-1.297$ and $-0.006$ near the high-$x$ end |
 | Initial condition | Uniform $\psi = -0.006$, then `seed_grid_fcc`: a $2 \times 1$ row of FCC seeds of radius 120 at $x = 130$, amplitude $0.4$, $\rho = -0.036$, each jittered by $\pm 0.2R$ and randomly oriented. Each seed is built from the four $\langle 111\rangle$ wave vectors, in contrast to @sec-tungsten's six $\{110\}$ vectors |
-| Key physical parameters | $T_{\mathrm{const}} = 980$, $T_0 = 89285$ (no unit is stated anywhere in this application, unlike @sec-tungsten's TOML comments); $n_{\mathrm{sol}} = -0.036$, $n_{\mathrm{vap}} = -1.297$; $B_x = 0.8179$, $\alpha = 0.20$; barred polynomial coefficients. $G_{\mathrm{grid}} = V_{\mathrm{grid}} = 0$: **the shipped run is isothermal**. Lengths and times are reduced PFC units with no SI mapping in the repository |
+| Key physical parameters | $T_{\mathrm{const}} = 980$ held inside $[T_{\min}, T_{\max}] = [780, 1280]$, $T_0 = 89285$ (no unit is stated anywhere in this application, unlike @sec-tungsten's TOML comments); $B_x = 0.8179$, $\alpha = 0.20$; barred polynomial coefficients. The coexistence densities $-0.036$ and $-1.297$ are set in the initial- and boundary-condition blocks, not in `model.params`. $G_{\mathrm{grid}} = V_{\mathrm{grid}} = 0$: **the shipped run is isothermal**, so the temperature clamp is a no-op on every shipped preset. Lengths and times are reduced PFC units with no SI mapping in the repository |
 | Observable | `SPECTRAL_CHECKSUM` sum, sum of squares and $L^2$ of $\psi$; the summed free energy (`last_free_energy_sum`), which this application computes per cell and @sec-tungsten does not; binary field dumps |
 | Model maturity | numerical verification: **regression** — the operators and the pointwise nonlinearity are checked to $10^{-14}$ against an independently written reference formula, and one synthetic case is pinned; there is no closed-form solution of the model · physical completeness: **extended** — the tungsten equation of state plus a separate correlation kernel $P(k)$ and a travelling temperature field · calibration: **representative**, with the same caveat as @sec-tungsten: no source is cited anywhere in the repository for any of the aluminium coefficients |
 
@@ -124,13 +126,30 @@ settles where the local temperature matches the interface condition, and then
 travels with the gradient. Setting $G_{\mathrm{grid}} = 0$ — the shipped value
 — recovers an isothermal run at `T_const`.
 
-::: {.callout-warning}
-## `T_min` and `T_max` do nothing
+@eq-al-temp is a straight line in $x$ with no bound of its own, so on a domain
+$1393$ reduced units long any non-trivial $G_{\mathrm{grid}}$ drives
+$T_{\mathrm{const}} + T_{\mathrm{var}}$ arbitrarily far from
+$T_{\mathrm{const}}$. Since 0.2 it is held inside
+$[T_{\min}, T_{\max}] = [780, 1280]$, and an inverted window, or a
+$T_{\mathrm{const}}$ outside it, is rejected at load time rather than
+silently pinning the whole domain at one end. Because every shipped preset is
+isothermal the clamp is a no-op on all of them, and no pinned checksum moved.
 
-The schema declares `T_min` and `T_max` as required parameters and every
-shipped input and test supplies them, but **no code reads them**. There is no
-clamping of the temperature field anywhere in the application. They are
-vestigial, and a reader should not assume the travelling profile is bounded.
+::: {.callout-note}
+## What `required` used to mean here
+
+Until 0.2 `T_{\min}` and `T_{\max}` were declared **required** and read
+nowhere — and so were seven other fields, nine of the twenty-five in total.
+`AluminumPhysics::from_json` also skipped the schema whenever
+`model.params` was empty, which is exactly what `inputs_json/smoke.json`
+shipped, so a configuration could declare nothing and quietly inherit the C++
+struct defaults. The parse is now unconditional, `T_{\min}`/`T_{\max}` clamp
+the temperature, and the seven that named nothing this model computes
+(`alpha_farTol`, `alpha_highOrd` — tungsten's $C_2$; `shift_u`, `shift_s` —
+the vapour shift already baked into the barred coefficients; `n0`,
+`n_{\mathrm{sol}}`, `n_{\mathrm{vap}}` — duplicates of values that act in
+the initial- and boundary-condition blocks) were removed from the schema.
+Unknown keys are ignored, so older inputs still load.
 :::
 
 ## Solution strategy
@@ -154,7 +173,10 @@ As in @sec-tungsten, **dealiasing is off**: the shared option defaults to
   input file.
 * **CPU/GPU parity.** A live CPU run and a live device run agree to $10^{-10}$.
   There is no separately pinned GPU literal.
-* **Schema.** JSON round-trip and range validation on every parameter.
+* **Schema.** JSON round-trip and range validation on every parameter, and
+  the loader is held to it: an empty or absent `model.params` is a load
+  failure, not a silent fall-back to the C++ struct defaults. Every field the
+  schema declares is read by the model.
 
 Like @sec-tungsten this model has no closed-form reference; coverage is
 regression and schema rather than analytical.

--- a/docs/report/14_allen_cahn.qmd
+++ b/docs/report/14_allen_cahn.qmd
@@ -10,50 +10,54 @@ Unlike the Cahn–Hilliard model of @sec-cahn-hilliard, the order parameter here
 is **not** conserved: a grain can shrink and vanish. This is the standard model
 for curvature-driven grain growth.
 
-The question the shipped run asks is deliberately coarse: **seed one grain of
-the favoured phase in a matrix of the other and drive the transformation — does
-the favoured phase actually take over?** The named observable is the
-**superlevel-set area** $A(t) = \lvert\{\phi > 0\}\rvert$, the number of cells
-in the growing phase, reported as the ratio $A(t_1)/A(0)$. It is the
-non-conserved counterpart of a mass check: Cahn–Hilliard's mean must not move,
-and Allen–Cahn's area must. @fig-allen-cahn-growth shows it happening, with
-the measured ratio printed on each panel.
+The question the shipped run asks: **seed one grain of the favoured phase in
+a matrix of the other and drive the transformation — does the front move at
+the speed the sharp-interface theory says it should?** The measured quantity
+is the **interface velocity** $\mathrm{d}R/\mathrm{d}t$, where
+$R = \sqrt{A/\pi}$ is the equivalent radius of the superlevel-set area
+$A(t) = \lvert\{\phi > 0\}\rvert$. Growth of $A$ is the non-conserved
+counterpart of a mass check — Cahn–Hilliard's mean must not move, and
+Allen–Cahn's area must — but the *ratio* $A(t_1)/A(0)$ that this chapter once
+reported is grid-dependent, and $\mathrm{d}R/\mathrm{d}t$ is not.
+@fig-allen-cahn-growth shows it happening.
 
 ## Problem setup
 
 Command-line driven, no JSON, and no science preset. There is one further thing
-worth stating plainly: **no ctest runs this binary.** The area criterion below
-is enforced by the program's own exit code when a user runs it; the automated
-suite exercises the update function through fixed small configurations
-instead.
+worth stating plainly: **no ctest runs this binary.** The velocity criterion
+below reaches the program's exit code only when a user passes `--strict`; the
+automated suite runs the same update function and the same criterion through
+`allen-cahn-interface-kinetics`, at two grid sizes, and additionally pins the
+shipped preset itself.
 
 | Item | Description |
 |---|---|
 | Use case | A single grain of the favoured phase growing into a matrix of the other under a constant driving force |
-| Domain | $n_x \times n_y \times 1$ slab with $\Delta x = \Delta y = 1$, hard-coded — the spacing is not a command-line argument. Defaults $64 \times 64$ |
-| Grid | `nx ny n_steps [dt] [M] [epsilon] [driving_force] [png_initial] [png_final]`; defaults 5000 steps at $\Delta t = 9\times10^{-5}$. There is no output cadence: at most two PNG snapshots, the initial and the final state |
+| Domain | $n_x \times n_y \times 1$ slab with $\Delta x = \Delta y = 1$, hard-coded — the spacing is not a command-line argument. Defaults $256 \times 256$. The fixed spacing is load-bearing: the interface can only be resolved by enlarging $\varepsilon\sqrt{2M}$, never by refining the grid |
+| Grid | `nx ny n_steps [dt] [M] [epsilon] [driving_force] [png_initial] [png_final]`; defaults 5000 steps at $\Delta t = 5\times10^{-3}$, 16 % of the explicit-Euler diffusive limit. There is no output cadence: at most two PNG snapshots, the initial and the final state |
 | Boundary conditions | Periodic in $x$ and $y$, by separated-layout halo exchange. There is no non-periodic option |
 | Initial condition | A single Gaussian nucleus, $\phi = -1 + 2\exp(-r^2/2\sigma^2)$ centred in the slab, with $\sigma = \max(2,\ 0.055\min(n_x,n_y))$ — about 5.5 % of the shorter side. Deterministic; no noise anywhere |
-| Key physical parameters | $M = 8.0$, $\varepsilon = 0.19$, $F = 10.0$. **Nondimensional and illustrative**; the application states no units and cites no reference model. $\varepsilon$ is as much a numerical parameter as a physical one, since it sets both the interface width and the stiff reaction timestep limit |
-| Observable | $A(t_1)/A(0)$ for $A = \lvert\{\phi > 0\}\rvert$, which the program prints and uses as its exit status (failure unless $A(t_1) \ge 5A(0)$); global $\min\phi$, $\max\phi$ and $\sum\phi$; `avg_step_time_s`; optional grayscale PNGs |
-| Model maturity | numerical verification: **regression** only — one pinned CPU checksum tied to a named machine and toolchain, plus CPU-vs-CUDA agreement to $10^{-9}$ and CPU-vs-HIP to $10^{-4}$. There is no analytical or manufactured-solution check anywhere in this application · physical completeness: **canonical** — the standard non-conserved double-well model with a constant driving force, with no elastic, thermal or solutal coupling · calibration: **none** |
+| Key physical parameters | $M = 8.0$, $\varepsilon = 0.75$, $F = 0.25$. **Nondimensional and illustrative**; the application states no units and cites no reference model. $\varepsilon$ is as much a numerical parameter as a physical one: it sets the interface width, the stiff reaction timestep limit *and*, through $F\varepsilon^2$, the distance to the bistability ceiling. The three are chosen jointly — see @sec-ac-two-limits |
+| Observable | $\mathrm{d}R/\mathrm{d}t$ over the second half of the run for $R = \sqrt{A/\pi}$, $A = \lvert\{\phi > 0\}\rvert$ sampled at $t = 0, t_1/2, 3t_1/4, t_1$, compared with the curvature-corrected sharp-interface law to $\pm 25\,\%$; the critical radius $M/v$; the interface width in cells; the distance to the bistability ceiling; global $\min\phi$, $\max\phi$ and $\sum\phi$; `avg_step_time_s`; optional grayscale PNGs. The verdict prints as `physics_check=` and reaches the exit status only under `--strict` |
+| Model maturity | numerical verification: **analytical** and **regression** — the measured interface velocity is compared with the sharp-interface solvability result plus the curvature term, and agrees to $1.6\,\%$ at the shipped preset and to $2.3\,\%$ on every grid from $128^2$ to $512^2$ (`docs/report/data/allen_cahn_resolution_margin.csv`); plus one pinned CPU checksum tied to a named machine and toolchain, CPU-vs-CUDA agreement to $10^{-9}$ and CPU-vs-HIP to $10^{-4}$. There is no manufactured-solution check · physical completeness: **canonical** — the standard non-conserved double-well model with a constant driving force, with no elastic, thermal or solutal coupling · calibration: **none** |
 
 Periodicity means the grain grows inside an infinite square array of identical
 grains rather than in an unbounded matrix. There is no free surface and no
-container, so nothing pins the interface and there is no curvature-driven drift
-towards a wall — which is the right idealisation for asking whether a favoured
-phase grows at all. It also puts a ceiling on how long the experiment means
-anything: once the growing phase spans a substantial fraction of the box it
-begins to meet its own image, and the area ratio stops describing an isolated
-grain. The 5× criterion is a coarse growth check rather than a measurement of
-interface velocity, and the application does **not** verify that the seed has
-stayed clear of its own images. It is also **grid-dependent**, which is worth
-knowing before reading a pass or a fail as a statement about the physics: the
-seed radius scales with the grid ($\sigma \propto \min(n_x,n_y)$) but the
-interface advances at a velocity that does not, so the area ratio reached in a
-fixed number of steps falls as the grid grows. At the shipped defaults the
-run passes ($6.1\times$ at $64^2$, 5000 steps) and the same 5000 steps on a
-$256^2$ grid fails ($2.5\times$) while solving the same problem no worse.
+container, so nothing pins the interface and there is no drift towards a wall
+— which is the right idealisation for asking whether a favoured phase grows at
+all. It also puts a ceiling on how long the experiment means anything: once
+the growing phase spans a substantial fraction of the box it begins to meet
+its own image, and the application does **not** verify that the seed has
+stayed clear of its own images.
+
+The criterion used to be a coarse area ratio, $A(t_1) \ge 5A(0)$, and it was
+**grid-dependent**: the seed radius scales with the grid
+($\sigma \propto \min(n_x,n_y)$) but the interface velocity does not, so the
+same physics scored $6.1\times$ at $64^2$, $3.5\times$ at $128^2$ and
+$2.5\times$ at $256^2$ — pass, fail, fail. $\mathrm{d}R/\mathrm{d}t$ replaces
+it, read off the second half of the run because the Gaussian initial
+condition is far from the equilibrium $\tanh$ and its collapse moves the
+contour by a distance that scales with the seed.
 
 ## Governing equations
 
@@ -105,14 +109,82 @@ the reason $\varepsilon$ is a numerical as well as a physical parameter.
 Explicit Euler with separated halos, so the stencil evaluation and the halo
 exchange are distinct phases. Optional PNG snapshots of $\phi$.
 
+## The two limits that set the preset {#sec-ac-two-limits}
+
+These are coupled, and the coupling is the reason the shipped preset changed
+in 0.2 rather than being nudged. Measurements:
+`docs/report/data/allen_cahn_resolution_margin.csv`.
+
+**The interface must span cells.** Its equilibrium half-width is
+$\delta = \varepsilon\sqrt{2M}$, measured in cells because $\Delta x = 1$ is
+hard-coded — so resolving it means enlarging $\delta$, not refining the grid.
+Below about $1.5$ cells the front is pinned by the lattice. At $\delta = 0.76$
+cells, the pre-0.2 value, the measured speed is $32\,\%$ below the continuum
+law at a safe driving force; at $1.5$ cells the error is $0.05\,\%$ and at
+$2.0$ cells $1.2\,\%$.
+
+**The driving force has a ceiling.** A front exists only while
+$F\varepsilon^2 < 2/(3\sqrt3) = 0.385$; above it there is no metastable
+$\phi < 0$ phase and the box decays wholesale. Approaching it is bad well
+before crossing it. At $94\,\%$ of the ceiling — the pre-0.2 value — the
+matrix well has moved from $\phi = -1$ to $\phi = -0.69$ and retains
+$1.5\,\%$ of the symmetric barrier depth, and the $F\varepsilon^2 \to 0$ law
+@eq-ac-velocity is $26\,\%$ slow.
+
+**Why they cannot be fixed separately.** The pre-0.2 preset measured
+$+9\,\%$ against @eq-ac-velocity, which reads as agreement and is not: it is
+the lattice slowing the front by $\sim 12\,\%$ against the finite tilt
+speeding the continuum front by $\sim 26\,\%$. Backing $F$ off at
+$\varepsilon = 0.19$ removes only the second, so the residual walks from
+$+17\,\%$ at the ceiling to $-65\,\%$ at a quarter of it. There is no safe
+driving force at a $0.76$-cell interface. The 0.2 preset resolves the
+interface first — $\varepsilon = 0.75$, $\delta = 3.0$ cells — and can then
+afford $F = 0.25$, a factor $2.7$ under the ceiling.
+
+The grid moved with them. A resolved interface at a safe driving force has a
+critical nucleus $R^\* = M/v = 7.1$ cells against $0.70$ before, and the seed
+$\sigma = 0.055\min(n_x,n_y)$ is only $4.1$ cells at $64^2$: the old default
+grid would now dissolve its own seed. $256^2$ gives a $16.7$-cell seed.
+
+## The prediction, with curvature {#sec-ac-curvature}
+
+The measured object is a growing disc, and Allen–Cahn moves an interface by
+mean curvature as well as by the bulk driving force:
+
+$$
+\frac{\mathrm{d}R}{\mathrm{d}t} \;=\; \tfrac{3}{2} F \varepsilon \sqrt{2M}
+                                    \;-\; \frac{M}{R} .
+$$ {#eq-ac-velocity}
+
+The first term is the solvability result: project the travelling wave onto
+$\phi'$ in @eq-ac-pde, with $\phi = -\tanh(\xi/\delta)$ giving
+$\int\phi'^2 = 4/3\delta$ and $\int\phi' = -2$. The second was ignored while
+$F = 10$ made $M/R$ about $6\,\%$ of the answer. It is not ignorable at a
+driving force far enough under the ceiling to be safe: $M/R$ is $20\,\%$ here,
+and it does **not** shrink with the grid, because the seed scales with the box
+and so $R/R^\*$ is nearly grid-independent. Comparing a disc with a flat-front
+law leaves a $20\,\%$ bias that looks exactly like a grid dependence and that
+no amount of refinement removes.
+
 ## Verification
 
-* **Superlevel-set growth.** The area with $\phi$ above zero grows by at least
-  a factor of five between $t=0$ and the end of the run — the non-conserved
-  counterpart to a conservation check. This is enforced by the program's exit
-  code, not by a ctest.
+* **Interface velocity against @eq-ac-velocity.** Measured over the second
+  half of the run and required to land within $\pm 25\,\%$ of the
+  curvature-corrected prediction, after the two quarter velocities agree to
+  $25\,\%$ so the front is known to be steady. Residual at the shipped
+  preset: $1.6\,\%$; at most $2.3\,\%$ on any grid from $128^2$ to $512^2$.
+  The verdict prints as `physics_check=` and reaches the process exit status
+  only under `--strict`.
+* **Grid independence.** `allen-cahn-interface-kinetics` runs $256^2$ and
+  $384^2$ and requires both to reach the same verdict and to sit the same
+  distance from their own predictions, to $3\,\%$.
+* **Preset guards.** The same test pins the shipped preset itself: interface
+  width at least 2 cells, driving force at most half the bistability ceiling,
+  seed radius at least twice the critical radius, timestep at most a quarter
+  of the stability limit.
 * **Golden checksum.** One pinned CPU literal for a $32^2$, 20-step
   configuration, annotated with the machine and toolchain it was taken on.
+  It sets every parameter explicitly and did not move with the preset.
 * **CPU–GPU parity.** CPU against CUDA to $10^{-9}$, and CPU against HIP to
   $10^{-4}$ — the looser HIP bound is documented as rounding accumulated in the
   nonlinear term.
@@ -124,7 +196,12 @@ does not use the JSON session path.
 
 ## Visualisation
 
-![One grain growing, with the application's own observable written on it. The
+![One grain growing, with the application's own observable written on it.
+**Rendered at the pre-0.2 preset** ($\varepsilon = 0.19$, $F = 10$), which is
+what the run recorded in `run_field_demos.sh` still uses; it is kept because
+it is the clearest picture in the report of what sitting 6 % under the
+bistability ceiling does to a double well — see the well-shift note below,
+and @sec-ac-two-limits. The
 five panels are five *separate runs* at increasing `n_steps`, because this
 application has no output cadence — it writes at most two PNGs, the initial
 and the final state — but the initial condition is deterministic and there is
@@ -137,7 +214,9 @@ which is why the radius grows roughly linearly while the area grows roughly
 quadratically. Two details are real rather than artefacts. The matrix is
 darkest at $t = 0$ and lighter afterwards because the driving force $F = 10$
 shifts both wells: $\phi$ actually relaxes to $-0.69$ and $+1.15$, not
-$\pm1$. The grain interior is flat because the PNG the application writes
+$\pm1$ — which is exactly the 94-%-of-the-ceiling symptom the 0.2 preset
+moved away from; at $\varepsilon = 0.75$, $F = 0.25$ the wells sit at $-0.92$
+and $+1.06$. The grain interior is flat because the PNG the application writes
 clips at $\phi = 1$, so anything above that is saturated and unrecoverable —
 harmless here, since the subject of the figure is the interface and the
 level set that defines the observable sits in the middle of the recoverable

--- a/docs/report/data/allen_cahn_resolution_margin.csv
+++ b/docs/report/data/allen_cahn_resolution_margin.csv
@@ -1,0 +1,37 @@
+# apps/allen_cahn: interface resolution against bistability margin. LUMI login node, single rank, dx = 1.
+# v_flat = (3/2) F eps sqrt(2M) is the flat-front sharp-interface law the app prints.
+# R_crit = M / v_flat; v_curvature_corrected = v_flat (1 - R_crit / R_mean) with R_mean = (R_half + R_final) / 2,
+# which is what a growing disc obeys (Allen-Cahn moves an interface by curvature as well as by the driving force).
+# margin_fraction = F eps^2 / (2/(3 sqrt 3)); 1.0 is the bistability ceiling, above which there is no second phase.
+# delta_cells = eps sqrt(2M) / dx is the interface half-width in grid cells.
+#
+# Studies:
+#   width-at-fixed-margin  interface width varied at a fixed margin_fraction of 0.365, 256^2. The lattice error
+#                          collapses from -32% at 0.76 cells to +0.05% at 1.5 cells and stays within 2.3% above it.
+#   old-preset-grid        the pre-0.2 preset (eps=0.19, F=10) across grids: the residual against the corrected
+#                          law grows monotonically from +19% to +22%, i.e. it never converges.
+#   new-preset-grid        the 0.2 preset (eps=0.75, F=0.25): 0.07% to 2.3% on every grid from 128^2 to 512^2.
+#   margin-at-old-width    driving force backed off at the old 0.76-cell interface: the residual walks from +17%
+#                          at the ceiling to -65% at a quarter of it. The 6% margin was buying the agreement.
+study,nx,steps,dt,M,eps,F,delta_cells,margin_fraction,R_half,R_final,R_crit,v_measured,v_flat,v_curvature_corrected,rel_error_flat,rel_error_corrected
+width-at-fixed-margin,256,20000,9e-05,8.0,0.19,3.896,0.76,0.3654,20.7143,23.2073,1.8012,2.77005,4.44144,4.077155,-0.3763,-0.3206
+width-at-fixed-margin,256,5000,0.0012,8.0,0.375,1.0,1.5,0.3654,23.2621,29.0982,3.5556,1.94535,2.25,1.944425,-0.1354,0.0005
+width-at-fixed-margin,256,5000,0.002,8.0,0.5,0.5625,2.0,0.3654,24.2273,31.3113,4.7407,1.41678,1.6875,1.399412,-0.1604,0.0124
+width-at-fixed-margin,256,5000,0.005,8.0,0.75,0.25,3.0,0.3654,27.1984,38.3815,7.1111,0.894648,1.125,0.881023,-0.2048,0.0155
+width-at-fixed-margin,256,5000,0.005,8.0,1.0,0.140625,4.0,0.3654,23.0698,30.003,9.4815,0.554659,0.84375,0.542277,-0.3426,0.0228
+old-preset-grid,64,5000,9e-05,8.0,0.19,10.0,0.76,0.9379,7.22515,10.0293,0.7018,12.4627,11.4,10.472703,0.0932,0.19
+old-preset-grid,128,5000,9e-05,8.0,0.19,10.0,0.76,0.9379,12.7162,15.5126,0.7018,12.4287,11.4,10.833203,0.0902,0.1473
+old-preset-grid,192,5000,9e-05,8.0,0.19,10.0,0.76,0.9379,18.2295,21.0799,0.7018,12.6682,11.4,10.992973,0.1112,0.1524
+old-preset-grid,256,5000,9e-05,8.0,0.19,10.0,0.76,0.9379,23.6422,26.5829,0.7018,13.0697,11.4,11.081434,0.1465,0.1794
+old-preset-grid,384,5000,9e-05,8.0,0.19,10.0,0.76,0.9379,34.724,37.7122,0.7018,13.2807,11.4,11.179116,0.165,0.188
+old-preset-grid,512,5000,9e-05,8.0,0.19,10.0,0.76,0.9379,45.7794,48.8603,0.7018,13.6927,11.4,11.230938,0.2011,0.2192
+new-preset-grid,128,5000,0.005,8.0,0.75,0.25,3.0,0.3654,13.1106,21.3797,7.1111,0.661532,1.125,0.661101,-0.412,0.0007
+new-preset-grid,192,5000,0.005,8.0,0.75,0.25,3.0,0.3654,21.2003,31.7153,7.1111,0.841197,1.125,0.822632,-0.2523,0.0226
+new-preset-grid,256,5000,0.005,8.0,0.75,0.25,3.0,0.3654,27.1984,38.3815,7.1111,0.894648,1.125,0.881023,-0.2048,0.0155
+new-preset-grid,384,5000,0.005,8.0,0.75,0.25,3.0,0.3654,37.6108,49.5331,7.1111,0.953791,1.125,0.941396,-0.1522,0.0132
+new-preset-grid,512,5000,0.005,8.0,0.75,0.25,3.0,0.3654,47.3382,59.7508,7.1111,0.993015,1.125,0.975592,-0.1173,0.0179
+margin-at-old-width,256,20000,9e-05,8.0,0.19,10.0,0.76,0.9379,32.5279,44.3383,0.7018,13.1227,11.4,11.191846,0.1511,0.1725
+margin-at-old-width,256,20000,9e-05,8.0,0.19,7.5,0.76,0.7034,26.4869,33.5112,0.9357,7.80474,8.55,8.283325,-0.0872,-0.0578
+margin-at-old-width,256,20000,9e-05,8.0,0.19,5.331,0.76,0.5,22.7642,27.0811,1.3164,4.79656,6.07734,5.756347,-0.2107,-0.1667
+margin-at-old-width,256,20000,9e-05,8.0,0.19,3.896,0.76,0.3654,20.7143,23.2073,1.8012,2.77005,4.44144,4.077155,-0.3763,-0.3206
+margin-at-old-width,256,20000,9e-05,8.0,0.19,2.665,0.76,0.25,18.9487,19.7708,2.6332,0.913435,3.0381,2.624872,-0.6993,-0.652

--- a/docs/tutorials/end_to_end_visualization.md
+++ b/docs/tutorials/end_to_end_visualization.md
@@ -29,7 +29,7 @@ Goal: two PNG files (initial and final field) without writing JSON.
    ```bash
    cd build
    mkdir -p png_out
-   mpirun -n 4 ./apps/allen_cahn/allen_cahn 128 128 5000 0.00009 8.0 0.19 10.0 \
+   mpirun -n 4 ./apps/allen_cahn/allen_cahn 256 256 5000 0.005 8.0 0.75 0.25 \
      png_out/initial.png png_out/final.png
    ```
 


### PR DESCRIPTION
Two defects, each needing a judgement call. Measurements for both are in the
new `docs/report/data/allen_cahn_resolution_margin.csv` (LUMI login node,
single rank).

---

## Defect 1 — the `allen_cahn` preset's bistability margin

### What was wrong

`driving_force = 10.0`, `epsilon = 0.19` gives `F eps^2 = 0.361` against the
ceiling `2/(3 sqrt 3) = 0.385` — 6.2% of margin. `driving_force = 20` or
`epsilon = 0.3` crosses it and the whole box flips.

### The judgement, and the evidence

**The margin is a symptom. The disease is the sub-grid interface, and the two
cannot be fixed separately.** I measured before deciding, as asked.

The interface is `eps*sqrt(2M) = 0.76` cells. Its effect and the margin's are
not independent, and the "agreement" the app reported was two large errors of
opposite sign cancelling:

* The exact travelling wave of the *tilted* cubic is faster than the
  `F eps^2 -> 0` law the app checks against. Solving `phi^3 - phi - F eps^2 = 0`
  for its middle root `phi_2` gives `v_exact = -(3/2) sqrt(2M) phi_2 / eps`,
  which at `F eps^2 = 0.361` is **26% faster** than `(3/2) F eps sqrt(2M)`.
* The lattice pins the front, **12% slow** at 0.76 cells.
* Net: the app measured `+9%` and called it agreement.

So backing the driving force off — the obvious repair — removes only one of
the two errors. Measured at `eps = 0.19` on `256^2`, residual against the
curvature-corrected law as `F` walks down from the ceiling:

| `F eps^2` / ceiling | 0.94 | 0.70 | 0.50 | 0.37 | 0.25 |
|---|---|---|---|---|---|
| residual | +17% | −6% | −17% | −32% | −65% |

**There is no safe driving force at a 0.76-cell interface.** At 64^2 and a
quarter of the ceiling the front stops entirely: `N` goes 52 → 64 over 20000
steps.

Fix the resolution and the margin becomes free. At a fixed margin fraction of
0.37, residual against interface width:

| `eps*sqrt(2M)` cells | 0.76 | 1.5 | 2.0 | 3.0 | 4.0 |
|---|---|---|---|---|---|
| residual | −32% | +0.05% | +1.2% | +1.6% | +2.3% |

**Related finding, worse than described.** With a resolved interface the
driving force must be small, and then the *curvature* term stops being
negligible: a disc obeys `dR/dt = (3/2) F eps sqrt(2M) - M/R`, and `M/R` is
20% of the answer here. It does **not** shrink with the grid, because the seed
scales with the box, so `R/R*` is nearly grid-independent. Comparing a disc
with a flat-front law leaves a 20% bias that looks exactly like a grid
dependence and that refinement never removes. The old preset hid this too:
`64^2` and `128^2` agree to 0.3%, which is why the old test picked that pair,
but extending to `512^2` spreads them by 10% and the residual against the flat
law grows monotonically from +19% to +22% — it never converges.

### What changed

* Preset: `epsilon 0.19 -> 0.75`, `driving_force 10.0 -> 0.25`, `dt 9e-5 ->
  0.005`, grid `64^2 -> 256^2`. `M = 8.0` is unchanged and the other two are
  round quarters, so the preset stays recognisable. Interface 3.0 cells;
  `F eps^2 = 0.141`, a factor 2.7 under the ceiling.
* The grid **had** to move: a resolved interface at a safe driving force has a
  critical nucleus `R* = M/v = 7.1` cells against 0.70 before, and the seed
  `sigma = 0.055*min(nx,ny)` is 4.1 cells at `64^2`. The old default grid now
  dissolves its own seed rather than growing it.
* `dt = 0.005` is 16% of the diffusive limit `dx^2/(4M) = 0.031`; superlevel
  counts are bit-identical from `dt/8`, and `dt = 0.031` blows up.
* The check now compares against `v_theory - M/R` at the mean radius of the
  measured interval, and the band tightens from a factor of two to **±25%**.
  Residual: 1.6% at the shipped preset, at most 2.3% from `128^2` to `512^2`.
* The app also prints `R*` next to `R0` and the distance to the ceiling as a
  percentage, and warns below a 2-cell interface, above half the ceiling, and
  on a subcritical seed. A seed that dissolves is reported as such instead of
  as a slow front.

### Which goldens moved, and why that is correct

**None.** `allen-cahn-cpu-golden` and the CPU-vs-CUDA / CPU-vs-HIP parity
tests all set `nx, ny, n_steps, dt, M, epsilon, driving_force` explicitly
rather than reading `RunConfig` defaults, and the seed width at their `32^2`
is on the `max(2, ...)` floor either way, so `fill_initial_condition` is
unchanged there. Verified: `sum = -967.34722270794146`,
`sumsq = 961.14566882919667` still pass at 1e-10. `tests/baselines/BASELINES.md`
needs no edit for the same reason.

What did move, deliberately, is `allen-cahn-interface-kinetics`:
`64^2`/`128^2` → `256^2`/`384^2` (the old grids are below the critical
radius), and it now requires each grid to match *its own* curvature-corrected
prediction to 5% and the two grids to agree on their residual to 3%, instead
of requiring the two raw speeds to match — which was requiring the physics to
be wrong, since a bigger disc really does grow faster.

### Tests

`apps/allen_cahn/tests/test_allen_cahn_interface_kinetics.cpp`, run time 8 s.

* **`the shipped preset resolves its interface and keeps a margin`** (new).
  Pins interface width >= 2 cells, driving force <= half the ceiling, seed
  radius > 2 `R*`, `dt` <= a quarter of the stability limit. **Confirmed
  failing before**: with the old defaults restored it fails at line 161,
  `0.76 >= 2.0`, and would also fail the margin assertion at 0.938 > 0.5.
* **`a sub-grid interface needs a near-critical driving force`** (new). Runs
  `64^2` at `eps = 0.19` with `F` at the *shipped* margin fraction and asserts
  the front does not reach the predicted speed — the measurement that says the
  two defects are one. Confirmed failing before (with the old defaults this
  case degenerates to the old preset, which passes).
* **`a subcritical seed is reported as dissolved, not as a slow front`** (new).
* `sharp-interface velocity ...` extended with the curvature identity
  (`v(R*) = 0`, `v(inf) = v_flat`).
* `the pass criterion is the same at 256^2 and 384^2` — confirmed failing
  before at line 312.

---

## Defect 2 — `AluminumPhysics::from_json` skips its own schema

### What was wrong

```cpp
if (!params_json.is_null() && !params_json.empty()) {
  apply_aluminum_json(params_json, p.params);
}
```

`"params": {}` — what `inputs_json/smoke.json` shipped — silently took the C++
member initialisers while all 25 schema fields were declared `required`.

### The judgement

**The fields are genuinely required; the loader was wrong, not the schema.**
This is a calibrated material model, and the README says plainly that no
source is cited anywhere in this repository for any aluminium coefficient. If
an empty block is allowed to inherit the struct defaults then a run's
parameters are not recoverable from its input file, and the defaults are an
uncited second copy of the calibration. `required` should mean required.

The parse is unconditional now. An empty *or absent* `model.params` reports
every missing field at once, and `smoke.json` spells all of them out (20 lines
in a smoke input is a fair price for a smoke input that actually exercises the
schema).

### Worse than described: nine unread fields, not four

The task named `T_min`, `T_max` "and two others". There were **nine**:
`n0`, `n_sol`, `n_vap`, `T_min`, `T_max`, `alpha_farTol`, `alpha_highOrd`,
`shift_u`, `shift_s`.

| Field | Call | Why |
|---|---|---|
| `T_min`, `T_max` | **Implement the clamp** | The pair names an obvious bound on a quantity the model already computes, the shipped values bracket `T_const = 980`, and `T_const + G(x - x0 - Vt)` is otherwise unbounded along a 1393-unit domain — the moving-frame machinery is exactly what needs bounding. Crucially, **implementing it changes no result**: every shipped preset has `G_grid = 0`, so the clamp is a strict no-op and the "implementing a clamp changes results" objection does not apply here. |
| `alpha_farTol`, `alpha_highOrd` | **Drop** | They parametrise *tungsten's* `C2` construction. The FCC dual-Gaussian peak this app uses has no far-field tolerance and no higher-order exponent — there is no aluminium quantity to implement. |
| `shift_u`, `shift_s` | **Drop** | They are the vapour shift that *produced* the `p*_bar` / `q*_bar` coefficients; the `_bar` names say it is already applied. Feeding it back in implied the app re-derives them. |
| `n0`, `n_sol`, `n_vap` | **Drop from `model.params`** | These are real quantities, but they act in the `initial_conditions` / `boundary_conditions` blocks, which carry their own copies (`constant.n0`, `seed_grid_fcc.rho`, `fixed.rho_low`/`rho_high`). A second copy under `model.params` that nothing reads is worse than an unused parameter: it can disagree with the one that acts. |

Unknown keys are ignored by `ParameterSchema`, so inputs that still carry the
removed seven load unchanged — they just no longer imply anything.

### What changed

* `from_json` parses unconditionally.
* `AluminumPointwise::clamp_temperature` holds `T_const + T_var` inside
  `[T_min, T_max]`; `temperature_variation` routes through it, so the
  nonlinearity and the free-energy density both see the bounded value.
* `validate_temperature_window` rejects `T_min >= T_max` or a `T_const`
  outside the window at load time — the schema validates one field at a time
  and cannot express this, and now that the pair actually clamps, a bad window
  would freeze the domain at one end instead of being harmlessly ignored.
* Schema 25 -> 18 fields, all read. `smoke.json`, `aluminumNew.json`,
  `aluminumNew.toml` and the three test parameter builders updated.

### Which goldens moved, and why that is correct

**None.** `aluminum-etd-cpu-golden` (`sum = -263.63079658808601`,
`sumsq = 1111.6016268617182`) is unchanged because its config sets
`G_grid = V_grid = 0`, so `T_var = 0`, `T_const = 980` is inside `[780, 1280]`
and the clamp never fires. The parameter builders lost only keys the schema
never read, so every parsed value is identical.

### Tests

`apps/aluminumNew/tests/test_aluminum_physics.cpp`, in `aluminum-all-tests`.

* **`AluminumPhysics::from_json enforces its own schema`** (new): empty block,
  absent block, one missing field, and a complete block that still loads.
  **Confirmed failing before** — with the guard restored it fails at lines 97
  and 102.
* **`AluminumPhysics clamps the temperature into [T_min, T_max]`** (new): both
  directions on `clamp_temperature`, the untouched interior, the clamp visible
  through `temperature_variation` (compared against a wide-open window so the
  unclamped value is shown to exceed the bound), and through `nonlinearity`.
  **Confirmed failing before** — with the clamp call removed it fails at
  line 156.
* **`AluminumPhysics rejects a temperature window that cannot clamp`** (new).

---

## Verification

Built and run on the LUMI **login node**, single rank, no `salloc`/`sbatch`.

```
ctest -R 'aluminum|allen-cahn|cahn_hilliard|tungsten' -E '4rank|2rank|mpi'
100% tests passed, 0 tests failed out of 10
```

`openpfc-cli-aluminum-smoke`, `aluminum-all-tests`, `aluminum-etd-cpu-golden`,
`allen-cahn-cpu-golden`, `allen-cahn-interface-kinetics` all pass.
`scripts/tests/test_openpfc_cli.py`: 31 passed.
`scripts/check_end_to_end_allen_cahn.py` and `scripts/check_doc_links.py`: OK.
`aluminum_etd` runs `inputs_json/smoke.json` end to end.

**Needs an allocation before merge:** `aluminum-golden-4rank` (`[golden][MPI]`)
could not run here — the shared job id is expired, and I did not submit. Its
settings come from the same `aluminum_params_json()` builder that the
single-rank goldens use and it asserts only finiteness, so the risk is low,
but it is untested on this branch. The HIP/CUDA aluminum tests
(`HIP_AluminumETD`, `CUDA_AluminumETD`) share the updated `model_params()`
builder and are likewise unbuilt here. Everything else that failed in a full
`ctest` run failed with `srun: Unable to confirm allocation` and fails the same
way on `master`.

## Not touched

`docs/report/16_scalability.qmd` and `docs/report/figures/make_figures.py`, as
asked.

`docs/report/figures/allen_cahn_growth_montage.svg` is **left at the pre-0.2
preset** and the caption in `14_allen_cahn.qmd` now says so. Regenerating it
means editing `run_field_demos.sh` and `make_field_figures.py` — outside what
this task authorised, and `cray-python` has no matplotlib here. The figure is
still a correct picture of what it is labelled as, and it happens to be the
clearest illustration in the report of the near-ceiling well shift the chapter
now discusses (phi relaxing to -0.69 and +1.15 rather than +/-1). Worth
regenerating when someone is next in that pipeline.

## Also found, not fixed (outside this task's app scope)

`apps/tungsten/include/tungsten/tungsten_physics.hpp` has the **same guard**
defeating **21** `required` fields. `apps/cahn_hilliard` has the guard too but
is harmless there — all 28 of its fields are declared optional with explicit
defaults, so the schema and the loader agree. Tungsten's do not.
