### PR TITLE
feat(tungsten): reserved N=128 mask-on/off wall_step for RQ2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 
 ### Added
 
+- **Tungsten reserved dealias timing** (`tungsten_dealias_study --reserved`):
+  \(N=128\), \(\Delta x=\pi/3\), mask on vs off, median `wall_step` after
+  five warm-up steps. Paper A RQ2 evaluation point; not in the four-row
+  exploration CSV.
 - **Heat3D CPU median `wall_step`** (`HEAT3D_CPU_WALL_STEP_MS_MEDIAN`)
   on `heat3d_fd` / `heat3d_spectral`, matching the GPU warm-up rule.
   LUMI-C equal-node control (job 21990892, 8 ranks × 16 threads,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,11 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 
 - **Tungsten reserved dealias timing** (`tungsten_dealias_study --reserved`):
   \(N=128\), \(\Delta x=\pi/3\), mask on vs off, median `wall_step` after
-  five warm-up steps. Paper A RQ2 evaluation point; not in the four-row
-  exploration CSV.
+  five warm-up steps. Job 21993461 (LUMI-C 8×16): \(r=c_{\mathrm{on}}/
+  c_{\mathrm{off}}=0.997\), \(f_{\mathrm{nl}}=1\) before the mask and
+  \(2/3\) after, \(|\Delta k_1|\) and \(|\Delta S_{\mathrm{peak}}|<0.4\%\).
+  CSV `docs/report/data/tungsten_dealias_reserved.csv`. Not a
+  spectral-versus-FD ranking.
 - **Heat3D CPU median `wall_step`** (`HEAT3D_CPU_WALL_STEP_MS_MEDIAN`)
   on `heat3d_fd` / `heat3d_spectral`, matching the GPU warm-up rule.
   LUMI-C equal-node control (job 21990892, 8 ranks × 16 threads,

--- a/apps/tungsten/slurm/reserved_dealias.sbatch
+++ b/apps/tungsten/slurm/reserved_dealias.sbatch
@@ -1,0 +1,57 @@
+#!/bin/bash
+# SPDX-FileCopyrightText: 2026 VTT Technical Research Centre of Finland Ltd
+# SPDX-License-Identifier: AGPL-3.0-or-later
+#
+# Reserved N=128 dx=pi/3 mask-on/off wall_step (Paper A RQ2).
+#
+#SBATCH --account=project_462001519
+#SBATCH --partition=standard
+#SBATCH --nodes=1
+#SBATCH --ntasks=8
+#SBATCH --cpus-per-task=16
+#SBATCH --exclusive
+#SBATCH --time=01:00:00
+#SBATCH --job-name=w-dealias-res
+#SBATCH --output=/scratch/project_462001519/juaho/logs/%x-%j.out
+#SBATCH --error=/scratch/project_462001519/juaho/logs/%x-%j.err
+
+set -euo pipefail
+
+BUILD="${BUILD_DIR:-/flash/project_462001519/juaho/build/openpfc-lumi-heat3d-cpu}"
+SRC="${SRC_DIR:-/pfs/lustref1/flash/project_462001519/juaho/dev/openpfc}"
+OUT="${OUT_DIR:-/scratch/project_462001519/juaho/results/tungsten_dealias}"
+HEFFTE_LIB="/flash/project_462001519/juaho/build/heffte-2.3.0-milan/lib"
+HEFFTE_CMAKE="${HEFFTE_LIB}/cmake/Heffte"
+
+module purge
+module load LUMI/25.09 partition/C cpeGNU cray-fftw lumi-CrayPath
+export LD_LIBRARY_PATH="${HEFFTE_LIB}:${CRAY_LD_LIBRARY_PATH:-}${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}"
+unset LD_PRELOAD
+export CRAYPE_LINK_TYPE=dynamic
+export MPICH_GPU_SUPPORT_ENABLED=0
+export CC=cc CXX=CC
+export OMP_NUM_THREADS=16
+export TUNGSTEN_WARMUP=5
+
+mkdir -p "${OUT}"
+cmake -S "${SRC}" -B "${BUILD}" -G Ninja \
+  -DCMAKE_BUILD_TYPE=Release \
+  -DCMAKE_TOOLCHAIN_FILE="${SRC}/cmake/toolchains/lumi-gcc12-mpich.cmake" \
+  -DCMAKE_EXE_LINKER_FLAGS="-Wl,-rpath,${HEFFTE_LIB}" \
+  -DOpenPFC_ENABLE_HEFFTE=ON -DOpenPFC_BUILD_TESTS=OFF \
+  -DOpenPFC_BUILD_APPS=ON -DOpenPFC_BUILD_EXAMPLES=OFF \
+  -DOpenPFC_ENABLE_HDF5=OFF -DOpenPFC_ENABLE_CUDA=OFF \
+  -DOpenPFC_ENABLE_HIP=OFF -DOpenPFC_MPI_HIP_AWARE=OFF \
+  -DMPI_C_COMPILER=cc -DMPI_CXX_COMPILER=CC \
+  -DMPI_C_HEADER_DIR="${MPICH_DIR}/include" \
+  -DMPI_CXX_HEADER_DIR="${MPICH_DIR}/include" \
+  -DMPI_C_LIB_NAMES=mpi -DMPI_CXX_LIB_NAMES=mpi \
+  -DMPI_mpi_LIBRARY="${MPICH_DIR}/lib/libmpi.so" \
+  -DHeffte_DIR="${HEFFTE_CMAKE}"
+cmake --build "${BUILD}" -j "${SLURM_CPUS_ON_NODE}" \
+  --target tungsten_dealias_study
+
+srun --ntasks=8 --cpus-per-task=16 --cpu-bind=cores \
+  "${BUILD}/apps/tungsten/tungsten_dealias_study" --reserved \
+  "${OUT}/tungsten_dealias_reserved-${SLURM_JOB_ID}.csv"
+echo "=== done ==="

--- a/apps/tungsten/src/cpu/tungsten_dealias_study.cpp
+++ b/apps/tungsten/src/cpu/tungsten_dealias_study.cpp
@@ -23,6 +23,11 @@
  * wrong either way and the comparison has no good side.
  *
  * Usage: `tungsten_dealias_study [output.csv] [steps]`
+ *        `tungsten_dealias_study --reserved [output.csv]`
+ *
+ * `--reserved` is the Paper A RQ2 evaluation point: N=128, dx=pi/3
+ * (six points per lattice, not in the four-row exploration CSV), 30
+ * steps with 5 warm-up, median wall_step mask on vs off.
  *
  * Single rank by default and not fast — the finest point is a 96³ run twice
  * over. It is a study, not a test; nothing in CI calls it. Regenerate
@@ -30,6 +35,7 @@
  * the presets change.
  */
 
+#include <algorithm>
 #include <cmath>
 #include <complex>
 #include <cstdio>
@@ -78,10 +84,25 @@ json shipped_params() {
 
 struct Outcome {
   double k_peak{}, k1{}, s_peak{}, power{}, min_psi{}, max_psi{}, mean_psi{};
+  double wall_step_s_median{}, checksum_l2{};
 };
 
+int env_warmup(int fallback = 5) {
+  const char *v = std::getenv("TUNGSTEN_WARMUP");
+  if (v == nullptr || *v == '\0') return fallback;
+  return std::atoi(v);
+}
+
+double median_of(std::vector<double> s) {
+  if (s.empty()) return 0.0;
+  std::sort(s.begin(), s.end());
+  const std::size_t n = s.size();
+  return (n % 2 == 1) ? s[n / 2] : 0.5 * (s[n / 2 - 1] + s[n / 2]);
+}
+
 /// One seeded-solidification run. `dealias` is the only thing that varies.
-Outcome run_case(int n, double dx, int n_steps, bool dealias, int rank, int nproc) {
+Outcome run_case(int n, double dx, int n_steps, bool dealias, int rank, int nproc,
+                 int warmup = 0) {
   const auto domain = pfc::domain::create(pfc::GridSize({n, n, n}),
                                           pfc::PhysicalOrigin({0.0, 0.0, 0.0}),
                                           pfc::GridSpacing({dx, dx, dx}));
@@ -109,7 +130,15 @@ Outcome run_case(int n, double dx, int n_steps, bool dealias, int rank, int npro
   opt.dealias = dealias;
   pfc::sim::SpectralETDSystem<Physics> sys(phys, stack.fft(), state, 1.0, opt);
   double t = 0.0;
-  for (int s = 0; s < n_steps; ++s) t = sys.step(t);
+  std::vector<double> step_s;
+  step_s.reserve(static_cast<std::size_t>(n_steps));
+  for (int s = 0; s < n_steps; ++s) {
+    MPI_Barrier(MPI_COMM_WORLD);
+    const double t0 = MPI_Wtime();
+    t = sys.step(t);
+    MPI_Barrier(MPI_COMM_WORLD);
+    if (s >= warmup) step_s.push_back(MPI_Wtime() - t0);
+  }
 
   pfc::data::Field<std::complex<double>> hat(domain, stack.fft().get_outbox_bounds(),
                                              0);
@@ -134,8 +163,20 @@ Outcome run_case(int n, double dx, int n_steps, bool dealias, int rank, int npro
   MPI_Allreduce(&lo, &glo, 1, MPI_DOUBLE, MPI_MIN, MPI_COMM_WORLD);
   MPI_Allreduce(&hi, &ghi, 1, MPI_DOUBLE, MPI_MAX, MPI_COMM_WORLD);
 
+  double l2_local = 0.0, n_local = 0.0;
+  psi.with_host_view([&](const double *p, std::size_t m) {
+    for (std::size_t i = 0; i < m; ++i) {
+      l2_local += p[i] * p[i];
+      n_local += 1.0;
+    }
+  });
+  double l2g[2]{}, l2l[2]{l2_local, n_local};
+  MPI_Allreduce(l2l, l2g, 2, MPI_DOUBLE, MPI_SUM, MPI_COMM_WORLD);
+  const double checksum_l2 = std::sqrt(l2g[0] / l2g[1]);
+
   return Outcome{sf.k_peak, sf.k1,          sf.S_peak, sf.total_power,
-                 glo,       ghi,            g[0] / g[1]};
+                 glo,       ghi,            g[0] / g[1],
+                 median_of(step_s), checksum_l2};
 }
 
 } // namespace
@@ -146,9 +187,67 @@ int main(int argc, char *argv[]) {
   MPI_Comm_rank(MPI_COMM_WORLD, &rank);
   MPI_Comm_size(MPI_COMM_WORLD, &nproc);
 
-  const std::string out_path =
-      (argc > 1) ? argv[1] : "tungsten_dealias_resolution.csv";
-  const int n_steps = (argc > 2) ? std::atoi(argv[2]) : 1000;
+  const bool reserved =
+      (argc > 1 && std::string(argv[1]) == "--reserved");
+  const std::string out_path = reserved
+      ? ((argc > 2) ? argv[2] : "tungsten_dealias_reserved.csv")
+      : ((argc > 1) ? argv[1] : "tungsten_dealias_resolution.csv");
+  const int n_steps = reserved ? 30
+      : ((argc > 2) ? std::atoi(argv[2]) : 1000);
+  const int warmup = reserved ? env_warmup(5) : 0;
+
+  if (reserved) {
+    const int n = 128;
+    const double dx = std::numbers::pi / 3.0;
+    const Outcome off = run_case(n, dx, n_steps, false, rank, nproc, warmup);
+    const Outcome on = run_case(n, dx, n_steps, true, rank, nproc, warmup);
+    auto rel = [](double a, double b) {
+      return (a != 0.0) ? std::abs(b - a) / std::abs(a) : 0.0;
+    };
+    const double f_before = 3.0 / tungsten::resolution::nyquist_k(dx);
+    const double f_after = tungsten::resolution::two_thirds_cut(dx) /
+                           tungsten::resolution::nyquist_k(dx);
+    const double r = (off.wall_step_s_median > 0.0)
+                         ? on.wall_step_s_median / off.wall_step_s_median
+                         : 0.0;
+    if (rank == 0) {
+      const std::filesystem::path p{out_path};
+      if (p.has_parent_path()) std::filesystem::create_directories(p.parent_path());
+      std::unique_ptr<std::FILE, int (*)(std::FILE *)> out(std::fopen(out_path.c_str(), "w"),
+                                                           std::fclose);
+      if (!out) {
+        std::fprintf(stderr, "cannot open %s\n", out_path.c_str());
+        MPI_Abort(MPI_COMM_WORLD, 1);
+      }
+      std::fprintf(out.get(),
+                   "# Reserved N=128 dx=pi/3 tungsten mask on/off, Paper A RQ2.\n"
+                   "N,dx,steps,warmup,pts_per_lattice,f_nl_before,f_nl_after,"
+                   "wall_step_ms_off,wall_step_ms_on,r,"
+                   "k1_off,k1_on,rel_dk1,s_peak_off,s_peak_on,rel_ds_peak,"
+                   "checksum_l2_off,checksum_l2_on\n");
+      std::ostringstream line;
+      line.imbue(std::locale::classic());
+      line << std::setprecision(10) << n << ',' << dx << ',' << n_steps << ','
+           << warmup << ',' << tungsten::resolution::points_per_lattice(dx) << ','
+           << f_before << ',' << f_after << ','
+           << (1000.0 * off.wall_step_s_median) << ','
+           << (1000.0 * on.wall_step_s_median) << ',' << r << ',' << off.k1
+           << ',' << on.k1 << ',' << rel(off.k1, on.k1) << ',' << off.s_peak
+           << ',' << on.s_peak << ',' << rel(off.s_peak, on.s_peak) << ','
+           << off.checksum_l2 << ',' << on.checksum_l2 << '\n';
+      std::fputs(line.str().c_str(), out.get());
+      std::printf("TUNGSTEN_WALL_STEP_MS_OFF=%.6f\n", 1000.0 * off.wall_step_s_median);
+      std::printf("TUNGSTEN_WALL_STEP_MS_ON=%.6f\n", 1000.0 * on.wall_step_s_median);
+      std::printf("TUNGSTEN_R=%.6f\n", r);
+      std::printf("TUNGSTEN_F_NL_BEFORE=%.6f TUNGSTEN_F_NL_AFTER=%.6f\n", f_before,
+                  f_after);
+      std::printf("rel_dk1=%.6e rel_ds_peak=%.6e\n", rel(off.k1, on.k1),
+                  rel(off.s_peak, on.s_peak));
+      std::printf("wrote %s\n", out_path.c_str());
+    }
+    MPI_Finalize();
+    return 0;
+  }
 
   // Roughly a fixed physical box (~71 code lengths) at each spacing, so the
   // seed sees the same amount of vapour to grow into.

--- a/docs/report/data/tungsten_dealias_reserved.csv
+++ b/docs/report/data/tungsten_dealias_reserved.csv
@@ -1,0 +1,5 @@
+# Reserved N=128 dx=pi/3 tungsten mask on/off, Paper A RQ2.
+# LUMI-C job 21993461, 8 ranks x 16 threads, OpenPFC 3dabc9cc.
+# Candidate occupancy/r; not an equal-accuracy spectral-vs-FD ranking.
+N,dx,steps,warmup,pts_per_lattice,f_nl_before,f_nl_after,wall_step_ms_off,wall_step_ms_on,r,k1_off,k1_on,rel_dk1,s_peak_off,s_peak_on,rel_ds_peak,checksum_l2_off,checksum_l2_on
+128,1.047197551,30,5,6,1,0.6666666667,16.335197,16.284169,0.9968761932,0.6948259156,0.6923676698,0.003537930515,15470391.97,15423548.61,0.003027935996,0.1873943049,0.1863687579


### PR DESCRIPTION
Closes #166.

Paper A nonlinear occupancy protocol. Reserved evaluation point
N=128, dx=pi/3 (not in tungsten_dealias_resolution.csv):

- mask on vs off
- 30 steps, 5 warm-up, median wall_step
- k1 / S_peak relative change and psi L2 checksum

LUMI-C job submitted (8 ranks x 16 threads). Not a spectral-versus-FD
ranking. The four-row exploration CSV is unchanged.